### PR TITLE
feat(github): add Renovate configuration and CI workflow for dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "schedule:earlyMondays",
+    ":preserveSemverRanges",
+    "group:allNonMajor",
+    ":disablePeerDependencies",
+    "customManagers:biomeVersions"
+  ],
+  "dependencyDashboard": true,
+  "postUpdateOptions": ["pnpmDedupe"],
+  "ignorePaths": ["**/node_modules/**", "**/bower_components/**"],
+  "labels": ["dependencies"],
+  "additionalBranchPrefix": "{{parentDir}}-",
+  "gitIgnoredAuthors": ["no-reply@studiocms.dev"],
+  "prHourlyLimit": 3,
+  "rangeStrategy": "bump",
+  "updatePinnedDependencies": false,
+  "packageRules": [
+    {
+      "matchDepTypes": ["packageManager", "engines"],
+      "enabled": false
+    },
+    {
+      "matchFileNames": [".node-version"],
+      "enabled": false
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,10 @@
     {
       "matchFileNames": [".node-version"],
       "enabled": false
+    },
+    {
+      "matchDepTypes": ["pnpm.catalog.min"],
+      "enabled": false
     }
   ]
 }

--- a/.github/workflows/ci-renovate.yml
+++ b/.github/workflows/ci-renovate.yml
@@ -1,0 +1,22 @@
+name: Add changeset to Renovate updates
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, labeled]
+    paths:
+      - 'package/**'
+
+jobs:
+  renovate:
+    name: Update Renovate PR
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies')
+
+    steps:
+      - name: Update PR
+        uses: mscharley/dependency-changesets-action@b73462eb4c2cf1fe16a8d9d681932fd05eea5c9f # v1.1.1
+        with:
+          token: ${{ secrets.STUDIOCMS_SERVICE_TOKEN }}
+          use-conventional-commits: true
+          author-name: StudioCMS
+          author-email: no-reply@studiocms.dev


### PR DESCRIPTION
This pull request includes updates to the Renovate configuration and adds a new GitHub workflow for handling Renovate updates. The most important changes are outlined below:

### Renovate Configuration Updates:

* [`.github/renovate.json`](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3R1-R30): Added a new Renovate configuration file with settings for schema, scheduling, dependency management, and package rules.

### GitHub Workflow Additions:

* [`.github/workflows/ci-renovate.yml`](diffhunk://#diff-541e73f76dfc7f14f49d736f365a707a685135abae37b14168a65c8ea8fa3309R1-R22): Introduced a new GitHub workflow to automatically add changesets to Renovate updates, triggered by specific pull request events and paths.