### PR TITLE
Relocate static assets to CDN and update references in the codebase

### DIFF
--- a/.changeset/public-worms-sniff.md
+++ b/.changeset/public-worms-sniff.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Relocate static assets to CDN R2 bucket

--- a/packages/studiocms/package.json
+++ b/packages/studiocms/package.json
@@ -49,7 +49,6 @@
     "renderer.d.ts",
     "ui.d.ts",
     "dist",
-    "static",
     "studiocms-cli.mjs"
   ],
   "scripts": {
@@ -158,7 +157,6 @@
     "@cloudinary/url-gen": "^1.21.0",
     "@matthiesenxyz/astrodtsbuilder": "^0.2.0",
     "@matthiesenxyz/integration-utils": "^0.3.0",
-    "rollup-plugin-copy": "^3.5.0",
     "mdast": "^3.0.0",
     "mdast-util-from-markdown": "^2.0.2",
     "mdast-util-to-markdown": "^2.1.1",

--- a/packages/studiocms/src/components/dashboard/BaseHead.astro
+++ b/packages/studiocms/src/components/dashboard/BaseHead.astro
@@ -23,9 +23,9 @@ const { title, description } = Astro.props;
   <Generator />
 
   {/* Favicon */}
-  <link rel="icon" href="/studiocms-resources/core/favicon.svg" type="image/svg+xml" />
-  <link rel="icon" href="/studiocms-resources/core/favicon-light.png" type="image/svg+xml" media="(prefers-color-scheme: dark)" />
-  <link rel="icon" href="/studiocms-resources/core/favicon-dark.png" type="image/png" media="(prefers-color-scheme: light)" />
+  <link rel="icon" href="https://cdn.studiocms.dev/favicon.svg" type="image/svg+xml" />
+  <link rel="icon" href="https://cdn.studiocms.dev/favicon-light.png" type="image/svg+xml" media="(prefers-color-scheme: dark)" />
+  <link rel="icon" href="https://cdn.studiocms.dev/favicon-dark.png" type="image/png" media="(prefers-color-scheme: light)" />
 
   {/* Primary Meta Tags */}
   <title>{title}</title>

--- a/packages/studiocms/src/index.ts
+++ b/packages/studiocms/src/index.ts
@@ -14,7 +14,6 @@ import { envField } from 'astro/config';
 import { z } from 'astro/zod';
 import boxen from 'boxen';
 import packageJson from 'package-json';
-import copy from 'rollup-plugin-copy';
 import { compare as semCompare } from 'semver';
 import { loadEnv } from 'vite';
 import { routesDir } from './consts.js';
@@ -1302,19 +1301,7 @@ export const studiocms = defineIntegration({
 							optimizeDeps: {
 								exclude: ['three'],
 							},
-							plugins: [
-								inlineModPlugin(),
-								copy({
-									copyOnce: true,
-									hook: 'buildStart',
-									targets: [
-										{
-											src: resolve('../static/studiocms-resources/*'),
-											dest: 'public/studiocms-resources/',
-										},
-									],
-								}),
-							],
+							plugins: [inlineModPlugin()],
 						},
 					});
 

--- a/packages/studiocms/src/layouts/auth/AuthLayout.astro
+++ b/packages/studiocms/src/layouts/auth/AuthLayout.astro
@@ -30,9 +30,9 @@ const { title, description, lang, disableScreen, checkLogin } = Astro.props;
     <Generator />
 
 	{/* Favicon */}
-	<link rel="icon" href="/studiocms-resources/core/favicon.svg" type="image/svg+xml" />
-	<link rel="icon" href="/studiocms-resources/core/favicon-light.png" type="image/svg+xml" media="(prefers-color-scheme: dark)" />
-	<link rel="icon" href="/studiocms-resources/core/favicon-dark.png" type="image/png" media="(prefers-color-scheme: light)" />
+	<link rel="icon" href="https://cdn.studiocms.dev/favicon.svg" type="image/svg+xml" />
+	<link rel="icon" href="https://cdn.studiocms.dev/favicon-light.png" type="image/svg+xml" media="(prefers-color-scheme: dark)" />
+	<link rel="icon" href="https://cdn.studiocms.dev/favicon-dark.png" type="image/png" media="(prefers-color-scheme: light)" />
 
   	{/* Primary Meta Tags */}
     <title>{title}</title>

--- a/packages/studiocms/src/scripts/three.ts
+++ b/packages/studiocms/src/scripts/three.ts
@@ -13,6 +13,8 @@ const loginPageBackground = configElement.dataset.config_background;
 const loginPageCustomImage = configElement.dataset.config_custom_image;
 const currentMode = document.documentElement.dataset.theme || 'dark';
 
+const studioCMS3DModal = 'https://cdn.studiocms.dev/studiocms-logo.glb';
+
 /**
  * A valid image that can be used as a background for the StudioCMS Logo.
  */
@@ -226,7 +228,7 @@ class StudioCMS3DLogo {
 		const loader = new GLTFLoader();
 
 		// Load the GLTF Model from the public dir & apply the material to all children
-		loader.loadAsync('/studiocms-resources/auth/studiocms-logo.glb').then((gltf) => {
+		loader.loadAsync(studioCMS3DModal).then((gltf) => {
 			this.model = gltf.scene;
 
 			this.model.traverse((child) => {

--- a/packages/studiocms/static/studiocms-resources/readme.md
+++ b/packages/studiocms/static/studiocms-resources/readme.md
@@ -1,0 +1,1 @@
+These resources have been relocated to StudioCMS R2 CDN bucket. these are being left here as references of what is currently in the CDN.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,9 +429,6 @@ importers:
       remark-rehype:
         specifier: ^11.1.1
         version: 11.1.1
-      rollup-plugin-copy:
-        specifier: ^3.5.0
-        version: 3.5.0
       semver:
         specifier: ^7.7.1
         version: 7.7.1
@@ -2096,12 +2093,6 @@ packages:
   '@types/figlet@1.7.0':
     resolution: {integrity: sha512-KwrT7p/8Eo3Op/HBSIwGXOsTZKYiM9NpWRBJ5sVjWP/SmlS+oxxRvJht/FNAtliJvja44N3ul1yATgohnVBV0Q==}
 
-  '@types/fs-extra@8.1.5':
-    resolution: {integrity: sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==}
-
-  '@types/glob@7.2.0':
-    resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
-
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -2131,9 +2122,6 @@ packages:
 
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
-
-  '@types/minimatch@5.1.2':
-    resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
 
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
@@ -2425,9 +2413,6 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
-
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
 
@@ -2552,9 +2537,6 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
-  colorette@1.4.0:
-    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
-
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -2564,9 +2546,6 @@ packages:
 
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -3249,10 +3228,6 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
-
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3260,10 +3235,6 @@ packages:
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
-
-  globby@10.0.1:
-    resolution: {integrity: sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==}
-    engines: {node: '>=8'}
 
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -3432,10 +3403,6 @@ packages:
   import-meta-resolve@4.1.0:
     resolution: {integrity: sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==}
 
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
-
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -3515,10 +3482,6 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
-
-  is-plain-object@3.0.1:
-    resolution: {integrity: sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==}
-    engines: {node: '>=0.10.0'}
 
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
@@ -3911,9 +3874,6 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
   minimatch@8.0.4:
     resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -4158,10 +4118,6 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -4505,10 +4461,6 @@ packages:
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
-  rollup-plugin-copy@3.5.0:
-    resolution: {integrity: sha512-wI8D5dvYovRMx/YYKtUNt3Yxaw4ORC9xo6Gt9t22kveWz1enG9QrhVlagzwrxSC455xD1dHMKhIJkbsQ7d48BA==}
-    engines: {node: '>=8.3'}
 
   rollup@4.34.8:
     resolution: {integrity: sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==}
@@ -7325,15 +7277,6 @@ snapshots:
 
   '@types/figlet@1.7.0': {}
 
-  '@types/fs-extra@8.1.5':
-    dependencies:
-      '@types/node': 22.10.2
-
-  '@types/glob@7.2.0':
-    dependencies:
-      '@types/minimatch': 5.1.2
-      '@types/node': 22.10.2
-
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -7366,8 +7309,6 @@ snapshots:
     optional: true
 
   '@types/mdx@2.0.13': {}
-
-  '@types/minimatch@5.1.2': {}
 
   '@types/ms@0.7.34': {}
 
@@ -8004,11 +7945,6 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.0
 
-  brace-expansion@1.1.11:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
@@ -8144,15 +8080,11 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
 
-  colorette@1.4.0: {}
-
   comma-separated-tokens@2.0.3: {}
 
   commander@13.0.0: {}
 
   common-ancestor-path@1.0.1: {}
-
-  concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
 
@@ -8704,15 +8636,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-
   glob@9.3.5:
     dependencies:
       fs.realpath: 1.0.0
@@ -8721,17 +8644,6 @@ snapshots:
       path-scurry: 1.11.1
 
   globals@11.12.0: {}
-
-  globby@10.0.1:
-    dependencies:
-      '@types/glob': 7.2.0
-      array-union: 2.1.0
-      dir-glob: 3.0.1
-      fast-glob: 3.3.3
-      glob: 7.2.3
-      ignore: 5.3.2
-      merge2: 1.4.1
-      slash: 3.0.0
 
   globby@11.1.0:
     dependencies:
@@ -9042,11 +8954,6 @@ snapshots:
 
   import-meta-resolve@4.1.0: {}
 
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
@@ -9103,8 +9010,6 @@ snapshots:
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
-
-  is-plain-object@3.0.1: {}
 
   is-stream@4.0.1: {}
 
@@ -9784,10 +9689,6 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  minimatch@3.1.2:
-    dependencies:
-      brace-expansion: 1.1.11
-
   minimatch@8.0.4:
     dependencies:
       brace-expansion: 2.0.1
@@ -10026,8 +9927,6 @@ snapshots:
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
-
-  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -10461,14 +10360,6 @@ snapshots:
   retry@0.13.1: {}
 
   reusify@1.0.4: {}
-
-  rollup-plugin-copy@3.5.0:
-    dependencies:
-      '@types/fs-extra': 8.1.5
-      colorette: 1.4.0
-      fs-extra: 8.1.0
-      globby: 10.0.1
-      is-plain-object: 3.0.1
 
   rollup@4.34.8:
     dependencies:


### PR DESCRIPTION
This pull request includes significant changes to relocate static assets to a CDN and remove the `rollup-plugin-copy` dependency. The changes span multiple files, updating references to static assets and cleaning up dependencies.

Relocation of static assets to CDN:

* [`.changeset/public-worms-sniff.md`](diffhunk://#diff-6d26cfee8ae130bdd5cd8b4fec13387dbe0b89dc71fef5ea66ee6f64403a2e65R1-R5): Added a changeset to document the relocation of static assets to the CDN R2 bucket.
* [`packages/studiocms/src/components/dashboard/BaseHead.astro`](diffhunk://#diff-4d7a90fbc7cb5127a71dc32ab5cb8b23b377a2bcaced8edce9dd413b8243a6d5L26-R28): Updated favicon URLs to point to the CDN.
* [`packages/studiocms/src/layouts/auth/AuthLayout.astro`](diffhunk://#diff-11853d1a5baaa8d1bd513d670712c424e3ac8ae2234ad691e75cc4c47cdd0442L33-R35): Updated favicon URLs to point to the CDN.
* [`packages/studiocms/src/scripts/three.ts`](diffhunk://#diff-12d6b45bb310a556afb1f47d48341bedc832f952d049519e3951babb80ba9a7dR16-R17): Updated the 3D model URL to point to the CDN. [[1]](diffhunk://#diff-12d6b45bb310a556afb1f47d48341bedc832f952d049519e3951babb80ba9a7dR16-R17) [[2]](diffhunk://#diff-12d6b45bb310a556afb1f47d48341bedc832f952d049519e3951babb80ba9a7dL229-R231)

Removal of `rollup-plugin-copy` dependency:

* [`packages/studiocms/package.json`](diffhunk://#diff-2d16107b635fed3f93e32a31b7351ed4af23aa3e9b5de69af9992939bbb41c38L161): Removed the `rollup-plugin-copy` dependency and the `static` directory from the package files. [[1]](diffhunk://#diff-2d16107b635fed3f93e32a31b7351ed4af23aa3e9b5de69af9992939bbb41c38L161) [[2]](diffhunk://#diff-2d16107b635fed3f93e32a31b7351ed4af23aa3e9b5de69af9992939bbb41c38L52)
* [`packages/studiocms/src/index.ts`](diffhunk://#diff-acb4a7fbcdb98537d3c96596b3f5ba1d778913c6b1d764de60dd9a2c761b4c46L17): Removed the `rollup-plugin-copy` import and its usage in the `plugins` array. [[1]](diffhunk://#diff-acb4a7fbcdb98537d3c96596b3f5ba1d778913c6b1d764de60dd9a2c761b4c46L17) [[2]](diffhunk://#diff-acb4a7fbcdb98537d3c96596b3f5ba1d778913c6b1d764de60dd9a2c761b4c46L1305-R1304)
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL432-L434): Cleaned up entries related to `rollup-plugin-copy` and its dependencies. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL432-L434) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2099-L2104) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2135-L2137) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2428-L2430) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2555-L2557) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2568-L2570) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3252-L3255) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3264-L3267) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3435-L3438) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3519-L3522) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3914-L3916) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4162-L4165) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4509-L4512) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7328-L7336) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7370-L7371) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8007-L8011) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8147-L8156) [[18]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8707-L8715) [[19]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8725-L8735) [[20]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9045-L9049) [[21]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9107-L9108) [[22]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9787-L9790) [[23]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10030-L10031) [[24]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10465-L10472)

Documentation update:

* [`packages/studiocms/static/studiocms-resources/readme.md`](diffhunk://#diff-19bc5963b791d6f0bd7c6bdb4023ea5544240c8f5f78b63b46fe5ada64bf45f1R1): Added a note about the relocation of resources to the CDN.