### PR TITLE
Add drizzle-orm to the package filter to prevent auto bumping.

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["node-playground", "build-scripts"]
+  "ignore": ["node-playground", "build-scripts"],
+  "privatePackages": false
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,7 @@
   "prHourlyLimit": 3,
   "rangeStrategy": "bump",
   "updatePinnedDependencies": false,
+  "dependencyDashboardLabels": ["TRACKER"],
   "packageRules": [
     {
       "matchDepTypes": ["packageManager", "engines"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,6 +29,10 @@
     {
       "matchDepTypes": ["pnpm.catalog.min"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["drizzle-orm"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
This pull request includes a small change to the `.github/renovate.json` file. The change disables updates for the `drizzle-orm` package.

* [`.github/renovate.json`](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3R32-R35): Added a configuration to disable updates for the `drizzle-orm` package.

if drizzle-orm gets bumped outside of within an AstroDB update it will break everything