### PR TITLE
fix(studiocms): update entrypoints and add light theme font palette for code blocks

### DIFF
--- a/.changeset/crazy-lamps-fly.md
+++ b/.changeset/crazy-lamps-fly.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Fix Missing CSS on DB start pages for the code blocks

--- a/packages/studiocms/src/index.ts
+++ b/packages/studiocms/src/index.ts
@@ -425,22 +425,22 @@ export const studiocms = defineIntegration({
 					const routes: Route[] = [
 						{
 							pattern: 'start',
-							entrypoint: routesDir.sdk('1-start.astro'),
+							entrypoint: routesDir.fts('1-start.astro'),
 							enabled: dbStartPage,
 						},
 						{
 							pattern: 'start/1',
-							entrypoint: routesDir.sdk('1-start.astro'),
+							entrypoint: routesDir.fts('1-start.astro'),
 							enabled: dbStartPage,
 						},
 						{
 							pattern: 'start/2',
-							entrypoint: routesDir.sdk('2-next.astro'),
+							entrypoint: routesDir.fts('2-next.astro'),
 							enabled: dbStartPage,
 						},
 						{
 							pattern: 'done',
-							entrypoint: routesDir.sdk('3-done.astro'),
+							entrypoint: routesDir.fts('3-done.astro'),
 							enabled: dbStartPage,
 						},
 						{

--- a/packages/studiocms/src/styles/dashboard-code.css
+++ b/packages/studiocms/src/styles/dashboard-code.css
@@ -17,11 +17,31 @@
 		8 #9ecbff /* few chars */;
 }
 
+@font-palette-values --github-light {
+	font-family: "Monaspace";
+	override-colors:
+		0 #cf222e /* keywords, {} */, 
+		1 #6e7781 /* comments */, 
+		2 #000d99 /* literals */,
+		3 #000d99 /* numbers */, 
+		4 #6639ba /* functions, [] */, 
+		5 #000000 /* js others */, 
+		6 #d19a66 /* not in use */, 
+		7 #000d99 /* inside quotes, css properties, few chars */, 
+		8 #000d99 /* few chars */;
+}
+
 .custom-code {
 	font-family: "Monaspace", monospace;
 	font-palette: --github-dark;
 	font-size: 14px;
 	line-height: 1.6;
+}
+
+[data-theme="light"] {
+	.custom-code {
+		font-palette: --github-light;
+	}
 }
 
 .code-container {


### PR DESCRIPTION
Adds Light theme CSS for Codeblocks on db start pages

fixes entrypoint from earlier patch

with CSS update: (See 482 for before image)
![image](https://github.com/user-attachments/assets/f415342f-b231-466f-be9f-a4e54956858c)

closes #482 