### PR TITLE
feat(cli) Implement new JWT functionality

### DIFF
--- a/.changeset/afraid-toys-itch.md
+++ b/.changeset/afraid-toys-itch.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Implement new CLI functionality to generate JWT tokens usable for custom sqld servers

--- a/.github/workflows/ci-renovate.yml
+++ b/.github/workflows/ci-renovate.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, labeled]
     paths:
-      - 'package/**'
+      - 'packages/**'
 
 jobs:
   renovate:

--- a/packages/studiocms/src/cli/cmds/crypto.ts
+++ b/packages/studiocms/src/cli/cmds/crypto.ts
@@ -9,8 +9,9 @@ import {
 	StudioCMSColorwayInfoBg,
 	boxen,
 	label,
-} from '../lib/utils';
-import { generator } from './crypto/generator';
+} from '../lib/utils.js';
+import { OneYear } from './crypto/consts.js';
+import { generator } from './crypto/generator.js';
 
 const program = new Command('crypto')
 	.description('Crypto Utilities for Security')
@@ -24,7 +25,10 @@ const program = new Command('crypto')
 
 program
 	.command('gen-jwt')
-	.argument('<key-file>', 'Path your your private key file (.pem)')
+	.argument(
+		'<key-file>',
+		'a relative path (`../keys/libsql.pem`) from the current directory your your private key file (.pem)'
+	)
 	.description('Generate a JWT token from a keyfile')
 	.summary('Generate JWT token from a keyfile')
 	.option('-c, --claim <claim...>', 'claim in the form [key=value]')
@@ -48,7 +52,7 @@ program
 
 			spinner.message('Key Found. Getting Expire Date.');
 
-			const exp: number = maybeExp ? Number.parseInt(maybeExp) : 31556926;
+			const exp: number = maybeExp ? Number.parseInt(maybeExp) : OneYear;
 
 			spinner.message('Expire Date set.  Generating Token.');
 

--- a/packages/studiocms/src/cli/cmds/crypto.ts
+++ b/packages/studiocms/src/cli/cmds/crypto.ts
@@ -32,7 +32,7 @@ program
 	.description('Generate a JWT token from a keyfile')
 	.summary('Generate JWT token from a keyfile')
 	.option('-c, --claim <claim...>', 'claim in the form [key=value]')
-	.option('-e, --exp <date-in-seconds>', 'expiry date in seconds from issued at (iat) time')
+	.option('-e, --exp <date-in-seconds>', 'Expiry date in seconds (>=0) from issued at (iat) time')
 	.action(async (keyFile, { claim, exp: maybeExp }) => {
 		prompts.intro(label('StudioCMS Crypto: Generate JWT', StudioCMSColorwayBg, chalk.bold));
 

--- a/packages/studiocms/src/cli/cmds/crypto.ts
+++ b/packages/studiocms/src/cli/cmds/crypto.ts
@@ -91,7 +91,7 @@ program
 
 			if (!safeToken) {
 				spinner.stop(
-					'Token generation failed. This could be due to invalid key format or claim structure.'
+					'Token generation failed. Please check the key file, claim structure, and parameters.'
 				);
 				process.exit(1);
 			}

--- a/packages/studiocms/src/cli/cmds/crypto.ts
+++ b/packages/studiocms/src/cli/cmds/crypto.ts
@@ -27,7 +27,7 @@ program
 	.command('gen-jwt')
 	.argument(
 		'<key-file>',
-		'a relative path (`../keys/libsql.pem`) from the current directory your your private key file (.pem)'
+		'a relative path (`../keys/libsql.pem`) from the current directory to your private key file (.pem)'
 	)
 	.description('Generate a JWT token from a keyfile')
 	.summary('Generate JWT token from a keyfile')

--- a/packages/studiocms/src/cli/cmds/crypto.ts
+++ b/packages/studiocms/src/cli/cmds/crypto.ts
@@ -3,6 +3,7 @@ import * as prompts from '@clack/prompts';
 import { Command, Option } from '@commander-js/extra-typings';
 import chalk from 'chalk';
 import {
+	CLITitle,
 	StudioCMSColorway,
 	StudioCMSColorwayBg,
 	StudioCMSColorwayInfoBg,
@@ -13,7 +14,13 @@ import { generator } from './crypto/generator';
 
 const program = new Command('crypto')
 	.description('Crypto Utilities for Security')
-	.summary('Crypto Utilities for Security');
+	.summary('Crypto Utilities for Security')
+	.addHelpText('beforeAll', CLITitle)
+	.showHelpAfterError('(add --help for additional information)')
+	.helpOption('-h, --help', 'Display help for command.')
+	.action(function () {
+		this.help();
+	});
 
 program
 	.command('gen-jwt')

--- a/packages/studiocms/src/cli/cmds/crypto.ts
+++ b/packages/studiocms/src/cli/cmds/crypto.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import * as prompts from '@clack/prompts';
-import { Command, Option } from '@commander-js/extra-typings';
+import { Command } from '@commander-js/extra-typings';
 import chalk from 'chalk';
 import {
 	CLITitle,
@@ -30,7 +30,7 @@ program
 	.option('-c, --claim <claim...>', 'claim in the form [key=value]')
 	.option('-e, --exp <date-in-seconds>', 'expiry date in seconds from issued at (iat) time')
 	.action(async (keyFile, { claim, exp: maybeExp }) => {
-		prompts.intro(label('StudioCMS Crypto: Generate JWT', StudioCMSColorwayBg, chalk.black));
+		prompts.intro(label('StudioCMS Crypto: Generate JWT', StudioCMSColorwayBg, chalk.bold));
 
 		const spinner = prompts.spinner();
 

--- a/packages/studiocms/src/cli/cmds/crypto.ts
+++ b/packages/studiocms/src/cli/cmds/crypto.ts
@@ -27,7 +27,7 @@ program
 	.command('gen-jwt')
 	.argument(
 		'<key-file>',
-		'a relative path (`../keys/libsql.pem`) from the current directory to your private key file (.pem)'
+		'a relative path (e.g., `../keys/libsql.pem`) from the current directory to your private key file (.pem)'
 	)
 	.description('Generate a JWT token from a keyfile')
 	.summary('Generate JWT token from a keyfile')
@@ -52,7 +52,12 @@ program
 
 			spinner.message('Key Found. Getting Expire Date.');
 
-			const exp: number = maybeExp ? Number.parseInt(maybeExp) : OneYear;
+			const exp = maybeExp ? Number.parseInt(maybeExp) : OneYear;
+
+			if (exp < 0) {
+				spinner.stop('Expiration must be greater than 0');
+				process.exit(1);
+			}
 
 			spinner.message('Expire Date set.  Generating Token.');
 

--- a/packages/studiocms/src/cli/cmds/crypto.ts
+++ b/packages/studiocms/src/cli/cmds/crypto.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import * as prompts from '@clack/prompts';
+import { Command, Option } from '@commander-js/extra-typings';
+import chalk from 'chalk';
+import {
+	StudioCMSColorway,
+	StudioCMSColorwayBg,
+	StudioCMSColorwayInfoBg,
+	boxen,
+	label,
+} from '../lib/utils';
+import { generator } from './crypto/generator';
+
+const program = new Command('crypto')
+	.description('Crypto Utilities for Security')
+	.summary('Crypto Utilities for Security');
+
+program
+	.command('gen-jwt')
+	.argument('<key-file>', 'Path your your private key file (.pem)')
+	.description('Generate a JWT token from a keyfile')
+	.summary('Generate JWT token from a keyfile')
+	.option('-c, --claim <claim...>', 'claim in the form [key=value]')
+	.option('-e, --exp <date-in-seconds>', 'expiry date in seconds from issued at (iat) time')
+	.action(async (keyFile, { claim, exp: maybeExp }) => {
+		prompts.intro(label('StudioCMS Crypto: Generate JWT', StudioCMSColorwayBg, chalk.black));
+
+		const spinner = prompts.spinner();
+
+		try {
+			spinner.start('Getting Key from keyFile');
+
+			const keyFilePath = new URL(keyFile, process.cwd());
+
+			const keyString = fs.readFileSync(keyFilePath, 'utf8').split(/\r?\n/).join('\\n');
+
+			if (!keyString) {
+				spinner.stop('Key not found, or invalid');
+				process.exit(1);
+			}
+
+			spinner.message('Key Found. Getting Expire Date.');
+
+			const exp: number = maybeExp ? Number.parseInt(maybeExp) : 31556926;
+
+			spinner.message('Expire Date set.  Generating Token.');
+
+			const safeToken = generator(keyString, claim, exp);
+
+			if (!safeToken) {
+				spinner.stop('Unable to generate token, please check logs and try again.');
+				process.exit(1);
+			}
+
+			spinner.stop('Token Generated.');
+
+			prompts.log.success(
+				boxen(chalk.bold(`${label('Token Generated!', StudioCMSColorwayInfoBg, chalk.bold)}`), {
+					ln2: 'Your new Token has been generated successfully:',
+					ln3: chalk.magenta(safeToken),
+				})
+			);
+
+			prompts.outro(
+				`${label('You can now use this token where needed.', StudioCMSColorwayBg, chalk.bold)} Stuck? Join us on Discord at ${StudioCMSColorway.bold.underline('https://chat.studiocms.dev')}`
+			);
+		} catch (err) {
+			prompts.log.error(`There was an Error generating your JWT: ${(err as Error).message}`);
+			process.exit(1);
+		}
+	});
+
+await program.parseAsync();

--- a/packages/studiocms/src/cli/cmds/crypto.ts
+++ b/packages/studiocms/src/cli/cmds/crypto.ts
@@ -54,6 +54,11 @@ program
 
 			const exp = maybeExp ? Number.parseInt(maybeExp) : OneYear;
 
+			if (Number.isNaN(exp)) {
+				spinner.stop('Expiration must be a valid number');
+				process.exit(1);
+			}
+
 			if (exp < 0) {
 				spinner.stop('Expiration must be greater than 0');
 				process.exit(1);

--- a/packages/studiocms/src/cli/cmds/crypto/builder.ts
+++ b/packages/studiocms/src/cli/cmds/crypto/builder.ts
@@ -1,3 +1,36 @@
+/* 
+    Based on `jwt-builder` by Vandium-io
+    
+    Builds JSON Web Token (JWT) programatically
+
+Copyright (c) 2016, Vandium Software Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Vandium Software Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+*/
+
 import fs from 'node:fs';
 import jwt from './jwt.js';
 

--- a/packages/studiocms/src/cli/cmds/crypto/builder.ts
+++ b/packages/studiocms/src/cli/cmds/crypto/builder.ts
@@ -1,0 +1,270 @@
+import fs from 'node:fs';
+import jwt from './jwt.js';
+
+// Algorithm types
+type Algorithm = 'HS256' | 'HS384' | 'HS512' | 'RS256';
+
+const ALGORITHM_HS256: Algorithm = 'HS256';
+const ALGORITHM_HS384: Algorithm = 'HS384';
+const ALGORITHM_HS512: Algorithm = 'HS512';
+const ALGORITHM_RS256: Algorithm = 'RS256';
+
+const JAN_1_2016 = 1451606400;
+
+// JWT Claims interface
+interface JWTClaims {
+	[key: string]: string | number | boolean | object;
+}
+
+// JWT Headers interface
+interface JWTHeaders {
+	[key: string]: string | number | boolean | object;
+}
+
+// Configuration interface
+interface JWTConfig {
+	algorithm?: Algorithm;
+	secret?: string;
+	privateKey?: string | Buffer;
+	exp?: number;
+	iat?: number | boolean;
+	nbf?: number | boolean;
+	headers?: JWTHeaders;
+	[key: string]: string | number | boolean | object | undefined;
+}
+
+// Time offset result interface
+interface TimeOffset {
+	value: number;
+	relative: boolean;
+}
+
+function nowInSeconds(): number {
+	return Math.floor(Date.now() / 1000);
+}
+
+function offsetTimeValue(value?: number): TimeOffset {
+	let relative: boolean;
+
+	if (value === undefined) {
+		value = 0;
+		relative = true;
+	} else {
+		value = Math.floor(value);
+		relative = value < JAN_1_2016;
+	}
+
+	return {
+		value: value,
+		relative: relative,
+	};
+}
+
+function addClaimTimeValue(
+	claims: JWTClaims,
+	name: string,
+	value: number | undefined,
+	relative: boolean
+): void {
+	if (value !== undefined) {
+		if (relative) {
+			value += nowInSeconds();
+		}
+
+		claims[name] = value;
+	}
+}
+
+function setFromConfig(builder: JWTTokenBuilder, config?: JWTConfig): void {
+	if (!config) {
+		return;
+	}
+
+	const claims: JWTClaims = {};
+
+	// biome-ignore lint/complexity/noForEach: <explanation>
+	Object.keys(config).forEach((key) => {
+		const value = config[key];
+
+		switch (key) {
+			case 'algorithm':
+				if (typeof value === 'string') {
+					builder.algorithm(value as Algorithm);
+				}
+				break;
+			case 'secret':
+				if (typeof value === 'string') {
+					builder.secret(value);
+				}
+				break;
+			case 'privateKey':
+				if (typeof value === 'string' || Buffer.isBuffer(value)) {
+					builder.privateKey(value);
+				}
+				break;
+			case 'exp':
+				if (typeof value === 'number') {
+					builder.exp(value);
+				}
+				break;
+			case 'iat':
+				if (value === true) {
+					builder.iat();
+				} else if (value !== false && typeof value === 'number') {
+					builder.iat(value);
+				}
+				break;
+			case 'nbf':
+				if (value === true) {
+					builder.nbf();
+				} else if (value !== false && typeof value === 'number') {
+					builder.nbf(value);
+				}
+				break;
+			case 'headers':
+				if (typeof value === 'object' && value !== null) {
+					builder.headers(value as JWTHeaders);
+				}
+				break;
+			default:
+				claims[key] = value as string | number | boolean | object;
+				break;
+		}
+	});
+
+	builder.claims(claims);
+}
+
+class JWTTokenBuilder {
+	private _algorithm: Algorithm;
+	private _claims: JWTClaims;
+	private _headers?: JWTHeaders;
+	private _secret?: string;
+	private _key?: string | Buffer;
+	private _iat?: number;
+	private _iat_relative?: boolean;
+	private _nbf?: number;
+	private _nbf_relative?: boolean;
+	private _exp?: number;
+
+	constructor(config?: JWTConfig) {
+		this._algorithm = ALGORITHM_HS256;
+		this._claims = {};
+
+		setFromConfig(this, config);
+	}
+
+	claims(userClaims: JWTClaims): JWTTokenBuilder {
+		this._claims = Object.assign({}, userClaims);
+
+		return this;
+	}
+
+	headers(userHeaders: JWTHeaders): JWTTokenBuilder {
+		this._headers = Object.assign({}, userHeaders);
+
+		return this;
+	}
+
+	algorithm(alg: Algorithm): JWTTokenBuilder {
+		switch (alg) {
+			case ALGORITHM_HS256:
+			case ALGORITHM_HS384:
+			case ALGORITHM_HS512:
+			case ALGORITHM_RS256:
+				this._algorithm = alg;
+				break;
+
+			default:
+				throw new Error(`unknown algorithm: ${alg}`);
+		}
+
+		return this;
+	}
+
+	secret(sec: string): JWTTokenBuilder {
+		this._secret = sec;
+
+		return this;
+	}
+
+	privateKey(key: string | Buffer): JWTTokenBuilder {
+		this._key = key;
+
+		return this;
+	}
+
+	privateKeyFromFile(filePath: string): JWTTokenBuilder {
+		return this.privateKey(fs.readFileSync(filePath));
+	}
+
+	iat(value?: number): JWTTokenBuilder {
+		const result = offsetTimeValue(value);
+
+		this._iat = result.value;
+		this._iat_relative = result.relative;
+
+		return this;
+	}
+
+	nbf(value?: number): JWTTokenBuilder {
+		const result = offsetTimeValue(value);
+
+		this._nbf = result.value;
+		this._nbf_relative = result.relative;
+
+		return this;
+	}
+
+	exp(value: number): JWTTokenBuilder {
+		this._exp = Math.floor(value);
+
+		return this;
+	}
+
+	build(): string {
+		let keyOrSecret: string | Buffer;
+
+		if (this._algorithm === ALGORITHM_RS256) {
+			if (!this._key) {
+				throw new Error('missing private key');
+			}
+
+			keyOrSecret = this._key;
+		} else {
+			if (!this._secret) {
+				throw new Error('missing secret');
+			}
+
+			keyOrSecret = this._secret;
+		}
+
+		const jwtClaims: JWTClaims = {};
+
+		addClaimTimeValue(jwtClaims, 'iat', this._iat, this._iat_relative ?? false);
+		addClaimTimeValue(jwtClaims, 'nbf', this._nbf, this._nbf_relative ?? false);
+		addClaimTimeValue(jwtClaims, 'exp', this._exp, true);
+
+		Object.assign(jwtClaims, this._claims);
+
+		const additional: { header?: JWTHeaders } = {};
+
+		if (this._headers) {
+			additional.header = this._headers;
+		}
+
+		return jwt.encode(jwtClaims, keyOrSecret, this._algorithm, additional);
+	}
+}
+
+export {
+	JWTTokenBuilder,
+	ALGORITHM_HS256,
+	ALGORITHM_HS384,
+	ALGORITHM_HS512,
+	ALGORITHM_RS256,
+	type Algorithm,
+	type JWTClaims,
+	type JWTHeaders,
+	type JWTConfig,
+};

--- a/packages/studiocms/src/cli/cmds/crypto/consts.ts
+++ b/packages/studiocms/src/cli/cmds/crypto/consts.ts
@@ -1,0 +1,4 @@
+/**
+ * One year in seconds
+ */
+export const OneYear = 31556926;

--- a/packages/studiocms/src/cli/cmds/crypto/generator.ts
+++ b/packages/studiocms/src/cli/cmds/crypto/generator.ts
@@ -1,0 +1,64 @@
+import { JWTTokenBuilder } from './builder.js';
+
+const builder = new JWTTokenBuilder();
+
+/**
+ * Converts a JWT token to URL-safe base64 format.
+ * Replaces '/' with '_', '+' with '-', and removes '=' padding.
+ *
+ * @param jwtToken - The original JWT token to convert
+ * @returns The JWT token in URL-safe base64 format
+ */
+export function convertJwtToBase64Url(jwtToken: string): string {
+	// Encode the JWT token to base64
+	const base64Encoded = Buffer.from(jwtToken).toString('base64');
+
+	// Make the base64 URL-safe:
+	// 1. Replace '/' with '_'
+	// 2. Replace '+' with '-'
+	// 3. Remove '=' padding
+	return base64Encoded.replace(/\//g, '_').replace(/\+/g, '-').replace(/=/g, '');
+}
+
+export function generator(secret: string, claims?: string[], exp?: number) {
+	const finalClaims: Record<string, string> = {};
+
+	if (claims) {
+		for (const c of claims) {
+			const parts = c.split('=');
+
+			if (parts.length !== 2) {
+				throw new Error(`invalid claim: ${c}`);
+			}
+			try {
+				finalClaims[parts[0].trim()] = JSON.parse(parts[1].trim());
+			} catch (e) {
+				finalClaims[parts[0].trim()] = parts[1].trim();
+			}
+		}
+	}
+
+	try {
+		builder.claims(finalClaims);
+	} catch (err) {
+		throw new Error((err as Error).message);
+	}
+
+	builder.iat(Math.floor(Date.now() / 1000));
+
+	if (exp) {
+		builder.exp(exp);
+	}
+
+	builder.algorithm('HS256');
+
+	if (!secret) {
+		throw new Error('Secret key missing or invalid');
+	}
+
+	builder.secret(secret);
+
+	const token = builder.build();
+
+	return convertJwtToBase64Url(token);
+}

--- a/packages/studiocms/src/cli/cmds/crypto/generator.ts
+++ b/packages/studiocms/src/cli/cmds/crypto/generator.ts
@@ -20,6 +20,15 @@ export function convertJwtToBase64Url(jwtToken: string): string {
 	return base64Encoded.replace(/\//g, '_').replace(/\+/g, '-').replace(/=/g, '');
 }
 
+/**
+ * Generates a JWT token with the specified secret, claims, and expiration time.
+ *
+ * @param secret - The secret key used to sign the JWT token
+ * @param claims - Optional array of claims in format "key=value"
+ * @param exp - Optional expiration time in seconds since epoch
+ * @returns The JWT token in URL-safe base64 format
+ * @throws Error if secret is invalid or claims are malformed
+ */
 export function generator(secret: string, claims?: string[], exp?: number) {
 	const finalClaims: Record<string, string> = {};
 
@@ -56,9 +65,16 @@ export function generator(secret: string, claims?: string[], exp?: number) {
 		throw new Error('Secret key missing or invalid');
 	}
 
+	if (secret.length < 32) {
+		console.warn('Warning: Short secret keys may compromise security');
+	}
+
 	builder.secret(secret);
 
-	const token = builder.build();
-
-	return convertJwtToBase64Url(token);
+	try {
+		const token = builder.build();
+		return convertJwtToBase64Url(token);
+	} catch (err) {
+		throw new Error(`Failed to build JWT token: ${(err as Error).message}`);
+	}
 }

--- a/packages/studiocms/src/cli/cmds/crypto/jwt.ts
+++ b/packages/studiocms/src/cli/cmds/crypto/jwt.ts
@@ -1,3 +1,12 @@
+/*
+ * Based on `jwt-simple`
+ *
+ * JSON Web Token encode and decode module for node.js
+ *
+ * Copyright(c) 2011 Kazuhito Hokamura
+ * MIT Licensed
+ */
+
 import crypto from 'node:crypto';
 
 /**

--- a/packages/studiocms/src/cli/cmds/crypto/jwt.ts
+++ b/packages/studiocms/src/cli/cmds/crypto/jwt.ts
@@ -1,0 +1,194 @@
+import crypto from 'node:crypto';
+
+/**
+ * support algorithm mapping
+ */
+const algorithmMap = {
+	HS256: 'sha256',
+	HS384: 'sha384',
+	HS512: 'sha512',
+	RS256: 'RSA-SHA256',
+};
+
+// JWT Headers interface
+interface JWTHeaders {
+	[key: string]: string | number | boolean | object;
+}
+
+/**
+ * Map algorithm to hmac or sign type, to determine which crypto function to use
+ */
+const typeMap = {
+	HS256: 'hmac',
+	HS384: 'hmac',
+	HS512: 'hmac',
+	RS256: 'sign',
+};
+
+export const jwt = {
+	version: '0.1.0',
+	decode: (
+		token: string,
+		key: string | Buffer<ArrayBufferLike>,
+		noVerify: boolean,
+		algorithm: keyof typeof algorithmMap
+	) => {
+		// check token
+		if (!token) {
+			throw new Error('No token supplied');
+		}
+		// check segments
+		const segments = token.split('.');
+		if (segments.length !== 3) {
+			throw new Error('Not enough or too many segments');
+		}
+
+		// All segment should be base64
+		const headerSeg = segments[0];
+		const payloadSeg = segments[1];
+		const signatureSeg = segments[2];
+
+		// base64 decode and parse JSON
+		const header = JSON.parse(base64urlDecode(headerSeg));
+		const payload = JSON.parse(base64urlDecode(payloadSeg));
+
+		if (!noVerify) {
+			if (!algorithm && /BEGIN( RSA)? PUBLIC KEY/.test(key.toString())) {
+				algorithm = 'RS256';
+			}
+
+			const signingMethod = algorithmMap[algorithm || header.alg];
+			const signingType = typeMap[algorithm || header.alg];
+			if (!signingMethod || !signingType) {
+				throw new Error('Algorithm not supported');
+			}
+
+			// verify signature. `sign` will return base64 string.
+			const signingInput = [headerSeg, payloadSeg].join('.');
+			if (!verify(signingInput, key, signingMethod, signingType, signatureSeg)) {
+				throw new Error('Signature verification failed');
+			}
+
+			// Support for nbf and exp claims.
+			// According to the RFC, they should be in seconds.
+			if (payload.nbf && Date.now() < payload.nbf * 1000) {
+				throw new Error('Token not yet active');
+			}
+
+			if (payload.exp && Date.now() > payload.exp * 1000) {
+				throw new Error('Token expired');
+			}
+		}
+
+		return payload;
+	},
+	encode: (
+		payload: object,
+		key: string | Buffer<ArrayBufferLike>,
+		algorithm: keyof typeof algorithmMap,
+		options?: { header?: JWTHeaders }
+	) => {
+		// Check key
+		if (!key) {
+			throw new Error('Require key');
+		}
+
+		// Check algorithm, default is HS256
+		if (!algorithm) {
+			algorithm = 'HS256';
+		}
+
+		const signingMethod = algorithmMap[algorithm];
+		const signingType = typeMap[algorithm];
+		if (!signingMethod || !signingType) {
+			throw new Error('Algorithm not supported');
+		}
+
+		// header, typ is fixed value.
+		const header = { typ: 'JWT', alg: algorithm };
+		if (options?.header) {
+			assignProperties(header, options.header);
+		}
+
+		// create segments, all segments should be base64 string
+		const segments = [];
+		segments.push(base64urlEncode(JSON.stringify(header)));
+		segments.push(base64urlEncode(JSON.stringify(payload)));
+		segments.push(sign(segments.join('.'), key, signingMethod, signingType));
+
+		return segments.join('.');
+	},
+};
+
+/**
+ * private util functions
+ */
+
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+function assignProperties(dest: Record<string, any>, source: Record<string, any>) {
+	for (const attr in source) {
+		// biome-ignore lint/suspicious/noPrototypeBuiltins: <explanation>
+		if (source.hasOwnProperty(attr)) {
+			dest[attr] = source[attr];
+		}
+	}
+}
+
+function verify(
+	input: crypto.BinaryLike,
+	key: string | Buffer<ArrayBufferLike>,
+	method: string,
+	type: string,
+	signature: string
+) {
+	if (type === 'hmac') {
+		return signature === sign(input, key, method, type);
+	}
+
+	if (type === 'sign') {
+		return crypto
+			.createVerify(method)
+			.update(input)
+			.verify(key, base64urlUnescape(signature), 'base64');
+	}
+
+	throw new Error('Algorithm type not recognized');
+}
+
+function sign(
+	input: crypto.BinaryLike,
+	key: string | Buffer<ArrayBufferLike>,
+	method: string,
+	type: string
+) {
+	// biome-ignore lint/suspicious/noImplicitAnyLet: <explanation>
+	let base64str;
+	if (type === 'hmac') {
+		base64str = crypto.createHmac(method, key).update(input).digest('base64');
+	} else if (type === 'sign') {
+		base64str = crypto.createSign(method).update(input).sign(key, 'base64');
+	} else {
+		throw new Error('Algorithm type not recognized');
+	}
+
+	return base64urlEscape(base64str);
+}
+
+function base64urlDecode(str: string) {
+	return Buffer.from(base64urlUnescape(str), 'base64').toString();
+}
+
+function base64urlUnescape(str: string) {
+	str += new Array(5 - (str.length % 4)).join('=');
+	return str.replace(/\-/g, '+').replace(/_/g, '/');
+}
+
+function base64urlEncode(str: string) {
+	return base64urlEscape(Buffer.from(str).toString('base64'));
+}
+
+function base64urlEscape(str: string) {
+	return str.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+export default jwt;

--- a/packages/studiocms/src/cli/index.ts
+++ b/packages/studiocms/src/cli/index.ts
@@ -22,7 +22,9 @@ await new Command('studiocms')
 	.command('add <plugins...>', 'Add StudioCMS plugin(s) to your project', {
 		executableFile: 'add.js',
 	})
-	.command('get-turso', 'Turso CLI Utilities', { executableFile: 'get-turso.js' })
+	.command('get-turso', 'Install the Turso CLI', {
+		executableFile: 'get-turso.js',
+	})
 	.command('init', 'Initialize the StudioCMS project after new installation.', {
 		executableFile: 'init.js',
 	})

--- a/packages/studiocms/src/cli/index.ts
+++ b/packages/studiocms/src/cli/index.ts
@@ -22,6 +22,9 @@ await new Command('studiocms')
 	.command('add <plugins...>', 'Add StudioCMS plugin(s) to your project', {
 		executableFile: 'add.js',
 	})
+	.command('crypto', 'Crypto Utilities for Security', {
+		executableFile: 'crypto.js',
+	})
 	.command('get-turso', 'Install the Turso CLI', {
 		executableFile: 'get-turso.js',
 	})

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,6 @@ catalog:
   '@astrojs/rss': ^4.0.11
   '@astrojs/react': ^4.2.1
   '@astrojs/check': ^0.9.4
-  '@astrojs/starlight': ^0.32.1
   '@astrojs/web-vitals': ^3.0.1
   '@astrojs/node': ^9.1.3
   '@types/node': ^22.0.0


### PR DESCRIPTION
As we are intending to offer our CMS to many different users, with different requirements it is important to make some functionality easier for the end user.

In a recent docs PR https://github.com/withstudiocms/docs/issues/51 there is instructions on setting up a `sqld` server for AstroDB, when configuring `sqld` it is recommended to generate a JWT for security.  This PR implements a non-external option for doing just that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new CLI crypto utility that enables secure token generation (JWT) with customizable options for claims and expiration.
  - Enhanced the command structure to provide clear, user-friendly cryptographic operations.

- **Chores**
  - Updated project configuration by removing an outdated dependency.
  
- **Bug Fixes**
  - Improved error handling for file access and token generation processes to enhance user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->