### PR TITLE
Update URLs on LIVE DOCS

### DIFF
--- a/www/docs/src/starlightOverrides/SiteTitle.astro
+++ b/www/docs/src/starlightOverrides/SiteTitle.astro
@@ -8,10 +8,10 @@ import type { Props } from '@astrojs/starlight/props';
     <Default {...Astro.props} />
     <ul>
         <li>
-          <a href="https://studiocms.xyz">Landing</a>
+          <a href="https://studiocms.dev">Landing</a>
         </li>
         <li>
-          <a href="https://demo.studiocms.xyz">Demo</a>
+          <a href="https://next-demo.studiocms.dev">Demo</a>
         </li>
     </ul>
 </div>


### PR DESCRIPTION
This pull request includes updates to the URLs in the `SiteTitle.astro` file to reflect the new domain for StudioCMS.

URL updates:

* Changed the "Landing" page URL from `https://studiocms.xyz` to `https://studiocms.dev`.
* Changed the "Demo" page URL from `https://demo.studiocms.xyz` to `https://next-demo.studiocms.dev`.