### PR TITLE
Add error handling for missing SSR Adapter in Astro Config

### DIFF
--- a/.changeset/ten-rats-stare.md
+++ b/.changeset/ten-rats-stare.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Add warning if no Adapter is present

--- a/packages/studiocms/src/utils/astroConfigCheck.ts
+++ b/packages/studiocms/src/utils/astroConfigCheck.ts
@@ -19,6 +19,13 @@ export const checkAstroConfig = defineUtility('astro:config:setup')(
 			);
 		}
 
+		if (!astroConfig.adapter) {
+			throw new StudioCMSCoreError(
+				'SSR Adapter not found in Astro Config',
+				'StudioCMS requires a Server Adapter to be set in your Astro Config. For how to setup a Server Adapter, see the Astro Docs: https://docs.astro.build/en/guides/on-demand-rendering/#server-adapters'
+			);
+		}
+
 		// Check for Site URL
 		if (!astroConfig.site) {
 			throw new StudioCMSCoreError(

--- a/packages/studiocms/src/utils/astroConfigCheck.ts
+++ b/packages/studiocms/src/utils/astroConfigCheck.ts
@@ -22,7 +22,7 @@ export const checkAstroConfig = defineUtility('astro:config:setup')(
 		if (!astroConfig.adapter) {
 			throw new StudioCMSCoreError(
 				'SSR Adapter not found in Astro Config',
-				'StudioCMS requires a Server Adapter to be set in your Astro Config. For how to setup a Server Adapter, see the Astro Docs: https://docs.astro.build/en/guides/on-demand-rendering/#server-adapters'
+				'StudioCMS requires a Server Adapter to be set in your Astro Config. For instructions on how to setup a Server Adapter, see the Astro Docs: https://docs.astro.build/en/guides/on-demand-rendering/#server-adapters'
 			);
 		}
 


### PR DESCRIPTION
This pull request includes a new feature to add a warning if no Adapter is present in the Astro configuration. The most important changes are:

* Added a new warning message to notify users if no SSR Adapter is found in the Astro configuration (`astroConfig`). This ensures that users are aware of the requirement for a Server Adapter and provides a link to the relevant documentation. (`packages/studiocms/src/utils/astroConfigCheck.ts`)
* Documented the new warning feature in the changeset file to indicate that it is a patch update. (`.changeset/ten-rats-stare.md`)