### PR TITLE
add drizzle schema for CLI

### DIFF
--- a/.changeset/khaki-eyes-trade.md
+++ b/.changeset/khaki-eyes-trade.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+fix editing users for cli

--- a/packages/studiocms/src/cli/cmds/users/steps/libsql/createUsers.ts
+++ b/packages/studiocms/src/cli/cmds/users/steps/libsql/createUsers.ts
@@ -3,7 +3,7 @@ import { z } from 'astro/zod';
 import dotenv from 'dotenv';
 import checkIfUnsafe from '../../../../../lib/auth/utils/unsafeCheck.js';
 import type { Context } from '../../../../lib/context.js';
-import { tsPermissions, tsUsers, useLibSQLDb } from '../../../../lib/useLibSQLDb.js';
+import { Permissions, Users, useLibSQLDb } from '../../../../lib/useLibSQLDb.js';
 import { createUserAvatar } from '../utils/avatar.js';
 import { checkRequiredEnvVars } from '../utils/checkRequiredEnvVars.js';
 import { hashPassword } from '../utils/password.js';
@@ -26,7 +26,7 @@ export async function libsqlCreateUsers(context: Context) {
 	// Environment variables are already checked by checkRequiredEnvVars
 	const db = useLibSQLDb(ASTRO_DB_REMOTE_URL as string, ASTRO_DB_APP_TOKEN as string);
 
-	const currentUsers = await db.select().from(tsUsers);
+	const currentUsers = await db.select().from(Users);
 
 	const inputData = await context.p.group(
 		{
@@ -118,7 +118,7 @@ export async function libsqlCreateUsers(context: Context) {
 
 	const newUserId = crypto.randomUUID();
 
-	const newUser: typeof tsUsers.$inferInsert = {
+	const newUser: typeof Users.$inferInsert = {
 		id: newUserId,
 		name,
 		username,
@@ -129,7 +129,7 @@ export async function libsqlCreateUsers(context: Context) {
 		avatar: await createUserAvatar(email),
 	};
 
-	const newRank: typeof tsPermissions.$inferInsert = {
+	const newRank: typeof Permissions.$inferInsert = {
 		user: newUserId,
 		rank,
 	};
@@ -147,8 +147,8 @@ export async function libsqlCreateUsers(context: Context) {
 			task: async (message) => {
 				try {
 					const [insertedUser, insertedRank] = await db.batch([
-						db.insert(tsUsers).values(newUser).returning(),
-						db.insert(tsPermissions).values(newRank).returning(),
+						db.insert(Users).values(newUser).returning(),
+						db.insert(Permissions).values(newRank).returning(),
 					]);
 
 					if (insertedUser.length === 0 || insertedRank.length === 0) {

--- a/packages/studiocms/src/cli/cmds/users/steps/libsql/modifyUsers.ts
+++ b/packages/studiocms/src/cli/cmds/users/steps/libsql/modifyUsers.ts
@@ -3,7 +3,7 @@ import dotenv from 'dotenv';
 import { eq } from 'drizzle-orm';
 import checkIfUnsafe from '../../../../../lib/auth/utils/unsafeCheck.js';
 import type { Context } from '../../../../lib/context.js';
-import { tsPermissions, tsUsers, useLibSQLDb } from '../../../../lib/useLibSQLDb.js';
+import { Permissions, Users, useLibSQLDb } from '../../../../lib/useLibSQLDb.js';
 import { checkRequiredEnvVars } from '../utils/checkRequiredEnvVars.js';
 import { hashPassword } from '../utils/password.js';
 
@@ -30,8 +30,8 @@ export async function libsqlModifyUsers(context: Context) {
 	const allUsers: { value: string; label: string; hint?: string }[] = [];
 
 	const [currentUsers, currentPermissions] = await db.batch([
-		db.select().from(tsUsers),
-		db.select().from(tsPermissions),
+		db.select().from(Users),
+		db.select().from(Permissions),
 	]);
 
 	if (currentUsers.length === 0) {
@@ -98,9 +98,9 @@ export async function libsqlModifyUsers(context: Context) {
 					task: async (message) => {
 						try {
 							await db
-								.update(tsUsers)
+								.update(Users)
 								.set({ name: newDisplayName })
-								.where(eq(tsUsers.id, userSelection));
+								.where(eq(Users.id, userSelection));
 
 							message('User modified successfully');
 						} catch (e) {
@@ -151,9 +151,9 @@ export async function libsqlModifyUsers(context: Context) {
 					task: async (message) => {
 						try {
 							await db
-								.update(tsUsers)
+								.update(Users)
 								.set({ username: newUserName })
-								.where(eq(tsUsers.id, userSelection));
+								.where(eq(Users.id, userSelection));
 
 							message('User modified successfully');
 						} catch (e) {
@@ -220,9 +220,9 @@ export async function libsqlModifyUsers(context: Context) {
 							const hashedPassword = await hashPassword(newPassword, CMS_ENCRYPTION_KEY as string);
 
 							await db
-								.update(tsUsers)
+								.update(Users)
 								.set({ password: hashedPassword })
-								.where(eq(tsUsers.id, userSelection));
+								.where(eq(Users.id, userSelection));
 
 							message('User modified successfully');
 						} catch (e) {

--- a/packages/studiocms/src/cli/lib/useLibSQLDb.ts
+++ b/packages/studiocms/src/cli/lib/useLibSQLDb.ts
@@ -1,6 +1,28 @@
 import { createClient } from '@libsql/client';
 import { drizzle } from 'drizzle-orm/libsql';
-import * as schema from '../../sdk/tables.js';
+import * as s from 'drizzle-orm/sqlite-core';
+
+export const Users = s.sqliteTable('StudioCMSUsers', {
+	id: s.text('id').primaryKey(),
+	url: s.text('url'),
+	name: s.text('name').notNull(),
+	email: s.text('email').unique(),
+	avatar: s.text('avatar').default('https://seccdn.libravatar.org/static/img/mm/80.png'),
+	username: s.text('username').notNull(),
+	password: s.text('password'),
+	updatedAt: s.integer('updatedAt', { mode: 'timestamp' }),
+	createdAt: s.integer('createdAt', { mode: 'timestamp' }),
+	emailVerified: s.integer('emailVerified', { mode: 'boolean' }).default(false).notNull(),
+	notifications: s.text('notifications'),
+});
+
+export const Permissions = s.sqliteTable('StudioCMSPermissions', {
+	user: s
+		.text('user')
+		.references(() => Users.id)
+		.notNull(),
+	rank: s.text('rank').notNull(),
+});
 
 /**
  * Returns a new Drizzle libSQL connection.
@@ -8,7 +30,12 @@ import * as schema from '../../sdk/tables.js';
 export const useLibSQLDb = (url: string, authToken: string) => {
 	try {
 		const client = createClient({ url, authToken });
-		const db = drizzle(client, { schema });
+		const db = drizzle(client, {
+			schema: {
+				StudioCMSUsers: Users,
+				StudioCMSPermissions: Permissions,
+			},
+		});
 
 		return db;
 	} catch (error) {
@@ -16,7 +43,3 @@ export const useLibSQLDb = (url: string, authToken: string) => {
 		throw new Error('Database connection failed. Please check your credentials and try again.');
 	}
 };
-
-const { tsUsers, tsPermissions } = schema;
-
-export { tsUsers, tsPermissions };


### PR DESCRIPTION
Using Full Astro DB for the schema in the CLI presents an issue when calling the virtual module.  this resolves this issue by implementing a copy of the needed parts of our schema in drizzle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved user editing functionality in the command-line interface.
- **Chores**
  - Updated internal database schema definitions and references for better consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->