### PR TITLE
feat(buildkit): add support for additional image file types in asset handling

### DIFF
--- a/.changeset/big-toys-brake.md
+++ b/.changeset/big-toys-brake.md
@@ -1,0 +1,5 @@
+---
+"@withstudiocms/buildkit": patch
+---
+
+add support for additional image file types in asset handling and add README

--- a/packages/withstudiocms_buildkit/README.md
+++ b/packages/withstudiocms_buildkit/README.md
@@ -1,0 +1,67 @@
+# `@withstudiocms/buildkit`
+
+This is a esbuild based CLI kit for building Astro Integrations
+
+## Usage
+
+### Installation
+
+Install the package in the root of the repo:
+
+1. Install the required dependencies
+
+```bash
+pnpm add @withstudiocms/buildkit
+```
+
+```bash
+npm install @withstudiocms/buildkit
+```
+
+```bash
+yarn add @withstudiocms/buildkit
+```
+
+### Usage
+
+Once you install the buildkit package you now have access to a `buildkit` CLI utility, add the following to your integration scripts:
+
+```json
+{
+  "scripts": {
+    "build": "buildkit build 'src/**/*.{ts,astro,css}'",
+    "dev": "buildkit dev 'src/**/*.{ts,astro,css}'"
+  }
+}
+```
+
+The command pattern is `buildkit <command> 'path/to/file or glob/**/**.{ts}' [flags]`
+
+#### Available Flags
+
+- `--no-clean-dist`: Do not clean the dist output during build.
+- `--bundle`: Enable bundling
+- `--force-cjs`: Force CJS output
+- `--build-tsconfig`: Allows you to have a normal dev tsconfig (`tsconfig.json`) and a `tsconfig.build.json` for build time.
+
+#### Files considered Assets
+
+The following file extensions will be copied from their src to their respective outputs and not transformed as if they are static assets.
+
+- `.astro`
+- `.d.ts`
+- `.json`
+- `.gif`
+- `.jpeg`
+- `.jpg`
+- `.png`
+- `.tiff`
+- `.webp`
+- `.avif`
+- `.svg`
+
+For other content types and how to use them see [The esBuild Docs](https://esbuild.github.io/content-types/)
+
+## Licensing
+
+[MIT Licensed](https://github.com/withstudiocms/cachedfetch/blob/main/LICENSE).

--- a/packages/withstudiocms_buildkit/README.md
+++ b/packages/withstudiocms_buildkit/README.md
@@ -40,8 +40,8 @@ The command pattern is `buildkit <command> 'path/to/file or glob/**/**.{ts}' [fl
 #### Available Flags
 
 - `--no-clean-dist`: Do not clean the dist output during build.
-- `--bundle`: Enable bundling
-- `--force-cjs`: Force CJS output
+- `--bundle`: Enable bundling.
+- `--force-cjs`: Force CJS output.
 - `--build-tsconfig`: Allows you to have a normal dev tsconfig (`tsconfig.json`) and a `tsconfig.build.json` for build time.
 
 #### Files considered Assets

--- a/packages/withstudiocms_buildkit/README.md
+++ b/packages/withstudiocms_buildkit/README.md
@@ -1,6 +1,6 @@
 # `@withstudiocms/buildkit`
 
-This is a esbuild based CLI kit for building Astro Integrations
+This is an esbuild based CLI kit for building Astro Integrations
 
 ## Usage
 

--- a/packages/withstudiocms_buildkit/README.md
+++ b/packages/withstudiocms_buildkit/README.md
@@ -64,4 +64,5 @@ For other content types and how to use them see [The esBuild Docs](https://esbui
 
 ## Licensing
 
-[MIT Licensed](https://github.com/withstudiocms/cachedfetch/blob/main/LICENSE).
+-[MIT Licensed](https://github.com/withstudiocms/cachedfetch/blob/main/LICENSE).
++[MIT Licensed](https://github.com/withstudiocms/studiocms/blob/main/LICENSE).

--- a/packages/withstudiocms_buildkit/cmd/build.js
+++ b/packages/withstudiocms_buildkit/cmd/build.js
@@ -16,7 +16,14 @@ const defaultConfig = {
 		'.astro': 'copy',
 		'.d.ts': 'copy',
 		'.json': 'copy',
+		'.gif': 'copy',
+		'.jpeg': 'copy',
+		'.jpg': 'copy',
 		'.png': 'copy',
+		'.tiff': 'copy',
+		'.webp': 'copy',
+		'.avif': 'copy',
+		'.svg': 'copy',
 	},
 };
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes # <!-- If aplicable add an issue number to this PR so it can be closed otherwise feel free to remove this. -->
- What does this PR change? Give us a brief description.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced asset handling during builds with support for additional image file types, including `.gif`, `.jpeg`, `.jpg`, `.tiff`, `.webp`, `.avif`, and `.svg`.

- **Documentation**
	- Added comprehensive README for the `@withstudiocms/buildkit` package, including installation instructions, usage guidance, command options, and asset processing details for a smoother integration experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->