### PR TITLE
update renderers functionality

### DIFF
--- a/.changeset/light-carrots-reflect.md
+++ b/.changeset/light-carrots-reflect.md
@@ -1,0 +1,6 @@
+---
+"@studiocms/renderers": patch
+"@studiocms/core": patch
+---
+
+Add @studiocms/markdown-remark as a renderer option, and implement component proxy system to actually be used by this renderer

--- a/packages/studiocms/src/index.ts
+++ b/packages/studiocms/src/index.ts
@@ -113,7 +113,7 @@ export default defineIntegration({
 						{ integration: nodeNamespaceBuiltinsAstro() },
 						{ integration: ui({ noInjectCSS: true }) },
 						{ integration: core(options) },
-						{ integration: renderers(rendererConfig, verbose) },
+						{ integration: renderers({ verbose, opts: rendererConfig }) },
 						{ integration: imageHandler(options) },
 						{ integration: auth(options) },
 						{ integration: dashboard(options) },
@@ -230,22 +230,20 @@ export default defineIntegration({
 								.join('\n')
 						: '';
 
-					if (ComponentRegistry) {
-						addVirtualImports(params, {
-							name: pkgName,
-							imports: {
-								'studiocms:component-proxy': `
-									export * from ${resolve('./utils/AstroComponentProxy.js')};
+					addVirtualImports(params, {
+						name: pkgName,
+						imports: {
+							'studiocms:component-proxy': `
+									export * from "${resolve('./utils/AstroComponentProxy.js')}";
 
 									export const componentKeys = ${JSON.stringify(componentKeys)};
 									${components}
 								`,
-								'studiocms:plugin-helpers': `
+							'studiocms:plugin-helpers': `
 									export * from "${resolve('./plugins.js')}";
 								`,
-							},
-						});
-					}
+						},
+					});
 
 					let pluginListLength = 0;
 					let pluginListMessage = '';

--- a/packages/studiocms_core/package.json
+++ b/packages/studiocms_core/package.json
@@ -113,6 +113,7 @@
   "dependencies": {
     "@studiocms/ui": "catalog:",
     "@studiocms/robotstxt": "workspace:*",
+    "@studiocms/markdown-remark-processor": "^1.0.0",
     "astro-integration-kit": "catalog:",
     "@markdoc/markdoc": "catalog:studiocms-renderer",
     "mrmime": "catalog:studiocms-core",

--- a/packages/studiocms_core/src/schemas/config/index.ts
+++ b/packages/studiocms_core/src/schemas/config/index.ts
@@ -10,6 +10,7 @@ import {
 	type Renderer,
 	type StudioCMSRendererConfig,
 	StudioCMSRendererConfigSchema,
+	TransformToProcessor,
 } from './rendererConfig.js';
 import { SDKSchema } from './sdk.js';
 
@@ -19,6 +20,7 @@ import { SDKSchema } from './sdk.js';
 export {
 	StudioCMSRendererConfigSchema,
 	FrontEndConfigSchema,
+	TransformToProcessor,
 	type StudioCMSRendererConfig,
 	type CustomRenderer,
 	type Renderer,

--- a/packages/studiocms_core/src/schemas/config/rendererConfig.ts
+++ b/packages/studiocms_core/src/schemas/config/rendererConfig.ts
@@ -1,9 +1,15 @@
 import { z } from 'astro/zod';
 import { type MarkdocRenderer, markdocConfigSchema, type markdocRenderer } from './markdoc.js';
 import { mdxConfigSchema } from './mdx.js';
+import {
+	StudioCMSMarkdownExtendedSchema,
+	TransformToProcessor,
+} from './studiocms-markdown-remark.js';
 
 export type Renderer = (content: string) => Promise<string>;
 export type { markdocRenderer, MarkdocRenderer };
+
+export { TransformToProcessor };
 
 /**
  * Custom Renderer Type
@@ -43,13 +49,14 @@ export const StudioCMSRendererConfigSchema = z
 		 */
 		renderer: z
 			.union([
+				z.literal('studiocms'),
 				z.literal('astro'),
 				z.literal('markdoc'),
 				z.literal('mdx'),
 				z.custom<CustomRenderer>(),
 			])
 			.optional()
-			.default('astro'),
+			.default('studiocms'),
 		/**
 		 * Allows customization of the Markdoc Configuration
 		 *
@@ -64,6 +71,14 @@ export const StudioCMSRendererConfigSchema = z
 		 * @see https://mdxjs.com/ for more info about MDX.
 		 */
 		mdxConfig: mdxConfigSchema,
+
+		/**
+		 * Allows customization of the StudioCMS Markdown Extended Configuration
+		 *
+		 * StudioCMS Markdown Extended is a collection of custom markdown features for StudioCMS.
+		 * @see https://github.com/withstudiocms/markdown-remark/tree/main for more info about StudioCMS Markdown Extended.
+		 */
+		studiocms: StudioCMSMarkdownExtendedSchema,
 	})
 	.optional()
 	.default({});

--- a/packages/studiocms_core/src/schemas/config/studiocms-markdown-remark.ts
+++ b/packages/studiocms_core/src/schemas/config/studiocms-markdown-remark.ts
@@ -1,0 +1,79 @@
+import type { StudioCMSConfigOptions } from '@studiocms/markdown-remark-processor';
+import { z } from 'astro/zod';
+
+export const StudioCMSSanitizeOptionsSchema = z
+	.object({
+		/** An Array of strings indicating elements that the sanitizer should not remove. All elements not in the array will be dropped. */
+		allowElements: z.array(z.string()).optional(),
+		/** An Array of strings indicating elements that the sanitizer should remove, but keeping their child elements. */
+		blockElements: z.array(z.string()).optional(),
+		/** An Array of strings indicating elements (including nested elements) that the sanitizer should remove. */
+		dropElements: z.array(z.string()).optional(),
+		/** An Object where each key is the attribute name and the value is an Array of allowed tag names. Matching attributes will not be removed. All attributes that are not in the array will be dropped. */
+		allowAttributes: z.record(z.array(z.string())).optional(),
+		/** An Object where each key is the attribute name and the value is an Array of dropped tag names. Matching attributes will be removed. */
+		dropAttributes: z.record(z.array(z.string())).optional(),
+		/** A Boolean value set to false (default) to remove components and their children. If set to true, components will be subject to built-in and custom configuration checks (and will be retained or dropped based on those checks). */
+		allowComponents: z.boolean().optional(),
+		/** A Boolean value set to false (default) to remove custom elements and their children. If set to true, custom elements will be subject to built-in and custom configuration checks (and will be retained or dropped based on those checks). */
+		allowCustomElements: z.boolean().optional(),
+		/** A Boolean value set to false (default) to remove HTML comments. Set to true in order to keep comments. */
+		allowComments: z.boolean().optional(),
+	})
+	.optional();
+
+export const StudioCMSMarkdownExtendedSchema = z
+	.union([
+		z.literal(false),
+		z.object({
+			callouts: z
+				.union([
+					z.literal(false),
+					z.object({
+						theme: z
+							.union([z.literal('github'), z.literal('obsidian'), z.literal('vitepress')])
+							.optional()
+							.default('obsidian'),
+					}),
+				])
+				.optional()
+				.default({})
+				.transform((value) => {
+					if (value === false) {
+						return { theme: 'obsidian' as const, enabled: false };
+					}
+					return { ...value, enabled: true };
+				}),
+
+			autoLinkHeadings: z.boolean().optional().default(true),
+
+			discordSubtext: z.boolean().optional().default(true),
+
+			sanitize: StudioCMSSanitizeOptionsSchema,
+		}),
+	])
+	.optional()
+	.default({})
+	.transform((value) => {
+		if (value === false) {
+			return {
+				callouts: { enabled: false, theme: 'obsidian' as const },
+				autoLinkHeadings: false,
+				discordSubtext: false,
+			};
+		}
+		return value;
+	});
+
+export const TransformToProcessor = StudioCMSMarkdownExtendedSchema.transform(
+	({ autoLinkHeadings, callouts, discordSubtext, sanitize }) => {
+		return {
+			studiocms: {
+				callouts: callouts.enabled ? { theme: callouts.theme } : false,
+				autolink: autoLinkHeadings,
+				discordSubtext,
+				sanitize,
+			},
+		} as { studiocms: StudioCMSConfigOptions };
+	}
+);

--- a/packages/studiocms_core/src/schemas/config/studiocms-markdown-remark.ts
+++ b/packages/studiocms_core/src/schemas/config/studiocms-markdown-remark.ts
@@ -5,19 +5,19 @@ export const StudioCMSSanitizeOptionsSchema = z
 	.object({
 		/** An Array of strings indicating elements that the sanitizer should not remove. All elements not in the array will be dropped. */
 		allowElements: z.array(z.string()).optional(),
-		/** An Array of strings indicating elements that the sanitizer should remove, but keeping their child elements. */
+		/** An Array of strings indicating elements that the sanitizer should remove. Children will be kept. */
 		blockElements: z.array(z.string()).optional(),
 		/** An Array of strings indicating elements (including nested elements) that the sanitizer should remove. */
 		dropElements: z.array(z.string()).optional(),
-		/** An Object where each key is the attribute name and the value is an Array of allowed tag names. Matching attributes will not be removed. All attributes that are not in the array will be dropped. */
+		/** An object where each key is the attribute name and the value is an array of allowed tag names. Matching attributes will not be removed. All attributes that are not in the array will be dropped. */
 		allowAttributes: z.record(z.array(z.string())).optional(),
-		/** An Object where each key is the attribute name and the value is an Array of dropped tag names. Matching attributes will be removed. */
+		/** An object where each key is the attribute name and the value is an array of dropped tag names. Matching attributes will be removed. */
 		dropAttributes: z.record(z.array(z.string())).optional(),
-		/** A Boolean value set to false (default) to remove components and their children. If set to true, components will be subject to built-in and custom configuration checks (and will be retained or dropped based on those checks). */
+		/** A boolean value to remove components and their children. If set to true, components will be subject to built-in and custom configuration checks (and will be retained or dropped based on those checks). Default is `false`. */
 		allowComponents: z.boolean().optional(),
-		/** A Boolean value set to false (default) to remove custom elements and their children. If set to true, custom elements will be subject to built-in and custom configuration checks (and will be retained or dropped based on those checks). */
+		/** A boolean value to remove custom elements and their children. If set to true, custom elements will be subject to built-in and custom configuration checks (and will be retained or dropped based on those checks). Default is `false` */
 		allowCustomElements: z.boolean().optional(),
-		/** A Boolean value set to false (default) to remove HTML comments. Set to true in order to keep comments. */
+		/** A boolean value to remove HTML comments. Set to true in order to keep comments. Default is `false`. */
 		allowComments: z.boolean().optional(),
 	})
 	.optional();

--- a/packages/studiocms_renderers/components/Renderer.js
+++ b/packages/studiocms_renderers/components/Renderer.js
@@ -8,7 +8,7 @@ export default Object.assign(
 				return 'AstroComponent';
 			},
 			async *[Symbol.asyncIterator]() {
-				const renderedContent = await contentRenderer(content);
+				const renderedContent = await contentRenderer(content, result);
 				yield new HTMLString(renderedContent);
 			},
 		};

--- a/packages/studiocms_renderers/package.json
+++ b/packages/studiocms_renderers/package.json
@@ -27,8 +27,8 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "build-scripts build 'src/**/*.ts' --build-tsconfig",
-    "dev": "build-scripts dev 'src/**/*.ts' --build-tsconfig"
+    "build": "build-scripts build 'src/**/*.{ts,css}' --build-tsconfig",
+    "dev": "build-scripts dev 'src/**/*.{ts,css}' --build-tsconfig"
   },
   "files": [
     "dist", "components", "exports"
@@ -52,9 +52,11 @@
   "type": "module",
   "dependencies": {
     "@studiocms/core": "workspace:*",
+    "@studiocms/markdown-remark-processor": "^1.0.0",
 
     "astro-integration-kit": "catalog:",
     
+    "@inox-tools/aik-mod": "0.9.1",
     "@inox-tools/runtime-logger": "catalog:studiocms-shared",
     "@matthiesenxyz/astrodtsbuilder": "catalog:studiocms-shared",
     "@matthiesenxyz/integration-utils": "catalog:studiocms-shared",

--- a/packages/studiocms_renderers/src/index.ts
+++ b/packages/studiocms_renderers/src/index.ts
@@ -1,7 +1,14 @@
+import inlineMod from '@inox-tools/aik-mod';
 import { runtimeLogger } from '@inox-tools/runtime-logger';
 import type { StudioCMSRendererConfig } from '@studiocms/core/schemas';
-import type { AstroIntegration } from 'astro';
-import { addVirtualImports, createResolver } from 'astro-integration-kit';
+import {
+	addVirtualImports,
+	createResolver,
+	defineIntegration,
+	withPlugins,
+} from 'astro-integration-kit';
+import { z } from 'astro/zod';
+import { shared } from './lib/shared.js';
 import rendererConfigDTS from './stubs/renderer-config.js';
 import rendererMarkdownConfigDTS from './stubs/renderer-markdownConfig.js';
 import rendererDTS from './stubs/renderer.js';
@@ -18,60 +25,146 @@ const { name: pkgName } = readJson<{ name: string }>(new URL('../package.json', 
  *
  * @see [StudioCMS Docs](https://docs.studiocms.dev) for more information on how to use StudioCMS.
  */
-export function studioCMSRenderers(
-	options: StudioCMSRendererConfig,
-	verbose?: boolean
-): AstroIntegration {
-	const { resolve } = createResolver(import.meta.url);
-	const RendererComponent = resolve('../components/Renderer.js');
+export const studioCMSRenderers = defineIntegration({
+	name: pkgName,
+	optionsSchema: z.object({
+		opts: z.custom<StudioCMSRendererConfig>(),
+		verbose: z.boolean(),
+	}),
+	setup: ({ options: { opts, verbose } }) => {
+		// Resolver Function
+		const { resolve } = createResolver(import.meta.url);
+		const RendererComponent = resolve('../components/Renderer.js');
 
-	return {
-		name: pkgName,
-		hooks: {
-			'astro:config:setup': (params) => {
-				// Destructure the params
-				const { logger, config } = params;
+		// Resolve the callout theme based on the user's configuration
+		const resolvedCalloutTheme = resolve(
+			`./styles/md-remark-callouts/${opts.studiocms.callouts.theme}.css`
+		);
 
-				// Log that Setup is Starting
-				integrationLogger(
-					{ logger, logLevel: 'info', verbose },
-					'Setting up StudioCMS Renderer...'
-				);
-				// Setup the runtime logger
-				runtimeLogger(params, { name: 'studiocms-renderer' });
+		return withPlugins({
+			name: pkgName,
+			plugins: [inlineMod],
+			hooks: {
+				'astro:config:setup': (params) => {
+					// Destructure the params
+					const { logger, injectScript } = params;
 
-				// Add Virtual Imports
-				addVirtualImports(params, {
-					name: pkgName,
-					imports: {
-						'studiocms:renderer': `export { default as StudioCMSRenderer } from '${RendererComponent}';`,
-						'studiocms:renderer/config': `export default ${JSON.stringify(options)}`,
-						'studiocms:renderer/astroMarkdownConfig': `export default ${JSON.stringify(config.markdown)}`,
-						'studiocms:renderer/current': `
-						export * from '${resolve('./lib/contentRenderer.js')}';
-						import contentRenderer from '${resolve('./lib/contentRenderer.js')}';
-						export default contentRenderer;
-						`,
-					},
-				});
-				integrationLogger(
-					{ logger, logLevel: 'info', verbose },
-					'StudioCMS Renderer Virtual Imports Added...'
-				);
+					// Log that Setup is Starting
+					integrationLogger(
+						{ logger, logLevel: 'info', verbose },
+						'Setting up StudioCMS Renderer...'
+					);
+					// Setup the runtime logger
+					runtimeLogger(params, { name: 'studiocms-renderer' });
+
+					addVirtualImports(params, {
+						name: pkgName,
+						imports: {
+							'studiocms:renderer/config': `export default ${JSON.stringify(opts)}`,
+							'studiocms:renderer': `export { default as StudioCMSRenderer } from '${RendererComponent}';`,
+							'studiocms:renderer/current': `
+							export * from '${resolve('./lib/contentRenderer.js')}';
+								import contentRenderer from '${resolve('./lib/contentRenderer.js')}';
+								export default contentRenderer;
+							`,
+							// Styles for the Markdown Remark processor
+							'studiocms:renderer/markdown-remark/css': `
+								import '${resolve('./styles/md-remark-headings.css')}';
+								${opts.studiocms.callouts.enabled ? `import '${resolvedCalloutTheme}';` : ''}
+							`,
+						},
+					});
+
+					if (opts.renderer === 'studiocms') {
+						injectScript('page-ssr', 'import "studiocms:renderer/markdown-remark/css";');
+					}
+
+					integrationLogger(
+						{ logger, logLevel: 'info', verbose },
+						'StudioCMS Renderer Virtual Imports Added...'
+					);
+				},
+				'astro:config:done': ({ injectTypes, config }) => {
+					// Inject Types for Renderer
+					injectTypes(rendererDTS);
+
+					// Inject Types for Renderer Config
+					injectTypes(rendererConfigDTS);
+
+					// Inject Types for Astro Markdown Config
+					injectTypes(rendererMarkdownConfigDTS);
+
+					// Inject the Markdown configuration into the shared state
+					shared.markdownConfig = config.markdown;
+					shared.studiocms = opts.studiocms;
+				},
 			},
-			'astro:config:done': ({ injectTypes }) => {
-				// Inject Types for Renderer
-				injectTypes(rendererDTS);
+		});
+	},
+});
 
-				// Inject Types for Renderer Config
-				injectTypes(rendererConfigDTS);
+// /**
+//  * **StudioCMS Renderers Integration**
+//  *
+//  * @param options StudioCMS Renderer Configuration
+//  * @returns AstroIntegration
+//  *
+//  * @see [StudioCMS Docs](https://docs.studiocms.dev) for more information on how to use StudioCMS.
+//  */
+// export function studioCMSRenderers(
+// 	options: StudioCMSRendererConfig,
+// 	verbose?: boolean
+// ): AstroIntegration {
+// 	const { resolve } = createResolver(import.meta.url);
+// 	const RendererComponent = resolve('../components/Renderer.js');
 
-				// Inject Types for Astro Markdown Config
-				injectTypes(rendererMarkdownConfigDTS);
-			},
-		},
-	};
-}
+// 	return {
+// 		name: pkgName,
+// 		hooks: {
+// 			'astro:config:setup': (params) => {
+// 				// Destructure the params
+// 				const { logger, config } = params;
+
+// 				// Log that Setup is Starting
+// 				integrationLogger(
+// 					{ logger, logLevel: 'info', verbose },
+// 					'Setting up StudioCMS Renderer...'
+// 				);
+// 				// Setup the runtime logger
+// 				runtimeLogger(params, { name: 'studiocms-renderer' });
+
+// 				// Add Virtual Imports
+// 				addVirtualImports(params, {
+// 					name: pkgName,
+// 					imports: {
+// 						'studiocms:renderer': `export { default as StudioCMSRenderer } from '${RendererComponent}';`,
+// 						'studiocms:renderer/config': `export default ${JSON.stringify(options)}`,
+// 						'studiocms:renderer/astroMarkdownConfig': `export default ${JSON.stringify(config.markdown)}`,
+// 						'studiocms:renderer/current': `
+// 						export * from '${resolve('./lib/contentRenderer.js')}';
+// 						import contentRenderer from '${resolve('./lib/contentRenderer.js')}';
+// 						export default contentRenderer;
+// 						`,
+// 					},
+// 				});
+// 				integrationLogger(
+// 					{ logger, logLevel: 'info', verbose },
+// 					'StudioCMS Renderer Virtual Imports Added...'
+// 				);
+// 			},
+// 			'astro:config:done': ({ injectTypes }) => {
+// 				// Inject Types for Renderer
+// 				injectTypes(rendererDTS);
+
+// 				// Inject Types for Renderer Config
+// 				injectTypes(rendererConfigDTS);
+
+// 				// Inject Types for Astro Markdown Config
+// 				injectTypes(rendererMarkdownConfigDTS);
+// 			},
+// 		},
+// 	};
+// }
 
 export default studioCMSRenderers;
 

--- a/packages/studiocms_renderers/src/index.ts
+++ b/packages/studiocms_renderers/src/index.ts
@@ -103,69 +103,6 @@ export const studioCMSRenderers = defineIntegration({
 	},
 });
 
-// /**
-//  * **StudioCMS Renderers Integration**
-//  *
-//  * @param options StudioCMS Renderer Configuration
-//  * @returns AstroIntegration
-//  *
-//  * @see [StudioCMS Docs](https://docs.studiocms.dev) for more information on how to use StudioCMS.
-//  */
-// export function studioCMSRenderers(
-// 	options: StudioCMSRendererConfig,
-// 	verbose?: boolean
-// ): AstroIntegration {
-// 	const { resolve } = createResolver(import.meta.url);
-// 	const RendererComponent = resolve('../components/Renderer.js');
-
-// 	return {
-// 		name: pkgName,
-// 		hooks: {
-// 			'astro:config:setup': (params) => {
-// 				// Destructure the params
-// 				const { logger, config } = params;
-
-// 				// Log that Setup is Starting
-// 				integrationLogger(
-// 					{ logger, logLevel: 'info', verbose },
-// 					'Setting up StudioCMS Renderer...'
-// 				);
-// 				// Setup the runtime logger
-// 				runtimeLogger(params, { name: 'studiocms-renderer' });
-
-// 				// Add Virtual Imports
-// 				addVirtualImports(params, {
-// 					name: pkgName,
-// 					imports: {
-// 						'studiocms:renderer': `export { default as StudioCMSRenderer } from '${RendererComponent}';`,
-// 						'studiocms:renderer/config': `export default ${JSON.stringify(options)}`,
-// 						'studiocms:renderer/astroMarkdownConfig': `export default ${JSON.stringify(config.markdown)}`,
-// 						'studiocms:renderer/current': `
-// 						export * from '${resolve('./lib/contentRenderer.js')}';
-// 						import contentRenderer from '${resolve('./lib/contentRenderer.js')}';
-// 						export default contentRenderer;
-// 						`,
-// 					},
-// 				});
-// 				integrationLogger(
-// 					{ logger, logLevel: 'info', verbose },
-// 					'StudioCMS Renderer Virtual Imports Added...'
-// 				);
-// 			},
-// 			'astro:config:done': ({ injectTypes }) => {
-// 				// Inject Types for Renderer
-// 				injectTypes(rendererDTS);
-
-// 				// Inject Types for Renderer Config
-// 				injectTypes(rendererConfigDTS);
-
-// 				// Inject Types for Astro Markdown Config
-// 				injectTypes(rendererMarkdownConfigDTS);
-// 			},
-// 		},
-// 	};
-// }
-
 export default studioCMSRenderers;
 
 export type { StudioCMSRendererConfig };

--- a/packages/studiocms_renderers/src/lib/astro-remark.ts
+++ b/packages/studiocms_renderers/src/lib/astro-remark.ts
@@ -1,7 +1,7 @@
-import astroMarkdownConfig from 'studiocms:renderer/astroMarkdownConfig';
 import { createMarkdownProcessor } from '@astrojs/markdown-remark';
+import { shared } from './shared.js';
 
-const cachedProcessor = await createMarkdownProcessor(astroMarkdownConfig);
+const cachedProcessor = await createMarkdownProcessor(shared.markdownConfig);
 
 /**
  * Render Astro Markdown

--- a/packages/studiocms_renderers/src/lib/contentRenderer.ts
+++ b/packages/studiocms_renderers/src/lib/contentRenderer.ts
@@ -3,6 +3,7 @@ import rendererConfig from 'studiocms:renderer/config';
 import renderAstroMD from './astro-remark.js';
 import renderMarkDoc from './markdoc.js';
 import renderAstroMDX from './mdx.js';
+import renderStudioCMS from './studiocms.js';
 
 const { renderer } = rendererConfig;
 
@@ -16,7 +17,8 @@ const { renderer } = rendererConfig;
  * @returns A promise that resolves to the rendered content as a string.
  * @throws Will throw an error if the custom renderer object is invalid.
  */
-export async function contentRenderer(content: string): Promise<string> {
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+export async function contentRenderer(content: string, SSRResult: any): Promise<string> {
 	if (typeof renderer === 'object') {
 		if (!renderer.renderer || !renderer.name) {
 			throw new Error('Invalid custom renderer');
@@ -26,6 +28,9 @@ export async function contentRenderer(content: string): Promise<string> {
 	}
 
 	switch (renderer) {
+		case 'studiocms':
+			logger.debug('Using built-in renderer: studiocms');
+			return await renderStudioCMS(content, SSRResult);
 		case 'astro':
 			logger.debug('Using built-in renderer: astro remark');
 			return await renderAstroMD(content);

--- a/packages/studiocms_renderers/src/lib/errors.ts
+++ b/packages/studiocms_renderers/src/lib/errors.ts
@@ -1,0 +1,29 @@
+import { StudioCMSCoreError } from '@studiocms/core/errors';
+
+export class StudioCMSRendererError extends StudioCMSCoreError {
+	name = 'StudioCMS Renderer Error';
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+export function prefixError(err: any, prefix: string): any {
+	// If the error is an object with a `message` property, attempt to prefix the message
+	if (err?.message) {
+		try {
+			err.message = `${prefix}:\n${err.message}`;
+			return err;
+		} catch {
+			// Any errors here are ok, there's fallback code below
+		}
+	}
+
+	// If that failed, create a new error with the desired message and attempt to keep the stack
+	const wrappedError = new Error(`${prefix}${err ? `: ${err}` : ''}`);
+	try {
+		wrappedError.stack = err.stack;
+		wrappedError.cause = err;
+	} catch {
+		// It's ok if we could not set the stack or cause - the message is the most important part
+	}
+
+	return wrappedError;
+}

--- a/packages/studiocms_renderers/src/lib/runtime.ts
+++ b/packages/studiocms_renderers/src/lib/runtime.ts
@@ -1,0 +1,47 @@
+import { StudioCMSRendererError, prefixError } from './errors.js';
+
+/**
+ * Imports components by their keys from the 'studiocms:markdown-remark/user-components' module.
+ *
+ * @param keys - An array of strings representing the keys of the components to import.
+ * @returns A promise that resolves to an object containing the imported components.
+ * @throws {MarkdownRemarkError} If any component fails to import, an error is thrown with a prefixed message.
+ */
+export async function importComponentsKeys() {
+	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+	const predefinedComponents: Record<string, any> = {};
+
+	const mod = import('studiocms:component-proxy').catch((e) => {
+		const newErr = prefixError(
+			e,
+			'Failed to import user components from Virtual Module "studiocms:component-proxy"'
+		);
+		console.error(newErr);
+		throw new StudioCMSRendererError(newErr.message, newErr.stack);
+	});
+
+	const componentKeys = (await mod).componentKeys;
+
+	for (const key of componentKeys) {
+		try {
+			predefinedComponents[key.toLowerCase()] = (await mod)[key.toLowerCase()];
+		} catch (e) {
+			if (e instanceof Error) {
+				const newErr = prefixError(
+					e,
+					`Failed to import component "${key}" from Virtual Module "studiocms:component-proxy"`
+				);
+				console.error(newErr);
+				throw new StudioCMSRendererError(newErr.message, newErr.stack);
+			}
+			const newErr = prefixError(
+				new Error('Unknown error'),
+				`Failed to import component "${key}" from Virtual Module "studiocms:component-proxy"`
+			);
+			console.error(newErr);
+			throw new StudioCMSRendererError(newErr.message, newErr.stack);
+		}
+	}
+
+	return predefinedComponents;
+}

--- a/packages/studiocms_renderers/src/lib/shared.ts
+++ b/packages/studiocms_renderers/src/lib/shared.ts
@@ -1,0 +1,24 @@
+import type { Shared } from './types.js';
+
+export const symbol: symbol = Symbol.for('@studiocms/markdown-remark');
+
+/**
+ * A shared object that is either retrieved from the global scope using a symbol or
+ * initialized as a new object with a `markdownConfig` property.
+ *
+ * @constant
+ * @type {Shared}
+ *
+ * @remarks
+ * The `@ts-ignore` comments are used to suppress TypeScript errors related to the use of
+ * the global scope and assignment within expressions. The `biome-ignore` comment is used
+ * to suppress linting errors for the same reason.
+ */
+export const shared: Shared =
+	// @ts-ignore
+	globalThis[symbol] ||
+	// @ts-ignore
+	// biome-ignore lint/suspicious/noAssignInExpressions: <explanation>
+	(globalThis[symbol] = {
+		markdownConfig: {},
+	});

--- a/packages/studiocms_renderers/src/lib/studiocms.ts
+++ b/packages/studiocms_renderers/src/lib/studiocms.ts
@@ -14,15 +14,12 @@ const cachedProcessor = await createMarkdownProcessor({
 const _components = await importComponentsKeys();
 
 /**
- * Render Astro Markdown
+ * Render StudioCMS Markdown content
  *
- * Renders Astro Markdown content
+ * @param content - The StudioCMS Markdown content
+ * @param SSRResult - The SSR result Used to render the custom components
  *
- * Astro is the built-in Astro remark-markdown plugin.
- * @see https://www.npmjs.com/package/@astrojs/markdown-remark
- *
- * @param content - The content to render
- * @returns The rendered content
+ * @returns The rendered HTML
  */
 
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>

--- a/packages/studiocms_renderers/src/lib/studiocms.ts
+++ b/packages/studiocms_renderers/src/lib/studiocms.ts
@@ -1,0 +1,37 @@
+import { createComponentProxy, transformHTML } from 'studiocms:component-proxy';
+import { TransformToProcessor } from '@studiocms/core/schemas';
+import { createMarkdownProcessor } from '@studiocms/markdown-remark-processor';
+import { importComponentsKeys } from './runtime.js';
+import { shared } from './shared.js';
+
+const studiocmsMarkdownExtended = TransformToProcessor.parse(shared.studiocms);
+
+const cachedProcessor = await createMarkdownProcessor({
+	...shared.markdownConfig,
+	...studiocmsMarkdownExtended,
+});
+
+const _components = await importComponentsKeys();
+
+/**
+ * Render Astro Markdown
+ *
+ * Renders Astro Markdown content
+ *
+ * Astro is the built-in Astro remark-markdown plugin.
+ * @see https://www.npmjs.com/package/@astrojs/markdown-remark
+ *
+ * @param content - The content to render
+ * @returns The rendered content
+ */
+
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+export async function renderStudioCMS(content: string, SSRResult: any) {
+	const components = createComponentProxy(SSRResult, _components);
+	const code = (await cachedProcessor.render(content)).code;
+
+	const html = await transformHTML(code, components, studiocmsMarkdownExtended.studiocms.sanitize);
+	return html;
+}
+
+export default renderStudioCMS;

--- a/packages/studiocms_renderers/src/lib/types.ts
+++ b/packages/studiocms_renderers/src/lib/types.ts
@@ -1,0 +1,13 @@
+import type { StudioCMSConfigOptions } from '@studiocms/markdown-remark-processor';
+import type { AstroConfig } from 'astro';
+
+/**
+ * Interface representing shared configuration for markdown.
+ *
+ * @interface Shared
+ * @property {AstroConfig['markdown']} markdownConfig - The markdown configuration from AstroConfig.
+ */
+export interface Shared {
+	markdownConfig: AstroConfig['markdown'];
+	studiocms: StudioCMSConfigOptions;
+}

--- a/packages/studiocms_renderers/src/styles/md-remark-callouts/github.css
+++ b/packages/studiocms_renderers/src/styles/md-remark-callouts/github.css
@@ -1,0 +1,72 @@
+[data-theme="light"] .callout {
+	border-left-color: var(--callout-color-light);
+}
+
+[data-theme="light"] .callout-title {
+	color: var(--callout-color-light);
+}
+
+.callout {
+	border-left-color: var(--callout-color-dark);
+}
+
+.callout-title {
+	color: var(--callout-color-dark);
+}
+
+.callout {
+	width: 100%;
+	padding: 0.5rem 1rem;
+	border-left-width: 0.25em;
+	border-left-style: solid;
+	margin-bottom: 1rem;
+}
+
+.callout-title {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+
+	line-height: 1;
+	font-weight: 500;
+}
+
+.callout-icon svg {
+	overflow: visible !important;
+	display: inline-block;
+
+	vertical-align: text-bottom;
+
+	fill: currentColor;
+}
+
+.callout-content > :first-child {
+	margin-top: 1rem;
+}
+
+.callout-content > :last-child {
+	margin-bottom: 0;
+}
+
+.callout-collapsible .callout-title {
+	cursor: pointer;
+}
+
+.callout-collapsible .callout-fold {
+	display: flex;
+	align-items: center;
+	padding-inline-end: 8px;
+}
+
+.callout-collapsible > .callout-title .callout-fold svg {
+	transform: rotate(-90deg);
+	transition: transform 100ms ease-in-out;
+}
+
+.callout-collapsible[open] > .callout-title .callout-fold svg {
+	transform: none;
+}
+
+.callout-fold {
+	margin-left: -2px;
+}

--- a/packages/studiocms_renderers/src/styles/md-remark-callouts/obsidian.css
+++ b/packages/studiocms_renderers/src/styles/md-remark-callouts/obsidian.css
@@ -1,0 +1,83 @@
+[data-theme="light"] .callout {
+	mix-blend-mode: darken;
+	background-color: rgb(from var(--callout-color-light) r g b / 0.1);
+}
+
+[data-theme="light"] .callout-title {
+	color: var(--callout-color-light);
+}
+
+.callout {
+	mix-blend-mode: lighten;
+	background-color: rgb(from var(--callout-color-dark) r g b / 0.1);
+}
+
+.callout-title {
+	color: var(--callout-color-dark);
+}
+
+.callout {
+	overflow: hidden;
+
+	width: 100%;
+	padding: 12px 12px 12px 24px;
+	border-radius: 4px;
+	margin: 1em 0;
+
+	line-height: 1.3;
+}
+
+.callout-title {
+	display: flex;
+	align-items: flex-start;
+	gap: 4px;
+
+	font-size: inherit;
+}
+
+.callout-icon {
+	display: flex;
+	flex: 0 0 auto;
+	align-items: center;
+}
+
+.callout-title-inner {
+	color: inherit;
+	font-weight: 600;
+}
+
+.callout-content {
+	overflow-x: auto;
+	padding: 0;
+	background-color: transparent;
+}
+
+.callout-collapsible .callout-title {
+	cursor: pointer;
+}
+
+.callout-collapsible .callout-fold {
+	display: flex;
+	align-items: center;
+	padding-inline-end: 8px;
+}
+
+.callout-collapsible > .callout-title .callout-fold svg {
+	transform: rotate(-90deg);
+	transition: transform 100ms ease-in-out;
+}
+
+.callout-collapsible[open] > .callout-title .callout-fold svg {
+	transform: none;
+}
+
+.callout-icon::after,
+.callout-fold::after {
+	content: "\200B";
+}
+
+.callout-icon svg,
+.callout-fold svg {
+	width: 18px;
+	height: 18px;
+}

--- a/packages/studiocms_renderers/src/styles/md-remark-callouts/vitepress.css
+++ b/packages/studiocms_renderers/src/styles/md-remark-callouts/vitepress.css
@@ -1,0 +1,72 @@
+[data-theme="dark"] .callout {
+	background-color: rgb(from var(--callout-color-light) r g b / 0.14);
+}
+
+.callout {
+	background-color: rgb(from var(--callout-color-dark) r g b / 0.16);
+}
+
+.callout {
+	width: 100%;
+	padding: 16px 16px 8px;
+	border: 1px solid transparent;
+	border-radius: 8px;
+	margin: 16px 0;
+
+	line-height: 24px;
+	font-size: 14px;
+}
+
+.callout-title {
+	display: flex;
+	align-items: flex-start;
+	gap: 6px;
+
+	font-size: inherit;
+}
+
+.callout-icon {
+	display: flex;
+	align-items: center;
+	flex: 0 0 auto;
+}
+
+.callout-title-inner {
+	font-weight: 600;
+}
+
+.callout-content p {
+	margin: 8px 0;
+}
+
+.callout-collapsible .callout-title {
+	cursor: pointer;
+	margin: 0 0 8px;
+}
+
+.callout-collapsible .callout-fold {
+	display: flex;
+	align-items: center;
+	padding-inline-end: 8px;
+}
+
+.callout-collapsible > .callout-title .callout-fold svg {
+	transform: rotate(-90deg);
+	transition: transform 100ms ease-in-out;
+}
+
+.callout-collapsible[open] > .callout-title .callout-fold svg {
+	transform: none;
+}
+
+.callout-icon::after,
+.callout-fold::after {
+	content: "\200B";
+}
+
+.callout-icon svg,
+.callout-fold svg {
+	width: 16px;
+	height: 16px;
+	stroke-width: 2.2;
+}

--- a/packages/studiocms_renderers/src/styles/md-remark-headings.css
+++ b/packages/studiocms_renderers/src/styles/md-remark-headings.css
@@ -1,0 +1,56 @@
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border-width: 0;
+}
+
+.heading-wrapper {
+	--icon-size: 1.5rem;
+	--icon-spacing: 0.25em;
+	--anchor-color: #808080;
+	--anchor-hover-color: #6e6e6e;
+	align-items: center;
+}
+
+.heading-wrapper svg {
+	display: inline;
+	width: var(--icon-size);
+	height: var(--icon-size);
+}
+
+.heading-wrapper > :first-child {
+	margin-inline-end: calc(var(--icon-size) + var(--icon-spacing));
+	display: inline;
+}
+
+.anchor-link {
+	margin-inline-start: calc(-1 * (var(--icon-size)));
+	color: var(--anchor-color);
+}
+
+.anchor-link .sr-only {
+	-webkit-user-select: none;
+	user-select: none;
+}
+
+.anchor-link:hover,
+.anchor-link:focus {
+	color: var(--anchor-hover-color);
+}
+
+@media (hover: hover) {
+	.anchor-link {
+		opacity: 0;
+	}
+}
+
+.heading-wrapper:hover > .anchor-link,
+.anchor-link:focus {
+	opacity: 1;
+}

--- a/packages/studiocms_renderers/virtuals.d.ts
+++ b/packages/studiocms_renderers/virtuals.d.ts
@@ -17,3 +17,20 @@ declare module 'studiocms:renderer/current' {
 	export default deModule;
 	export const contentRenderer: typeof import('./src/lib/contentRenderer.js').contentRenderer;
 }
+
+declare module 'studiocms:component-proxy' {
+	export const createComponentProxy: (
+		result: import('astro').SSRResult,
+		_components?: Record<string, any>
+	) => Record<string, any>;
+	export const dedent: (str: string) => string;
+	export const transformHTML: (
+		html: string,
+		components: Record<string, any>,
+		sanitizeOpts?: SanitizeOptions
+	) => Promise<string>;
+
+	export const componentKeys: string[];
+}
+
+declare module 'studiocms:renderer/markdown-remark/css' {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -733,6 +733,9 @@ importers:
       '@matthiesenxyz/astrodtsbuilder':
         specifier: catalog:studiocms-shared
         version: 0.2.0(astro@5.2.3(@types/node@22.10.2)(jiti@2.4.1)(rollup@4.28.1)(typescript@5.7.2)(yaml@2.6.1))
+      '@studiocms/markdown-remark-processor':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@studiocms/robotstxt':
         specifier: workspace:*
         version: link:../studiocms_robotstxt
@@ -978,6 +981,9 @@ importers:
       '@astrojs/react':
         specifier: 'catalog:'
         version: 4.1.0(@types/node@22.10.2)(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(jiti@2.4.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(yaml@2.6.1)
+      '@inox-tools/aik-mod':
+        specifier: 0.9.1
+        version: 0.9.1(astro-integration-kit@0.18.0(astro@5.2.3(@types/node@22.10.2)(jiti@2.4.1)(rollup@4.28.1)(typescript@5.7.2)(yaml@2.6.1)))(astro@5.2.3(@types/node@22.10.2)(jiti@2.4.1)(rollup@4.28.1)(typescript@5.7.2)(yaml@2.6.1))(vite@6.0.3(@types/node@22.10.2)(jiti@2.4.1)(yaml@2.6.1))
       '@inox-tools/runtime-logger':
         specifier: catalog:studiocms-shared
         version: 0.4.0(astro@5.2.3(@types/node@22.10.2)(jiti@2.4.1)(rollup@4.28.1)(typescript@5.7.2)(yaml@2.6.1))
@@ -996,6 +1002,9 @@ importers:
       '@studiocms/core':
         specifier: workspace:*
         version: link:../studiocms_core
+      '@studiocms/markdown-remark-processor':
+        specifier: ^1.0.0
+        version: 1.0.0
       astro:
         specifier: catalog:min
         version: 5.2.3(@types/node@22.10.2)(jiti@2.4.1)(rollup@4.28.1)(typescript@5.7.2)(yaml@2.6.1)
@@ -2552,6 +2561,9 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@studiocms/markdown-remark-processor@1.0.0':
+    resolution: {integrity: sha512-W3wszWS00bc+cQEe+HgynVam5sQcU6kQFv5ZJ/gSwG/KGMYmhKLrHDQBwn9PfjIWORkSqSBMQdsSoAD8fhg3tQ==}
 
   '@studiocms/ui@0.4.8':
     resolution: {integrity: sha512-nAwoANBGKTDVqJ4s6xvwD6Gkz5rtgRMUXqFBUL2hHwqoTwccL8zxR9ufW6eGopeF3DuE13B9wxKfqf7o1ufKow==}
@@ -4254,6 +4266,9 @@ packages:
 
   mdast-util-find-and-replace@3.0.1:
     resolution: {integrity: sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
@@ -6781,7 +6796,7 @@ snapshots:
   '@expressive-code/plugin-shiki@0.38.3':
     dependencies:
       '@expressive-code/core': 0.38.3
-      shiki: 1.27.2
+      shiki: 1.29.2
 
   '@expressive-code/plugin-text-markers@0.38.3':
     dependencies:
@@ -6896,6 +6911,16 @@ snapshots:
       - supports-color
       - vite
 
+  '@inox-tools/aik-mod@0.9.1(astro-integration-kit@0.18.0(astro@5.2.3(@types/node@22.10.2)(jiti@2.4.1)(rollup@4.28.1)(typescript@5.7.2)(yaml@2.6.1)))(astro@5.2.3(@types/node@22.10.2)(jiti@2.4.1)(rollup@4.28.1)(typescript@5.7.2)(yaml@2.6.1))(vite@6.0.3(@types/node@22.10.2)(jiti@2.4.1)(yaml@2.6.1))':
+    dependencies:
+      '@inox-tools/inline-mod': 2.0.2(vite@6.0.3(@types/node@22.10.2)(jiti@2.4.1)(yaml@2.6.1))
+      astro: 5.2.3(@types/node@22.10.2)(jiti@2.4.1)(rollup@4.28.1)(typescript@5.7.2)(yaml@2.6.1)
+      astro-integration-kit: 0.18.0(astro@5.2.3(@types/node@22.10.2)(jiti@2.4.1)(rollup@4.28.1)(typescript@5.7.2)(yaml@2.6.1))
+      debug: 4.4.0
+    transitivePeerDependencies:
+      - supports-color
+      - vite
+
   '@inox-tools/inline-mod@2.0.2(vite@6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1))':
     dependencies:
       '@inox-tools/utils': 0.3.0
@@ -6903,6 +6928,16 @@ snapshots:
       typescript: 5.7.2
     optionalDependencies:
       vite: 6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@inox-tools/inline-mod@2.0.2(vite@6.0.3(@types/node@22.10.2)(jiti@2.4.1)(yaml@2.6.1))':
+    dependencies:
+      '@inox-tools/utils': 0.3.0
+      debug: 4.4.0
+      typescript: 5.7.2
+    optionalDependencies:
+      vite: 6.0.3(@types/node@22.10.2)(jiti@2.4.1)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7864,6 +7899,36 @@ snapshots:
   '@shikijs/vscode-textmate@9.3.1': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@studiocms/markdown-remark-processor@1.0.0':
+    dependencies:
+      '@astrojs/prism': 3.2.0
+      github-slugger: 2.0.0
+      hast-util-from-html: 2.0.3
+      hast-util-is-element: 3.0.0
+      hast-util-to-string: 3.0.1
+      hast-util-to-text: 4.0.2
+      hastscript: 9.0.0
+      html-escaper: 3.0.3
+      import-meta-resolve: 4.1.0
+      js-yaml: 4.1.0
+      mdast-util-definitions: 6.0.0
+      mdast-util-find-and-replace: 3.0.2
+      rehype-autolink-headings: 7.1.0
+      rehype-raw: 7.0.0
+      rehype-stringify: 10.0.1
+      remark-gfm: 4.0.0
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.1
+      remark-smartypants: 3.0.2
+      shiki: 1.29.2
+      unified: 11.0.5
+      unist-util-remove-position: 5.0.0
+      unist-util-visit: 5.0.0
+      unist-util-visit-parents: 6.0.1
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@studiocms/ui@0.4.8(astro@5.2.3(@types/node@20.17.10)(jiti@2.4.1)(rollup@4.28.1)(typescript@5.7.2)(yaml@2.6.1))(vite@6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1))':
     dependencies:
@@ -9862,6 +9927,13 @@ snapshots:
       - supports-color
 
   mdast-util-find-and-replace@3.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
+
+  mdast-util-find-and-replace@3.0.2:
     dependencies:
       '@types/mdast': 4.0.4
       escape-string-regexp: 5.0.0


### PR DESCRIPTION
This pull request introduces several changes across multiple files to enhance the StudioCMS integration, particularly focusing on the renderer configuration and markdown processing. The most significant changes include modifications to the renderer configuration schema, updates to the virtual imports, and the addition of new dependencies and utility functions.

### Renderer Configuration and Markdown Processing Enhancements:

* [`packages/studiocms_core/src/schemas/config/rendererConfig.ts`](diffhunk://#diff-81ff4b12f356cd1914a9798788ba6f4305789319c533c589f7cc8e9a15510dfeR52-R59): Updated the `StudioCMSRendererConfigSchema` to include the new `studiocms` renderer and its configuration options, with `studiocms` set as the default renderer. [[1]](diffhunk://#diff-81ff4b12f356cd1914a9798788ba6f4305789319c533c589f7cc8e9a15510dfeR52-R59) [[2]](diffhunk://#diff-81ff4b12f356cd1914a9798788ba6f4305789319c533c589f7cc8e9a15510dfeR74-R81)
* [`packages/studiocms_core/src/schemas/config/studiocms-markdown-remark.ts`](diffhunk://#diff-7300270765ebbbecb81114796528f360c4dc56811db4150dd4956047b59e5272R1-R79): Added the `StudioCMSMarkdownExtendedSchema` and `TransformToProcessor` to handle custom markdown features and sanitization options.

### Virtual Imports and Integration Setup:

* [`packages/studiocms_renderers/src/index.ts`](diffhunk://#diff-2407016885be6117b43fdbbd0eea40a0dae99a3b108518e0474ba9411eb351faL21-R50): Refactored the `studioCMSRenderers` function to use `defineIntegration` and added virtual imports for the new markdown remark CSS and renderer configuration. [[1]](diffhunk://#diff-2407016885be6117b43fdbbd0eea40a0dae99a3b108518e0474ba9411eb351faL21-R50) [[2]](diffhunk://#diff-2407016885be6117b43fdbbd0eea40a0dae99a3b108518e0474ba9411eb351faL43-R87) [[3]](diffhunk://#diff-2407016885be6117b43fdbbd0eea40a0dae99a3b108518e0474ba9411eb351faR96-R167)
* [`packages/studiocms_renderers/src/lib/astro-remark.ts`](diffhunk://#diff-e2691d442b21f47e0244369569b1fc807985029ff3bd42b72ed87f14488153b2L1-R4): Updated to use the shared markdown configuration instead of a static import.

### Dependency Updates and Utility Functions:

* `packages/studiocms_core/package.json` and `packages/studiocms_renderers/package.json`: Added `@studiocms/markdown-remark-processor` as a new dependency. [[1]](diffhunk://#diff-292a1303df3f6be4b9fc166af32dbe736c9c507a55d43054fa7614f9baec9b81R116) [[2]](diffhunk://#diff-1c550a614aa3ca2bcf7e858d9b1fab432970a6afe26fbe4707b6b5cb4153660aR55-R59)
* [`packages/studiocms_renderers/src/lib/runtime.ts`](diffhunk://#diff-96a586d14ceab303dc1f709ba075a3a52161b07401c85c437e0e52bd3e28dbe8R1-R47): Added a new utility function `importComponentsKeys` to import components by their keys from a virtual module, with error handling.

These changes collectively enhance the flexibility and functionality of the StudioCMS renderer, making it easier to configure and extend markdown processing capabilities.