### PR TITLE
Add mergebot workflow

### DIFF
--- a/.github/workflows/mergebot.yml
+++ b/.github/workflows/mergebot.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   mergebot:
     if: ${{ github.repository_owner == 'withstudiocms' }}
-    uses: withstudiocms/mergebot@main
+    uses: withstudiocms/mergebot/.github/workflows/mergebot.yml@main
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_MERGEBOT }}

--- a/.github/workflows/mergebot.yml
+++ b/.github/workflows/mergebot.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   mergebot:
     if: ${{ github.repository_owner == 'withstudiocms' }}
-    uses: withstudiocms/mergebot/.github/workflows/mergebot.yml@main
+    uses: withstudiocms/automations/.github/workflows/mergebot.yml@main
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_MERGEBOT }}

--- a/.github/workflows/mergebot.yml
+++ b/.github/workflows/mergebot.yml
@@ -1,0 +1,12 @@
+name: mergebot
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  mergebot:
+    if: ${{ github.repository_owner == 'withstudiocms' }}
+    uses: withstudiocms/mergebot@main
+    secrets:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_MERGEBOT }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for the `mergebot`. The most important changes include the addition of the `mergebot.yml` file, which configures the workflow to trigger on pushes to the `main` branch and uses the `withstudiocms/mergebot` action.

New GitHub Actions workflow:

* [`.github/workflows/mergebot.yml`](diffhunk://#diff-ad64cc54ac2c68e8015ab82176187923f57231c85316454a19611a16db14bb6fR1-R12): Added a new workflow named `mergebot` that triggers on pushes to the `main` branch and uses the `withstudiocms/mergebot` action. The workflow is conditioned to run only if the repository owner is `withstudiocms` and uses a secret for the Discord webhook.