### PR TITLE
Update labeler rules to label for new i18n paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,4 +2,4 @@
 
 translations:
   - changed-files:
-      - any-glob-to-any-file: packages/studiocms_core/src/i18n/translations/*
+      - any-glob-to-any-file: packages/studiocms/src/lib/i18n/translations/*


### PR DESCRIPTION
This pull request includes a small change to the `.github/labeler.yml` file. The change updates the file path for translations to reflect the correct directory.

* [`.github/labeler.yml`](diffhunk://#diff-a22c263686553013feaeb0677d26eeb0b8778a756c4311c1fce13384258026aaL5-R5): Updated the file path for translations from `packages/studiocms_core/src/i18n/translations/*` to `packages/studiocms/src/lib/i18n/translations/*`.