### PR TITLE
re-add accidentally removed action

### DIFF
--- a/.github/workflows/ci-i18n-pr.yml
+++ b/.github/workflows/ci-i18n-pr.yml
@@ -1,0 +1,36 @@
+name: Translation Changesets
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: write
+
+jobs:
+  build-translation-changesets:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'translations') && github.event.pull_request.user.login == 'studiocms-no-reply'
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+            ref: ${{ github.head_ref }}
+            token: ${{ secrets.STUDIOCMS_SERVICE_TOKEN }}
+
+      - name: Install Tools & Dependencies
+        uses: withstudiocms/automations/.github/actions/install@main
+
+      - name: Create Translation Changesets
+        run: pnpm ci:translations:changeset
+        env:
+          CI_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+    
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 # v5
+        with:
+          commit_message: '[ci] changesets'
+          branch: ${{ github.head_ref }}
+          commit_user_name: studiocms-no-reply
+          commit_user_email: no-reply@studiocms.dev
+          commit_author: StudioCMS <no-reply@studiocms.dev>


### PR DESCRIPTION
This pull request re-introduces a GitHub Actions workflow to automate the creation of translation changesets. The workflow is triggered by specific pull request events and performs several steps to ensure translation changes are properly managed and committed.

### New GitHub Actions Workflow:

* [`.github/workflows/ci-i18n-pr.yml`](diffhunk://#diff-0069e3e06516feef3e50ba6765d244f4ef3bc8f6057b3a86cd28a7f780f840dcR1-R36): Added a new workflow named "Translation Changesets" that triggers on pull request events labeled with 'translations' and synchronizes changes. The workflow includes steps to checkout the repository, install necessary tools and dependencies, create translation changesets, and commit the changes.