### PR TITLE
Update @types/node version and fix changeset release name

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@changesets/config": "3.1.1",
     "@changesets/changelog-github": "0.5.1",
     "@changesets/write": "0.4.0",
+    "@types/node": "catalog:",
     "build-scripts": "workspace:*",
     "studiocms": "workspace:*",
     "execa": "9.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@changesets/write':
         specifier: 0.4.0
         version: 0.4.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.17.10
       build-scripts:
         specifier: workspace:*
         version: link:build-scripts

--- a/scripts/translation-changeset.ts
+++ b/scripts/translation-changeset.ts
@@ -27,7 +27,7 @@ async function run() {
 
 	// Create a new changeset
 	const changesetId = await write(
-		{ summary, releases: [{ name: '@studiocms/core', type: 'patch' }] },
+		{ summary, releases: [{ name: 'studiocms', type: 'patch' }] },
 		process.cwd()
 	);
 


### PR DESCRIPTION
This pull request includes several changes related to dependencies and a script update. The most important changes are summarized below:

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R43): Added `@types/node` with a version specified as "catalog:".
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR87-R89): Added `@types/node` with a version specified as 'catalog:' and version 20.17.10.

Script update:

* [`scripts/translation-changeset.ts`](diffhunk://#diff-09f1354dca852ccda62569b9ce96b004aa990c54eb519f27193946df1066d76dL30-R30): Modified the `releases` object in the `run` function to use 'studiocms' instead of '@studiocms/core' for the name.