### PR TITLE
fix: prevent rendering quick tools on specific API routes and dashboard

### DIFF
--- a/.changeset/puny-plums-wear.md
+++ b/.changeset/puny-plums-wear.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Fix integration injection, and when quicktools are usable

--- a/packages/studiocms/src/components/user-quick-tools.ts
+++ b/packages/studiocms/src/components/user-quick-tools.ts
@@ -37,6 +37,8 @@ interface GetSessionResponse {
 	routes: Routes;
 }
 
+const knownAPIRoutes = ['/studiocms_api/', '/_studiocms-devapps/'];
+
 /**
  * Verifies if the user's permission level meets the required permission rank.
  *
@@ -64,7 +66,13 @@ class UserQuickTools extends HTMLElement {
 			return;
 		}
 
+		// If the user is on the dashboard, don't render the quick tools
 		if (window.location.pathname.includes(data.routes.dashboardIndex)) {
+			return;
+		}
+
+		// If the user is on any of the known StudioCMS API routes, don't render the quick tools
+		if (knownAPIRoutes.some((route) => window.location.pathname.includes(route))) {
 			return;
 		}
 

--- a/packages/studiocms/src/index.ts
+++ b/packages/studiocms/src/index.ts
@@ -961,10 +961,10 @@ export const studiocms = defineIntegration({
 								prerender: false,
 							});
 						}
-
-						// Setup Integrations
-						addIntegrationArray(params, integrations);
 					}
+
+					// Setup Integrations
+					addIntegrationArray(params, integrations);
 
 					// Inject Virtual modules
 					integrationLogger(logInfo, 'Adding Virtual Imports...');


### PR DESCRIPTION
This pull request includes changes to the `packages/studiocms` module to improve the behavior of the user quick tools component and fix a minor syntax issue in the integration setup. The most important changes include adding a check for known API routes to prevent rendering the quick tools and fixing a misplaced closing bracket in the integration setup.

Improvements to user quick tools behavior:

* [`packages/studiocms/src/components/user-quick-tools.ts`](diffhunk://#diff-e744e0c98faaf1f800a92b2f0e1775a7aad17d38cc254890b5d595d556e94761R40-R41): Added a constant `knownAPIRoutes` to define routes where the quick tools should not be rendered.
* [`packages/studiocms/src/components/user-quick-tools.ts`](diffhunk://#diff-e744e0c98faaf1f800a92b2f0e1775a7aad17d38cc254890b5d595d556e94761R69-R78): Updated the `UserQuickTools` class to check if the current path is a known API route before rendering the quick tools.

Syntax fix:

* [`packages/studiocms/src/index.ts`](diffhunk://#diff-acb4a7fbcdb98537d3c96596b3f5ba1d778913c6b1d764de60dd9a2c761b4c46R964-L967): Fixed a misplaced closing bracket in the `defineIntegration` function to ensure proper integration setup.