### PR TITLE
feat(studiocms): refactor SDK and page scripts

### DIFF
--- a/.changeset/few-papers-buy.md
+++ b/.changeset/few-papers-buy.md
@@ -1,0 +1,13 @@
+---
+"studiocms": patch
+---
+
+Refactor SDK and page scripts
+
+- SDK cache is now busted when it should be
+- Content management page sidebar now refreshes
+- You can now hide the default index in the siteConfig on the dashboard
+
+### NOTICE (non-breaking schema update)
+
+- You will need to push the new schema `astro db push --remote`

--- a/packages/studiocms/src/components/dashboard/configuration/ConfigForm.astro
+++ b/packages/studiocms/src/components/dashboard/configuration/ConfigForm.astro
@@ -75,7 +75,7 @@ const t = useTranslations(lang, '@studiocms/dashboard:configuration');
 
         <div class="form-row">
             <Select label={t('select-smtp-mailer')} name="enable-mailer" defaultValue={`${data.enableMailer}`} options={[{ label: 'Enabled', value: 'true' }, { label: 'Disabled', value: 'false' }]} fullWidth />
-            <div> {/* PLACEHOLDER */} </div>
+            <Select label={t('select-hide-default-index')} name="hide-default-index" defaultValue={`${data.hideDefaultIndex}`} options={[{ label: 'Enabled', value: 'true' }, { label: 'Disabled', value: 'false' }]} fullWidth />
         </div>
 
         <Divider />
@@ -148,6 +148,7 @@ const t = useTranslations(lang, '@studiocms/dashboard:configuration');
         updateSelectElmLabel('login-page-background', comp['select-login-page-bg']);
         updateSelectElmLabel('diff-enabled', comp['select-page-diff-tracking']);
         updateSelectElmLabel('enable-mailer', comp['select-smtp-mailer']);
+        updateSelectElmLabel('hide-default-index', comp['select-hide-default-index'])
     });
     
     if (!customElements.get('t-config-form')) {
@@ -191,6 +192,7 @@ const t = useTranslations(lang, '@studiocms/dashboard:configuration');
                 diffPerPage: parseInt(formData.get('diff-per-page') as string),
                 gridItems: enabledGridItems,
                 enableMailer: formData.get('enable-mailer') === 'true',
+                hideDefaultIndex: formData.get('hide-default-index') === 'true'
             }
 
             console.log(data);

--- a/packages/studiocms/src/components/dashboard/content-mgmt/CreateFolder.astro
+++ b/packages/studiocms/src/components/dashboard/content-mgmt/CreateFolder.astro
@@ -12,7 +12,7 @@ const { lang } = Astro.props;
 
 const t = useTranslations(lang, '@studiocms/dashboard:content-folder');
 ---
-<div id="create-folder-container">
+<div id="create-folder-container" data-content-management-url={StudioCMSRoutes.mainLinks.contentManagement}>
 
     <form id="create-folder-form" action={StudioCMSRoutes.endpointLinks.content.folder}>
     
@@ -46,6 +46,9 @@ const t = useTranslations(lang, '@studiocms/dashboard:content-folder');
 import { toast } from "studiocms:ui/components";
 
     const form = document.getElementById('create-folder-form') as HTMLFormElement;
+    const createContainer = document.getElementById('create-folder-container') as HTMLDivElement;
+
+    const { contentManagementUrl } = createContainer.dataset;
 
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
@@ -97,6 +100,7 @@ import { toast } from "studiocms:ui/components";
                 description: res.message,
                 type: 'success'
             })
+            if (contentManagementUrl) window.location.href = contentManagementUrl;
             return;
         }
     });

--- a/packages/studiocms/src/components/dashboard/content-mgmt/CreatePage.astro
+++ b/packages/studiocms/src/components/dashboard/content-mgmt/CreatePage.astro
@@ -46,7 +46,7 @@ const { lang } = Astro.props;
 
 const t = useTranslations(lang, '@studiocms/dashboard:content-page');
 ---
-<div id="create-page-container">
+<div id="create-page-container" data-content-management-url={StudioCMSRoutes.mainLinks.contentManagement}>
     <form id="page-create-form" action={StudioCMSRoutes.endpointLinks.content.page}>
 
       <Tabs variant={'starlight'}>
@@ -226,11 +226,9 @@ const t = useTranslations(lang, '@studiocms/dashboard:content-page');
 import { toast } from "studiocms:ui/components";
     // get the elements
     const createPageForm = document.getElementById('page-create-form') as HTMLFormElement;
+    const createContainer = document.getElementById('create-page-container') as HTMLDivElement;
 
-    function getParentFolderValue(value?: string) {
-      if (value === 'null') return null;
-      return value;
-    }
+    const { contentManagementUrl } = createContainer.dataset;
 
     const draftButton = document.getElementById('draft-button') as HTMLElement;
     const publishButton = document.getElementById('publish-button') as HTMLElement;
@@ -269,6 +267,7 @@ import { toast } from "studiocms:ui/components";
               description: res.message,
               type: 'success'
           })
+          if (contentManagementUrl) window.location.href = contentManagementUrl;
           return;
       }
       })
@@ -276,26 +275,6 @@ import { toast } from "studiocms:ui/components";
     publishButton.addEventListener('click', async (e) => {
       e.preventDefault();
       const formData = new FormData(createPageForm);
-
-      const data = {
-        title: formData.get('page-title')?.toString(),
-        slug: formData.get('page-slug')?.toString(),
-        description: formData.get('page-description')?.toString(),
-        type: formData.get('page-type')?.toString(),
-        showInNav: formData.get('show-in-nav')?.toString() === 'true',
-        heroImage: formData.get('page-hero-image')?.toString(),
-        parentFolder: getParentFolderValue(formData.get('parent-folder')?.toString()),
-        showAuthor: formData.get('show-author')?.toString() === 'true',
-        showContributors: formData.get('show-contributors')?.toString() === 'true',
-        categories: [],
-        tags: [],
-        draft: false,
-      };
-
-      const content = {
-        id: crypto.randomUUID(),
-        content: formData.get('page-content')?.toString(),
-      }
 
       const response = await fetch(createPageForm.action, {
           method: 'POST',
@@ -319,6 +298,7 @@ import { toast } from "studiocms:ui/components";
               description: res.message,
               type: 'success'
           })
+          if (contentManagementUrl) window.location.href = contentManagementUrl;
           return;
       }
       })

--- a/packages/studiocms/src/components/dashboard/content-mgmt/EditFolder.astro
+++ b/packages/studiocms/src/components/dashboard/content-mgmt/EditFolder.astro
@@ -21,7 +21,7 @@ const { lang } = Astro.props;
 
 const t = useTranslations(lang, '@studiocms/dashboard:content-folder');
 ---
-<div id="edit-folder-container">
+<div id="edit-folder-container" data-content-management-url={StudioCMSRoutes.mainLinks.contentManagement}>
 
     <form id="edit-folder-form" action={StudioCMSRoutes.endpointLinks.content.folder}>
 
@@ -68,6 +68,9 @@ const t = useTranslations(lang, '@studiocms/dashboard:content-folder');
 import { toast } from "studiocms:ui/components";
 
     const form = document.getElementById('edit-folder-form') as HTMLFormElement;
+    const createContainer = document.getElementById('edit-folder-container') as HTMLDivElement;
+
+    const { contentManagementUrl } = createContainer.dataset;
 
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
@@ -110,6 +113,7 @@ import { toast } from "studiocms:ui/components";
                 description: res.error,
                 type: 'danger'
             })
+            return;
         }
 
         if (response.status === 200) {
@@ -118,6 +122,8 @@ import { toast } from "studiocms:ui/components";
                 description: res.message,
                 type: 'success'
             })
+            if (contentManagementUrl) window.location.href = contentManagementUrl;
+            return;
         }
     });
 </script>

--- a/packages/studiocms/src/components/dashboard/content-mgmt/EditPage.astro
+++ b/packages/studiocms/src/components/dashboard/content-mgmt/EditPage.astro
@@ -73,7 +73,7 @@ const { lang } = Astro.props;
 
 const t = useTranslations(lang, '@studiocms/dashboard:content-page');
 ---
-<div id="edit-page-container">
+<div id="edit-page-container" data-content-management-url={StudioCMSRoutes.mainLinks.contentManagement}>
     <form id="edit-page-form" action={StudioCMSRoutes.endpointLinks.content.page}>
 
         <Tabs variant={'starlight'}>
@@ -299,6 +299,9 @@ import { toast } from "studiocms:ui/components";
 
 // get the elements
 const editPageForm = document.getElementById('edit-page-form') as HTMLFormElement;
+    const createContainer = document.getElementById('edit-page-container') as HTMLDivElement;
+
+    const { contentManagementUrl } = createContainer.dataset;
 
 editPageForm.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -326,6 +329,7 @@ editPageForm.addEventListener('submit', async (e) => {
             description: res.message,
             type: 'success'
         })
+        if (contentManagementUrl) window.location.href = contentManagementUrl;
         return;
     }
 });

--- a/packages/studiocms/src/components/dashboard/content-mgmt/PageList.astro
+++ b/packages/studiocms/src/components/dashboard/content-mgmt/PageList.astro
@@ -1,6 +1,12 @@
 ---
+import studioCMS_SDK_Cache from 'studiocms:sdk/cache';
 import TreeRenderer from './TreeRenderer.astro';
-import { PageFolderTree } from './shared.js';
+
+const config = await studioCMS_SDK_Cache.GET.siteConfig();
+
+const hideDefaults = config.data.hideDefaultIndex;
+
+const { data: PageFolderTree } = await studioCMS_SDK_Cache.GET.pageFolderTree(true, hideDefaults);
 
 interface Props {
 	isNewFolder?: boolean;

--- a/packages/studiocms/src/components/dashboard/content-mgmt/shared.ts
+++ b/packages/studiocms/src/components/dashboard/content-mgmt/shared.ts
@@ -8,8 +8,6 @@ interface PluginListItem {
 
 const { data: folderList } = await studioCMS_SDK_Cache.GET.folderList();
 
-export const { data: PageFolderTree } = await studioCMS_SDK_Cache.GET.pageFolderTree(true);
-
 export const parentFolders = folderList.map(({ id: value, name: label }) => ({ value, label }));
 
 // EXPORTS

--- a/packages/studiocms/src/db/tables.ts
+++ b/packages/studiocms/src/db/tables.ts
@@ -160,6 +160,7 @@ export const StudioCMSSiteConfig = defineTable({
 		diffPerPage: column.number({ default: 10 }),
 		gridItems: column.json({ default: [] }),
 		enableMailer: column.boolean({ default: false }),
+		hideDefaultIndex: column.boolean({ default: false }),
 	},
 });
 

--- a/packages/studiocms/src/lib/i18n/translations/en-us.json
+++ b/packages/studiocms/src/lib/i18n/translations/en-us.json
@@ -123,7 +123,8 @@
       "input-custom-login-page": "Login Page Background Image (Custom)",
       "select-page-diff-tracking": "Page Diff Tracking",
       "select-login-page-bg": "Login Page Background Image",
-      "select-smtp-mailer": "SMTP Mailer"
+      "select-smtp-mailer": "SMTP Mailer",
+      "select-hide-default-index": "Hide Index Page from dashboard"
     },
     "@studiocms/dashboard:smtp": {
       "title": "SMTP Configuration",

--- a/packages/studiocms/src/sdk/core.ts
+++ b/packages/studiocms/src/sdk/core.ts
@@ -1158,7 +1158,11 @@ export function studiocmsSDKCore() {
 			 * @returns A promise that resolves to an array of combined page data.
 			 * @throws {StudioCMS_SDK_Error} If an error occurs while getting the pages.
 			 */
-			pages: async (includeDrafts = false, tree?: FolderNode[]): Promise<CombinedPageData[]> => {
+			pages: async (
+				includeDrafts = false,
+				hideDefaultIndex = false,
+				tree?: FolderNode[]
+			): Promise<CombinedPageData[]> => {
 				try {
 					const pages: CombinedPageData[] = [];
 
@@ -1166,6 +1170,10 @@ export function studiocmsSDKCore() {
 
 					if (!includeDrafts) {
 						pagesRaw = pagesRaw.filter(({ draft }) => draft === false || draft === null);
+					}
+
+					if (hideDefaultIndex) {
+						pagesRaw = pagesRaw.filter(({ slug }) => slug !== 'index');
 					}
 
 					const folders = tree || (await buildFolderTree());


### PR DESCRIPTION
Refactor SDK and page scripts

- SDK cache is now busted when it should be
- Content management page sidebar now refreshes
- You can now hide the default index in the siteConfig on the dashboard

### NOTICE (non-breaking schema update)

- You will need to push the new schema `astro db push --remote`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new dashboard option that lets users hide the default index page for a cleaner view.
- **Refactor**
  - Enhanced folder and page management: successful submissions now automatically redirect you to the content management area.
  - Improved the sidebar refresh on the content management page for a smoother experience.
- **Chores**
  - Updated the database schema to support the new configuration options; please ensure you apply the necessary updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->