### PR TITLE
fix(auth): update arctic dependency to v3.5.0 and implement code verifier for OAuth2 flows

### DIFF
--- a/.changeset/stale-pillows-tap.md
+++ b/.changeset/stale-pillows-tap.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Update Arctic to v3.5.0 and implement new required code verifier for auth0 and discord

--- a/packages/studiocms/package.json
+++ b/packages/studiocms/package.json
@@ -145,7 +145,7 @@
     "@oslojs/binary": "^1.0.0",
     "@oslojs/crypto": "^1.0.1",
     "@oslojs/encoding": "^1.1.0",
-    "arctic": "^2.3.1",
+    "arctic": "^3.5.0",
     "three": "0.170.0",
     "mrmime": "^2.0.0",
     "unified": "^11.0.5",

--- a/packages/studiocms/src/routes/auth/api/auth0/index.ts
+++ b/packages/studiocms/src/routes/auth/api/auth0/index.ts
@@ -1,16 +1,20 @@
 import { setOAuthSessionTokenCookie } from 'studiocms:auth/lib/session';
-import { generateState } from 'arctic';
+import { generateCodeVerifier, generateState } from 'arctic';
 import type { APIContext, APIRoute } from 'astro';
-import { ProviderCookieName, auth0 } from './shared.js';
+import { ProviderCodeVerifier, ProviderCookieName, auth0 } from './shared.js';
 
 export const GET: APIRoute = async (context: APIContext) => {
 	const state = generateState();
 
+	const codeVerifier = generateCodeVerifier();
+
 	const scopes = ['profile', 'email'];
 
-	const url = auth0.createAuthorizationURL(state, scopes);
+	const url = auth0.createAuthorizationURL(state, codeVerifier, scopes);
 
 	setOAuthSessionTokenCookie(context, ProviderCookieName, state);
+
+	setOAuthSessionTokenCookie(context, ProviderCodeVerifier, codeVerifier);
 
 	return context.redirect(url.toString());
 };

--- a/packages/studiocms/src/routes/auth/api/auth0/shared.ts
+++ b/packages/studiocms/src/routes/auth/api/auth0/shared.ts
@@ -16,6 +16,7 @@ export const getClientDomain = () => {
 
 export const ProviderID = 'auth0';
 export const ProviderCookieName = 'auth0_oauth_state';
+export const ProviderCodeVerifier = 'auth0_oauth_code_verifier';
 
 export const auth0 = new Auth0(getClientDomain(), CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
 

--- a/packages/studiocms/src/routes/auth/api/discord/index.ts
+++ b/packages/studiocms/src/routes/auth/api/discord/index.ts
@@ -1,16 +1,20 @@
 import { setOAuthSessionTokenCookie } from 'studiocms:auth/lib/session';
-import { generateState } from 'arctic';
+import { generateCodeVerifier, generateState } from 'arctic';
 import type { APIContext, APIRoute } from 'astro';
-import { ProviderCookieName, discord } from './shared.js';
+import { ProviderCodeVerifier, ProviderCookieName, discord } from './shared.js';
 
 export const GET: APIRoute = async (context: APIContext) => {
 	const state = generateState();
 
 	const scopes = ['identify', 'email'];
 
-	const url: URL = discord.createAuthorizationURL(state, scopes);
+	const codeVerifier = generateCodeVerifier();
+
+	const url: URL = discord.createAuthorizationURL(state, codeVerifier, scopes);
 
 	setOAuthSessionTokenCookie(context, ProviderCookieName, state);
+
+	setOAuthSessionTokenCookie(context, ProviderCodeVerifier, codeVerifier);
 
 	return context.redirect(url.toString());
 };

--- a/packages/studiocms/src/routes/auth/api/discord/shared.ts
+++ b/packages/studiocms/src/routes/auth/api/discord/shared.ts
@@ -8,6 +8,7 @@ export const {
 
 export const ProviderID = 'discord';
 export const ProviderCookieName = 'discord_oauth_state';
+export const ProviderCodeVerifier = 'discord_oauth_code_verifier';
 
 export const discord = new Discord(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,8 +205,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       arctic:
-        specifier: ^2.3.1
-        version: 2.3.1
+        specifier: ^3.5.0
+        version: 3.5.0
       astro:
         specifier: catalog:min
         version: 5.4.3(@types/node@20.17.10)(jiti@2.4.1)(rollup@4.34.8)(typescript@5.7.2)(yaml@2.7.0)
@@ -1930,8 +1930,8 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  arctic@2.3.1:
-    resolution: {integrity: sha512-bnmPYWbPtrQcneG/dmZIdvDeZ7pYhHqd4hYTbOR5LB9f429XLHiE4VnmKmJCPkw+G2CsG689WS+NDwa5UKsigA==}
+  arctic@3.5.0:
+    resolution: {integrity: sha512-SR2BnMinzA5X4qsMR5wFMqELeKfMKNAThpRJyuPFJpCZIqvAMW0VbVSacycgIBV56XQLCLtUMwdohKEMaR2y1g==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -3050,7 +3050,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   locate-path@5.0.0:
@@ -6154,7 +6153,7 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  arctic@2.3.1:
+  arctic@3.5.0:
     dependencies:
       '@oslojs/crypto': 1.0.1
       '@oslojs/encoding': 1.1.0


### PR DESCRIPTION
This pull request includes updates to the Arctic library and implements a new required code verifier for Auth0 and Discord authentication. The most important changes include updating the Arctic library version, adding the code verifier to the authentication flow, and modifying related files to support this new feature.

### Library Update:
* Updated Arctic library to version 3.5.0 in `packages/studiocms/package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-2d16107b635fed3f93e32a31b7351ed4af23aa3e9b5de69af9992939bbb41c38L148-R148) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL208-R209) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1933-R1934) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3053) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6157-R6156)

### Auth0 Authentication:
* Added `ProviderCodeVerifier` import and usage in `packages/studiocms/src/routes/auth/api/auth0/callback.ts` and `packages/studiocms/src/routes/auth/api/auth0/index.ts` to handle the new code verifier. [[1]](diffhunk://#diff-b77ea2fbb4ccf7f0de8729c699e71529f7fecde653f05f8668a2e8a3060cd7c1R11) [[2]](diffhunk://#diff-b77ea2fbb4ccf7f0de8729c699e71529f7fecde653f05f8668a2e8a3060cd7c1R23-R35) [[3]](diffhunk://#diff-842e1094bf27d02822c661f663eaf4e0d22cbf9ffea74d9f2c90fc12a4504696L2-R18)
* Defined `ProviderCodeVerifier` in `packages/studiocms/src/routes/auth/api/auth0/shared.ts`.

### Discord Authentication:
* Added `ProviderCodeVerifier` import and usage in `packages/studiocms/src/routes/auth/api/discord/callback.ts` and `packages/studiocms/src/routes/auth/api/discord/index.ts` to handle the new code verifier. [[1]](diffhunk://#diff-0fed4d8e307cdefcf971311d329619f32f369fe21c4e5ea0795b8e6d8e3d05baL9-R32) [[2]](diffhunk://#diff-f9c75e30ea73661e9c74b5dfb2fae9d6817432d6531b150e5f54e608f69432a9L2-R18)
* Defined `ProviderCodeVerifier` in `packages/studiocms/src/routes/auth/api/discord/shared.ts`.