### PR TITLE
fix(studiocms): Fix weird astro bundling issue

### DIFF
--- a/.changeset/olive-otters-cheat.md
+++ b/.changeset/olive-otters-cheat.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Move routes to their ts variant to resolve weird bundling issue with astro

--- a/packages/studiocms/package.json
+++ b/packages/studiocms/package.json
@@ -125,7 +125,7 @@
     "./v/core.d.ts": "./dist/core.d.ts",
     "./v/auth.d.ts": "./dist/auth.d.ts",
     "./v/renderer.d.ts": "./dist/renderer.d.ts",
-    "./src/*": "./src/*"
+    "./src/routes/*": "./src/routes/*"
   },
   "type": "module",
   "dependencies": {

--- a/packages/studiocms/package.json
+++ b/packages/studiocms/package.json
@@ -46,7 +46,8 @@
     "README.md",
     "ui.d.ts",
     "dist",
-    "studiocms-cli.mjs"
+    "studiocms-cli.mjs",
+    "src"
   ],
   "scripts": {
     "build": "build-scripts build 'src/**/*.{ts,css}'",
@@ -123,7 +124,8 @@
     },
     "./v/core.d.ts": "./dist/core.d.ts",
     "./v/auth.d.ts": "./dist/auth.d.ts",
-    "./v/renderer.d.ts": "./dist/renderer.d.ts"
+    "./v/renderer.d.ts": "./dist/renderer.d.ts",
+    "./src/*": "./src/*"
   },
   "type": "module",
   "dependencies": {

--- a/packages/studiocms/src/consts.ts
+++ b/packages/studiocms/src/consts.ts
@@ -1,7 +1,4 @@
-import { createResolver } from 'astro-integration-kit';
 import type { TimeString } from './schemas/config/sdk.js';
-
-const { resolve } = createResolver(import.meta.url);
 
 /**
  * StudioCMS Site Config Table Entry ID
@@ -51,30 +48,28 @@ export type CurrentRESTAPIVersions = (typeof currentRESTAPIVersions)[number];
 /**
  * Routes Directory Resolver
  */
-const _routes_dir = (path: string) => resolve(`./routes/${path}`);
-
-const __temp = (path: string) => `studiocms/src/routes/${path}`;
+const _routes_dir = (path: string) => `studiocms/src/routes/${path}`;
 
 /**
  * REST API Directory Resolver
  */
 const _rest_dir = (version: CurrentRESTAPIVersions) => (file: string) =>
-	__temp(`rest/${version}/${file}`);
+	_routes_dir(`rest/${version}/${file}`);
 
 /**
  * REST API Directory
  */
 export const routesDir = {
-	fts: (file: string) => __temp(`firstTimeSetupRoutes/${file}`),
-	dashRoute: (file: string) => __temp(`dashboard/${file}`),
-	dashApi: (file: string) => __temp(`dashboard/studiocms_api/dashboard/${file}`),
-	errors: (file: string) => __temp(`error-pages/${file}`),
+	fts: (file: string) => _routes_dir(`firstTimeSetupRoutes/${file}`),
+	dashRoute: (file: string) => _routes_dir(`dashboard/${file}`),
+	dashApi: (file: string) => _routes_dir(`dashboard/studiocms_api/dashboard/${file}`),
+	errors: (file: string) => _routes_dir(`error-pages/${file}`),
 	v1Rest: (file: string) => _rest_dir('v1')(file),
-	sdk: (file: string) => __temp(`sdk/${file}`),
-	api: (file: string) => __temp(`api/${file}`),
-	authPage: (file: string) => __temp(`auth/${file}`),
-	authAPI: (file: string) => __temp(`auth/api/${file}`),
-	mailer: (file: string) => __temp(`mailer/${file}`),
+	sdk: (file: string) => _routes_dir(`sdk/${file}`),
+	api: (file: string) => _routes_dir(`api/${file}`),
+	authPage: (file: string) => _routes_dir(`auth/${file}`),
+	authAPI: (file: string) => _routes_dir(`auth/api/${file}`),
+	mailer: (file: string) => _routes_dir(`mailer/${file}`),
 };
 
 /**

--- a/packages/studiocms/src/consts.ts
+++ b/packages/studiocms/src/consts.ts
@@ -53,26 +53,28 @@ export type CurrentRESTAPIVersions = (typeof currentRESTAPIVersions)[number];
  */
 const _routes_dir = (path: string) => resolve(`./routes/${path}`);
 
+const __temp = (path: string) => `studiocms/src/routes/${path}`;
+
 /**
  * REST API Directory Resolver
  */
 const _rest_dir = (version: CurrentRESTAPIVersions) => (file: string) =>
-	_routes_dir(`rest/${version}/${file}`);
+	__temp(`rest/${version}/${file}`);
 
 /**
  * REST API Directory
  */
 export const routesDir = {
-	fts: (file: string) => _routes_dir(`firstTimeSetupRoutes/${file}`),
-	dashRoute: (file: string) => _routes_dir(`dashboard/${file}`),
-	dashApi: (file: string) => _routes_dir(`dashboard/studiocms_api/dashboard/${file}`),
-	errors: (file: string) => _routes_dir(`error-pages/${file}`),
+	fts: (file: string) => __temp(`firstTimeSetupRoutes/${file}`),
+	dashRoute: (file: string) => __temp(`dashboard/${file}`),
+	dashApi: (file: string) => __temp(`dashboard/studiocms_api/dashboard/${file}`),
+	errors: (file: string) => __temp(`error-pages/${file}`),
 	v1Rest: (file: string) => _rest_dir('v1')(file),
-	sdk: (file: string) => _routes_dir(`sdk/${file}`),
-	api: (file: string) => _routes_dir(`api/${file}`),
-	authPage: (file: string) => _routes_dir(`auth/${file}`),
-	authAPI: (file: string) => _routes_dir(`auth/api/${file}`),
-	mailer: (file: string) => _routes_dir(`mailer/${file}`),
+	sdk: (file: string) => __temp(`sdk/${file}`),
+	api: (file: string) => __temp(`api/${file}`),
+	authPage: (file: string) => __temp(`auth/${file}`),
+	authAPI: (file: string) => __temp(`auth/api/${file}`),
+	mailer: (file: string) => __temp(`mailer/${file}`),
 };
 
 /**

--- a/packages/studiocms/src/index.ts
+++ b/packages/studiocms/src/index.ts
@@ -464,25 +464,25 @@ export const studiocms = defineIntegration({
 					if (!dbStartPage) {
 						injectRoute({
 							pattern: sdkRouteResolver('list-pages'),
-							entrypoint: routesDir.sdk('list-pages.js'),
+							entrypoint: routesDir.sdk('list-pages.ts'),
 							prerender: false,
 						});
 
 						injectRoute({
 							pattern: sdkRouteResolver('update-latest-version-cache'),
-							entrypoint: routesDir.sdk('update-latest-version-cache.js'),
+							entrypoint: routesDir.sdk('update-latest-version-cache.ts'),
 							prerender: false,
 						});
 
 						injectRoute({
 							pattern: sdkRouteResolver('fallback-list-pages.json'),
-							entrypoint: routesDir.sdk('fallback-list-pages.json.js'),
+							entrypoint: routesDir.sdk('fallback-list-pages.json.ts'),
 							prerender: false,
 						});
 
 						injectRoute({
 							pattern: sdkRouteResolver('full-changelog.json'),
-							entrypoint: routesDir.sdk('full-changelog.json.js'),
+							entrypoint: routesDir.sdk('full-changelog.json.ts'),
 							prerender: false,
 						});
 
@@ -522,7 +522,7 @@ export const studiocms = defineIntegration({
 							{
 								enabled: dashboardEnabled && !dbStartPage,
 								pattern: 'search-list',
-								entrypoint: routesDir.dashApi('search-list.js'),
+								entrypoint: routesDir.dashApi('search-list.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage,
@@ -532,102 +532,102 @@ export const studiocms = defineIntegration({
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'config',
-								entrypoint: routesDir.dashApi('config.js'),
+								entrypoint: routesDir.dashApi('config.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'profile',
-								entrypoint: routesDir.dashApi('profile.js'),
+								entrypoint: routesDir.dashApi('profile.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'users',
-								entrypoint: routesDir.dashApi('users.js'),
+								entrypoint: routesDir.dashApi('users.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'content/page',
-								entrypoint: routesDir.dashApi('content/page.js'),
+								entrypoint: routesDir.dashApi('content/page.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'content/folder',
-								entrypoint: routesDir.dashApi('content/folder.js'),
+								entrypoint: routesDir.dashApi('content/folder.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'create-reset-link',
-								entrypoint: routesDir.dashApi('create-reset-link.js'),
+								entrypoint: routesDir.dashApi('create-reset-link.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'reset-password',
-								entrypoint: routesDir.dashApi('reset-password.js'),
+								entrypoint: routesDir.dashApi('reset-password.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'plugins/[plugin]',
-								entrypoint: routesDir.dashApi('plugins/[plugin].js'),
+								entrypoint: routesDir.dashApi('plugins/[plugin].ts'),
 							},
 							{
 								enabled: dbStartPage,
 								pattern: 'step-1',
-								entrypoint: routesDir.fts('api/step-1.js'),
+								entrypoint: routesDir.fts('api/step-1.ts'),
 							},
 							{
 								enabled: dbStartPage,
 								pattern: 'step-2',
-								entrypoint: routesDir.fts('api/step-2.js'),
+								entrypoint: routesDir.fts('api/step-2.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'create-user',
-								entrypoint: routesDir.dashApi('create-user.js'),
+								entrypoint: routesDir.dashApi('create-user.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'create-user-invite',
-								entrypoint: routesDir.dashApi('create-user-invite.js'),
+								entrypoint: routesDir.dashApi('create-user-invite.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'api-tokens',
-								entrypoint: routesDir.dashApi('api-tokens.js'),
+								entrypoint: routesDir.dashApi('api-tokens.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'verify-session',
-								entrypoint: routesDir.dashApi('verify-session.js'),
+								entrypoint: routesDir.dashApi('verify-session.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'mailer/config',
-								entrypoint: routesDir.mailer('config.js'),
+								entrypoint: routesDir.mailer('config.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'mailer/test-email',
-								entrypoint: routesDir.mailer('test-email.js'),
+								entrypoint: routesDir.mailer('test-email.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'verify-email',
-								entrypoint: routesDir.dashApi('verify-email.js'),
+								entrypoint: routesDir.dashApi('verify-email.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'email-notification-settings-site',
-								entrypoint: routesDir.dashApi('email-notification-settings-site.js'),
+								entrypoint: routesDir.dashApi('email-notification-settings-site.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'resend-verify-email',
-								entrypoint: routesDir.dashApi('resend-verify-email.js'),
+								entrypoint: routesDir.dashApi('resend-verify-email.ts'),
 							},
 							{
 								enabled: dashboardEnabled && !dbStartPage && authEnabled,
 								pattern: 'update-user-notifications',
-								entrypoint: routesDir.dashApi('update-user-notifications.js'),
+								entrypoint: routesDir.dashApi('update-user-notifications.ts'),
 							},
 						],
 					});
@@ -724,62 +724,62 @@ export const studiocms = defineIntegration({
 						routes: [
 							{
 								pattern: 'login',
-								entrypoint: routesDir.authAPI('login.js'),
+								entrypoint: routesDir.authAPI('login.ts'),
 								enabled: usernameAndPasswordAPI,
 							},
 							{
 								pattern: 'logout',
-								entrypoint: routesDir.authAPI('logout.js'),
+								entrypoint: routesDir.authAPI('logout.ts'),
 								enabled: dashboardEnabled && !options.dbStartPage,
 							},
 							{
 								pattern: 'register',
-								entrypoint: routesDir.authAPI('register.js'),
+								entrypoint: routesDir.authAPI('register.ts'),
 								enabled: usernameAndPasswordAPI && allowUserRegistration,
 							},
 							{
 								pattern: 'github',
-								entrypoint: routesDir.authAPI('github/index.js'),
+								entrypoint: routesDir.authAPI('github/index.ts'),
 								enabled: githubAPI,
 							},
 							{
 								pattern: 'github/callback',
-								entrypoint: routesDir.authAPI('github/callback.js'),
+								entrypoint: routesDir.authAPI('github/callback.ts'),
 								enabled: githubAPI,
 							},
 							{
 								pattern: 'discord',
-								entrypoint: routesDir.authAPI('discord/index.js'),
+								entrypoint: routesDir.authAPI('discord/index.ts'),
 								enabled: discordAPI,
 							},
 							{
 								pattern: 'discord/callback',
-								entrypoint: routesDir.authAPI('discord/callback.js'),
+								entrypoint: routesDir.authAPI('discord/callback.ts'),
 								enabled: discordAPI,
 							},
 							{
 								pattern: 'google',
-								entrypoint: routesDir.authAPI('google/index.js'),
+								entrypoint: routesDir.authAPI('google/index.ts'),
 								enabled: googleAPI,
 							},
 							{
 								pattern: 'google/callback',
-								entrypoint: routesDir.authAPI('google/callback.js'),
+								entrypoint: routesDir.authAPI('google/callback.ts'),
 								enabled: googleAPI,
 							},
 							{
 								pattern: 'auth0',
-								entrypoint: routesDir.authAPI('auth0/index.js'),
+								entrypoint: routesDir.authAPI('auth0/index.ts'),
 								enabled: auth0API,
 							},
 							{
 								pattern: 'auth0/callback',
-								entrypoint: routesDir.authAPI('auth0/callback.js'),
+								entrypoint: routesDir.authAPI('auth0/callback.ts'),
 								enabled: auth0API,
 							},
 							{
 								pattern: 'forgot-password',
-								entrypoint: routesDir.authAPI('forgot-password.js'),
+								entrypoint: routesDir.authAPI('forgot-password.ts'),
 								enabled: usernameAndPasswordAPI,
 							},
 						],
@@ -817,79 +817,79 @@ export const studiocms = defineIntegration({
 						// Folders API Routes
 						injectRoute({
 							pattern: v1RestRoute('folders'),
-							entrypoint: routesDir.v1Rest('folders/index.js'),
+							entrypoint: routesDir.v1Rest('folders/index.ts'),
 							prerender: false,
 						});
 						injectRoute({
 							pattern: v1RestRoute('folders/[id]'),
-							entrypoint: routesDir.v1Rest('folders/[id].js'),
+							entrypoint: routesDir.v1Rest('folders/[id].ts'),
 							prerender: false,
 						});
 
 						// Pages API Routes
 						injectRoute({
 							pattern: v1RestRoute('pages'),
-							entrypoint: routesDir.v1Rest('pages/index.js'),
+							entrypoint: routesDir.v1Rest('pages/index.ts'),
 							prerender: false,
 						});
 						injectRoute({
 							pattern: v1RestRoute('pages/[id]'),
-							entrypoint: routesDir.v1Rest('pages/[id]/index.js'),
+							entrypoint: routesDir.v1Rest('pages/[id]/index.ts'),
 							prerender: false,
 						});
 
 						// Page Diff (History) API Routes
 						injectRoute({
 							pattern: v1RestRoute('pages/[id]/history'),
-							entrypoint: routesDir.v1Rest('pages/[id]/history/index.js'),
+							entrypoint: routesDir.v1Rest('pages/[id]/history/index.ts'),
 							prerender: false,
 						});
 						injectRoute({
 							pattern: v1RestRoute('pages/[id]/history/[diffid]'),
-							entrypoint: routesDir.v1Rest('pages/[id]/history/[diffid].js'),
+							entrypoint: routesDir.v1Rest('pages/[id]/history/[diffid].ts'),
 							prerender: false,
 						});
 
 						// Settings API Routes
 						injectRoute({
 							pattern: v1RestRoute('settings'),
-							entrypoint: routesDir.v1Rest('settings/index.js'),
+							entrypoint: routesDir.v1Rest('settings/index.ts'),
 							prerender: false,
 						});
 
 						// Users API Routes
 						injectRoute({
 							pattern: v1RestRoute('users'),
-							entrypoint: routesDir.v1Rest('users/index.js'),
+							entrypoint: routesDir.v1Rest('users/index.ts'),
 							prerender: false,
 						});
 						injectRoute({
 							pattern: v1RestRoute('users/[id]'),
-							entrypoint: routesDir.v1Rest('users/[id].js'),
+							entrypoint: routesDir.v1Rest('users/[id].ts'),
 							prerender: false,
 						});
 
 						// Public Pages API Routes
 						injectRoute({
 							pattern: v1RestRoute('public/pages'),
-							entrypoint: routesDir.v1Rest('public/pages/index.js'),
+							entrypoint: routesDir.v1Rest('public/pages/index.ts'),
 							prerender: false,
 						});
 						injectRoute({
 							pattern: v1RestRoute('public/pages/[id]'),
-							entrypoint: routesDir.v1Rest('public/pages/[id].js'),
+							entrypoint: routesDir.v1Rest('public/pages/[id].ts'),
 							prerender: false,
 						});
 
 						// Public Folders API Routes
 						injectRoute({
 							pattern: v1RestRoute('public/folders'),
-							entrypoint: routesDir.v1Rest('public/folders/index.js'),
+							entrypoint: routesDir.v1Rest('public/folders/index.ts'),
 							prerender: false,
 						});
 						injectRoute({
 							pattern: v1RestRoute('public/folders/[id]'),
-							entrypoint: routesDir.v1Rest('public/folders/[id].js'),
+							entrypoint: routesDir.v1Rest('public/folders/[id].ts'),
 							prerender: false,
 						});
 					}

--- a/packages/studiocms/src/index.ts
+++ b/packages/studiocms/src/index.ts
@@ -477,7 +477,7 @@ export const studiocms = defineIntegration({
 						injectRoute({
 							pattern: sdkRouteResolver('fallback-list-pages.json'),
 							entrypoint: routesDir.sdk('fallback-list-pages.json.js'),
-							prerender: true,
+							prerender: false,
 						});
 
 						injectRoute({

--- a/packages/studiocms/src/routes/sdk/fallback-list-pages.json.ts
+++ b/packages/studiocms/src/routes/sdk/fallback-list-pages.json.ts
@@ -1,8 +1,6 @@
 import studioCMS_SDK from 'studiocms:sdk/cache';
 import type { APIRoute } from 'astro';
 
-export const prerender = true;
-
 export const GET: APIRoute = async (): Promise<Response> => {
 	const pages = await studioCMS_SDK.GET.pages();
 


### PR DESCRIPTION
This pull request includes several changes to the `studiocms` package to resolve a bundling issue with Astro by moving routes to their TypeScript variants. The changes also include updates to the `package.json` file and removal of unnecessary imports.

### Improvements to routing and bundling:

* Moved various route entry points from JavaScript to TypeScript in `packages/studiocms/src/index.ts` to resolve bundling issues. [[1]](diffhunk://#diff-acb4a7fbcdb98537d3c96596b3f5ba1d778913c6b1d764de60dd9a2c761b4c46L467-R485) [[2]](diffhunk://#diff-acb4a7fbcdb98537d3c96596b3f5ba1d778913c6b1d764de60dd9a2c761b4c46L525-R525) [[3]](diffhunk://#diff-acb4a7fbcdb98537d3c96596b3f5ba1d778913c6b1d764de60dd9a2c761b4c46L535-R630) [[4]](diffhunk://#diff-acb4a7fbcdb98537d3c96596b3f5ba1d778913c6b1d764de60dd9a2c761b4c46L727-R782) [[5]](diffhunk://#diff-acb4a7fbcdb98537d3c96596b3f5ba1d778913c6b1d764de60dd9a2c761b4c46L820-R892)
* Updated `package.json` to include the `src` directory and map new TypeScript routes. [[1]](diffhunk://#diff-2d16107b635fed3f93e32a31b7351ed4af23aa3e9b5de69af9992939bbb41c38L49-R50) [[2]](diffhunk://#diff-2d16107b635fed3f93e32a31b7351ed4af23aa3e9b5de69af9992939bbb41c38L126-R128)

### Codebase cleanup:

* Removed unnecessary import of `createResolver` from `astro-integration-kit` in `packages/studiocms/src/consts.ts`.
* Updated `_routes_dir` function to use direct path strings instead of resolver.

### Configuration:

* Added a changeset file to document the patch changes made to resolve the bundling issue.