### PR TITLE
Update Turso sponsor link and add StudioCMS coupon code

### DIFF
--- a/www/docs/src/content/docs/start-here/getting-started.mdx
+++ b/www/docs/src/content/docs/start-here/getting-started.mdx
@@ -30,6 +30,10 @@ StudioCMS uses `@astrojs/db` to connect to your libSQL database. You can use any
 
 ### Getting started with Turso
 
+<Aside type='tip' title='StudioCMS Coupon'>
+ Use the code `STUDIOCMS10` to get 10% off for 12 months of Turso.
+</Aside>
+
 <Steps>
 1. Install the <SponsorLink href={sponsors.turso.docs.installCLILink} text='Turso CLI'/>
 2. <SponsorLink href={sponsors.turso.docs.loginsignupLink} text='Login or signup'/> to Turso.

--- a/www/docs/src/share-link.ts
+++ b/www/docs/src/share-link.ts
@@ -4,15 +4,10 @@ export { default as SponsorLink } from './util/SponsorLink.astro';
 export const sponsors = {
 	turso: {
 		docs: {
-			sidebarSponsorLink: 'https://turso.tech',
+			sidebarSponsorLink: 'https://tur.so/studiocms',
 			installCLILink: 'https://docs.turso.tech/cli/installation',
 			loginsignupLink: 'https://docs.turso.tech/cli/authentication',
 		},
-		web: {
-			sponsorLink: 'https://turso.tech',
-		},
-		// TODO: Add Turso specific links when they are provided to us.
-		// Also, switch to utilizing these new links within the websites.
 	},
 };
 


### PR DESCRIPTION
This pull request includes updates to the documentation and sponsor links in the `www/docs` directory. The most important changes include adding a promotional coupon code for StudioCMS and updating the sponsor link for Turso.

Documentation updates:

* [`www/docs/src/content/docs/start-here/getting-started.mdx`](diffhunk://#diff-5c9ac9ad32d8906acf1154e81ba93cf559d26501f48659ef69b8b961b0736ff8R33-R36): Added an aside with a promotional coupon code `STUDIOCMS10` for a 10% discount on Turso for 12 months.

Sponsor link updates:

* [`www/docs/src/share-link.ts`](diffhunk://#diff-68aa278830cb45f0d73b876a5315c0cda8f68d7d08aae10cfd3bf2598694cc0bL7-L15): Updated the `sidebarSponsorLink` for Turso to `https://tur.so/studiocms` and removed unused sponsor links.