### PR TITLE
Ensure pkg-pr-new only runs on package changes

### DIFF
--- a/.github/workflows/snapshop-release.yml
+++ b/.github/workflows/snapshop-release.yml
@@ -1,6 +1,9 @@
 name: snapshot Release
 
-on: [pull_request]
+on: 
+  pull_request:
+    paths:
+        - 'packages/**'
 
 jobs:
   release:
@@ -19,7 +22,7 @@ jobs:
           node-version-file: '.node-version'
           cache: 'pnpm'
 
-      - name: Install Dependencies
+      - name: Install Dependencies 
         run: pnpm ci:install
   
       - name: Publish packages


### PR DESCRIPTION
This pull request includes a small but important change to the GitHub Actions workflow configuration. The change ensures that the workflow is triggered only when there are changes in the `packages` directory.

Changes to GitHub Actions workflow:

* [`.github/workflows/snapshop-release.yml`](diffhunk://#diff-1e39a8abb05a89222f89e1b264287241e9348e1ec25c8f45649952d5eb817657L3-R6): Modified the `on` trigger to specify that the workflow should only run on pull requests affecting files in the `packages` directory.