### PR TITLE
Hotfix

### DIFF
--- a/.changeset/wild-crabs-tap.md
+++ b/.changeset/wild-crabs-tap.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+fix firsttime setup page redirect, and fix sdk

--- a/packages/studiocms/src/routes/firstTimeSetupRoutes/1-start.astro
+++ b/packages/studiocms/src/routes/firstTimeSetupRoutes/1-start.astro
@@ -117,7 +117,7 @@ const curves = validImages.filter(({ name }) => name === 'studiocms-curves')[0];
                     description: 'Basic site information saved successfully!',
                     type: 'success',
                 })
-                window.location.assign('/setup/2');
+                window.location.assign('/start/2');
             }
 
             if (response.status !== 200) {

--- a/packages/studiocms/src/sdk/core.ts
+++ b/packages/studiocms/src/sdk/core.ts
@@ -1561,9 +1561,9 @@ export function studiocmsSDKCore() {
 					} = pageData;
 
 					const stringified = {
-						categories: JSON.stringify(categories || []),
-						tags: JSON.stringify(tags || []),
-						contributorIds: JSON.stringify(contributorIds || []),
+						categories: categories || [],
+						tags: tags || [],
+						contributorIds: contributorIds || [],
 					};
 
 					const contentData = {
@@ -1948,9 +1948,9 @@ export function studiocmsSDKCore() {
 						} = pageData;
 
 						const stringified = {
-							categories: JSON.stringify(categories || []),
-							tags: JSON.stringify(tags || []),
-							contributorIds: JSON.stringify(contributorIds || []),
+							categories: categories || [],
+							tags: tags || [],
+							contributorIds: contributorIds || [],
 						};
 
 						const contentData = {


### PR DESCRIPTION
This pull request includes several changes to fix issues with the first-time setup page redirect and the SDK in the `studiocms` package. The most important changes include updating the redirect URL in the first-time setup route and modifying how categories, tags, and contributor IDs are handled in the SDK core function.

Fixes to first-time setup page redirect:

* [`packages/studiocms/src/routes/firstTimeSetupRoutes/1-start.astro`](diffhunk://#diff-f66c82050bba1d03fbfec7dc9e9cec4f4c015e5582ab5718b61d91b9ae4d56feL120-R120): Changed the redirect URL from `/setup/2` to `/start/2`.

Improvements to SDK:

* [`packages/studiocms/src/sdk/core.ts`](diffhunk://#diff-ae147f9d6413d6cbe2985db2799b012f12cf29f84feedf1a88bebe4a8536d4d3L1564-R1566): Removed unnecessary JSON stringification for `categories`, `tags`, and `contributorIds` in the `studiocmsSDKCore` function. [[1]](diffhunk://#diff-ae147f9d6413d6cbe2985db2799b012f12cf29f84feedf1a88bebe4a8536d4d3L1564-R1566) [[2]](diffhunk://#diff-ae147f9d6413d6cbe2985db2799b012f12cf29f84feedf1a88bebe4a8536d4d3L1951-R1953)

Documentation:

* [`.changeset/wild-crabs-tap.md`](diffhunk://#diff-960ae1f434bb51ef004f8754c962c56f885baaecf86fbc78f7d35e906f0efb88R1-R5): Added a changeset entry to document the patch fix for the first-time setup page redirect and SDK.