### PR TITLE
fix(buildkit): update help command to show correct command name

### DIFF
--- a/.changeset/hungry-eels-jog.md
+++ b/.changeset/hungry-eels-jog.md
@@ -1,0 +1,5 @@
+---
+"@withstudiocms/buildkit": patch
+---
+
+fix buildkit help: Show correct command name

--- a/packages/withstudiocms_buildkit/index.js
+++ b/packages/withstudiocms_buildkit/index.js
@@ -163,7 +163,7 @@ function showHelp() {
 ${green('StudioCMS Buildkit')} - Build tool for StudioCMS packages
 
 ${yellow('Usage:')}
-  withstudiocms-buildkit <command> [...files] [...options]
+  buildkit <command> [...files] [...options]
 
 ${yellow('Commands:')}
   dev     Watch files and rebuild on changes
@@ -178,9 +178,9 @@ ${yellow('Options:')}
   --outdir=<path>   Specify output directory (default: dist)
 
 ${yellow('Examples:')}
-  withstudiocms-buildkit build "src/**/*.ts"
-  withstudiocms-buildkit dev "src/**/*.ts" --no-clean-dist
-  withstudiocms-buildkit build "src/**/*.ts" --bundle --force-cjs
+  buildkit build "src/**/*.ts"
+  buildkit dev "src/**/*.ts" --no-clean-dist
+  buildkit build "src/**/*.ts" --bundle --force-cjs
 `);
 }
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes # <!-- If aplicable add an issue number to this PR so it can be closed otherwise feel free to remove this. -->
- What does this PR change? Give us a brief description.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the help output to display the simplified command "buildkit" for clearer usage.
  - Revised command examples in the help text to reflect the new, user-friendly command-line interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->