### PR TITLE
Fix double toolbar on the outerbase viewer

### DIFF
--- a/.changeset/silly-mirrors-leave.md
+++ b/.changeset/silly-mirrors-leave.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/devapps": patch
+---
+
+fix double toolbar showing within outerbase toolbar app

--- a/packages/studiocms_devapps/src/routes/outerbase.astro
+++ b/packages/studiocms_devapps/src/routes/outerbase.astro
@@ -16,6 +16,13 @@ function getIFrameSrc(dbUrl: string) {
 }
 ---
 <html>
+    <head>
+        <style is:global>
+            astro-dev-toolbar {
+                display: none !important;
+            }
+        </style>
+    </head>
     <body style="margin: 0; padding: 0; overflow: hidden;">
         <iframe id="sqlIframe"
             style="width: 100%; height: 100vh; border: none;"
@@ -25,6 +32,7 @@ function getIFrameSrc(dbUrl: string) {
             data-dburl={dbEnv.remoteUrl}
             data-dbtoken={dbEnv.token}
             />
+
         <script>
             // @ts-ignore
             import { createClient } from 'https://esm.sh/@libsql/client@0.14.0/web';

--- a/packages/studiocms_devapps/src/routes/outerbase.astro
+++ b/packages/studiocms_devapps/src/routes/outerbase.astro
@@ -19,7 +19,7 @@ function getIFrameSrc(dbUrl: string) {
     <head>
         <style is:global>
             astro-dev-toolbar {
-                display: none !important;
+                display: none;
             }
         </style>
     </head>


### PR DESCRIPTION
This pull request includes changes to fix the issue of a double toolbar showing within the outerbase toolbar app and to improve the styling of the toolbar. The most important changes include the addition of a global style to hide the toolbar and the addition of a changeset entry to document the fix.

Styling improvements:

* [`packages/studiocms_devapps/src/routes/outerbase.astro`](diffhunk://#diff-2db9d0d0b740f772a18eceecf249a544a00f7af5b783cd01140cb61ab0aec0c5R19-R25): Added a global style to hide the `astro-dev-toolbar` to prevent the double toolbar issue.

Documentation:

* [`.changeset/silly-mirrors-leave.md`](diffhunk://#diff-e51796e7dc392d2c75021d45832f06f4fa6e84e2ad790952c56d709ddd266c76R1-R5): Added a changeset entry to document the fix for the double toolbar issue.