### PR TITLE
feat(sdk): Hide and protect Ghost (deleted) user account

### DIFF
--- a/.changeset/neat-chicken-call.md
+++ b/.changeset/neat-chicken-call.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Hide the deleted "Ghost" user from the dashboard

--- a/.changeset/neat-chicken-call.md
+++ b/.changeset/neat-chicken-call.md
@@ -2,4 +2,4 @@
 "studiocms": patch
 ---
 
-Hide the deleted "Ghost" user from the dashboard
+Hide and protect the deleted "Ghost" user from the dashboard

--- a/packages/studiocms/src/sdk/core.ts
+++ b/packages/studiocms/src/sdk/core.ts
@@ -1017,6 +1017,10 @@ export function studiocmsSDKCore() {
 					const users = await db.select().from(tsUsers);
 
 					for (const user of users) {
+						if (user.id === GhostUserDefaults.id) {
+							continue;
+						}
+
 						const UserData = await collectUserData(user);
 
 						combinedUserData.push(UserData);

--- a/packages/studiocms/src/sdk/core.ts
+++ b/packages/studiocms/src/sdk/core.ts
@@ -2434,6 +2434,11 @@ export function studiocmsSDKCore() {
 		 * @throws {StudioCMS_SDK_Error} If an error occurs while deleting the user.
 		 */
 		user: async (id: string): Promise<DeletionResponse> => {
+			if (id === GhostUserDefaults.id) {
+				throw new StudioCMS_SDK_Error(
+					`User with ID ${id} is an internal user and cannot be deleted.`
+				);
+			}
 			try {
 				const verifyNoReference = await clearUserReferences(id);
 


### PR DESCRIPTION
This pull request includes changes to hide and protect the deleted "Ghost" user from the dashboard in the `studiocms` package. The most important changes are:

Improvements to user data handling:

* [`.changeset/neat-chicken-call.md`](diffhunk://#diff-8f437b49a3fc90870aeedead2cc7e99412d09e97d8bb49b356fe1092be3773a3R1-R5): Added a changeset to document the patch that hides and protects the deleted "Ghost" user from the dashboard.

Codebase modifications:

* [`packages/studiocms/src/sdk/core.ts`](diffhunk://#diff-ae147f9d6413d6cbe2985db2799b012f12cf29f84feedf1a88bebe4a8536d4d3R1020-R1023): Updated the `studiocmsSDKCore` function to skip processing the "Ghost" user when collecting user data.
* [`packages/studiocms/src/sdk/core.ts`](diffhunk://#diff-ae147f9d6413d6cbe2985db2799b012f12cf29f84feedf1a88bebe4a8536d4d3R2437-R2441): Added a check to prevent deletion of the "Ghost" user and throw an error if an attempt is made to delete this internal user.