### PR TITLE
fix: correct data type sent by create page form

### DIFF
--- a/.changeset/social-olives-fly.md
+++ b/.changeset/social-olives-fly.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Fix: Create page form was sending the wrong type of data.

--- a/packages/studiocms/src/components/dashboard/islands/content-mgmt/CreatePage.astro
+++ b/packages/studiocms/src/components/dashboard/islands/content-mgmt/CreatePage.astro
@@ -248,6 +248,9 @@ import { toast } from "studiocms:ui/components";
       const response = await fetch(createPageForm.action, {
           method: 'POST',
           body: formData,
+          headers: {
+              'Content-Type': 'application/json',
+          },
       });
 
       const res = await response.json();
@@ -297,10 +300,7 @@ import { toast } from "studiocms:ui/components";
 
       const response = await fetch(createPageForm.action, {
           method: 'POST',
-          headers: {
-              'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ data, content }),
+          body: formData,
       });
 
       const res = await response.json();

--- a/packages/studiocms/src/routes/dashboard/studiocms_api/dashboard/content/page.ts
+++ b/packages/studiocms/src/routes/dashboard/studiocms_api/dashboard/content/page.ts
@@ -131,6 +131,8 @@ export const POST: APIRoute = async (context: APIContext) => {
 			await apiRoute(context);
 		}
 
+		studioCMS_SDK_Cache.CLEAR.pages();
+
 		return simpleResponse(200, 'Page created successfully');
 	} catch (error) {
 		return simpleResponse(500, 'Failed to create page');


### PR DESCRIPTION
This pull request includes several changes to fix the issue with the Create Page form in StudioCMS and improve the handling of page creation. The most important changes include updating the form data handling, adjusting the headers, and clearing the cache after page creation.

Fixes and improvements:

* [`.changeset/social-olives-fly.md`](diffhunk://#diff-37887d8a9f9ffabd47aa424ea922674c690faba1a6f3c7c9a5d795f7c65ee852R1-R5): Added a changeset entry to document the fix for the Create Page form sending the wrong type of data.

Form data handling:

* [`packages/studiocms/src/components/dashboard/islands/content-mgmt/CreatePage.astro`](diffhunk://#diff-8f59225c2e2a9c8d791b85e2227d24f2483ba39ab44ff7453bd83cf7135d6be5R251-R253): Updated the `fetch` request to include the `Content-Type` header as `application/json` when sending the form data.
* [`packages/studiocms/src/components/dashboard/islands/content-mgmt/CreatePage.astro`](diffhunk://#diff-8f59225c2e2a9c8d791b85e2227d24f2483ba39ab44ff7453bd83cf7135d6be5L300-R303): Removed the `Content-Type` header and adjusted the body to use `formData` instead of `JSON.stringify`.

Cache management:

* [`packages/studiocms/src/routes/dashboard/studiocms_api/dashboard/content/page.ts`](diffhunk://#diff-280778e85eb1dc28bb3b6804858cc12656468a471e4225114e27f7f225f923b6R134-R135): Added a call to `studioCMS_SDK_Cache.CLEAR.pages()` to clear the cache after successfully creating a page.