### PR TITLE
Update main repo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ The primary playground is the [Node Playground](./playground/)
 
 Steps to get a running playground should be the following:
 
-- clone repo
-- run `pnpm i --frozen-lockfile`
-- change `dbStartPage` in the [node playground's](./playground/studiocms.config.mjs) config to `true`
+- Clone the GitHub repository
+- Run `pnpm i --frozen-lockfile`
+- Change `dbStartPage` in the [node playground's](./playground/studiocms.config.mjs) config to `true`
+- Ensure `.env` variables are configured
 
   Commands to run:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Steps to get a running playground should be the following:
 - Clone the GitHub repository
 - Run `pnpm i --frozen-lockfile`
 - Change `dbStartPage` in the [node playground's](./playground/studiocms.config.mjs) config to `true`
-- Ensure `.env` variables are configured
+- Ensure `.env` variables are configured (see [`.env.demo`](./playground/.env.demo) for an example of available environment variables)
 
   Commands to run:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you encounter any bugs or have ideas for new features, please open an issue o
 
 ### Code Contributions
 
-We welcome contributions from the community! Whether it's bug reports, feature requests, or code contributions, we appreciate your help in making this project better. To get started read our [Contributing Guide](https://docs.studiocms.xyz/contributing/getting-started/)
+We welcome contributions from the community! Whether it's bug reports, feature requests, or code contributions, we appreciate your help in making this project better. To get started read our [Contributing Guide](https://docs.studiocms.dev/contributing/getting-started/)
 
 Please note that by contributing to this project, you agree to our [Code of Conduct](https://github.com/withstudiocms/.github/blob/main/CODE_OF_CONDUCT.md).
 
@@ -45,28 +45,19 @@ For an up-to-date list of our main tools check out our [`.prototools`](.prototoo
 
 For more information about Proto checkout [Proto's Website](https://moonrepo.dev/proto)
 
-## This is a [`Moon repository`](https://moonrepo.dev)
-
-Follow install instructions listed on Moonrepo's docs, and you'll be all set to go! Its even a super easy single line command you put in your terminal!
-
-To use the dev server the command is `moon run playground:dev`
-
-> Note: You can always fallback to standard pnpm, Please ensure your version matches our project, and run `pnpm i --frozen-lockfile` to install deps
-
 ## How to use the playgrounds
 
 At the moment these are the current steps for setting up the main StudioCMS playground.
 
 This is intended for testing and development, since we have not yet released a package to play with use these instruction _at your own risk_ This project is still very experimental
 
-The primary playground is the [Node Playground](./playgrounds/node/)
+The primary playground is the [Node Playground](./playground/)
 
 Steps to get a running playground should be the following:
 
 - clone repo
 - run `pnpm i --frozen-lockfile`
-- change `dbStartPage` in the [node playground's](./playground/studiocms.config.mts) config to `true`
-- read the first time setup instructions listed in the [main package readme](./packages/studiocms/README.md#first-start-and-setup) then replace the astro db commands with the following:
+- change `dbStartPage` in the [node playground's](./playground/studiocms.config.mjs) config to `true`
 
   Commands to run:
 
@@ -77,7 +68,7 @@ Once that process completes successfully you are ready to navigate to http://loc
 
 It will redirect and ask you to shutdown and change the above mentioned config option `dbStartPage` to `false` at which point that will enable full functionality of the CMS. you can now restart the dev server with `astro dev --remote` to continue viewing your new site!
 
-That will give you a running dev environment of what we work with daily... the only other thing to get the full functionality currently is to configure a gitub oAuth app for the [Dashboard and authentication](./packages/studiocms/README.md#authentication)
+That will give you a running dev environment of what we work with daily.
 
 To start the playground again use the command `pnpm playground:dev`
 


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to improve the documentation and instructions for contributors and users. The most important changes include updating links, removing outdated instructions, and clarifying the setup process for the playground environment.

Documentation updates:

* Updated the link to the Contributing Guide to use the new domain `studiocms.dev`.
* Removed outdated instructions related to Moonrepo and simplified the instructions for setting up the playground environment.
* Clarified the instructions for configuring and starting the playground environment, including removing references to GitHub OAuth setup.