### PR TITLE
feat(studiocms): replace lodash with deepmerge-ts for config merging

### DIFF
--- a/.changeset/big-ants-happen.md
+++ b/.changeset/big-ants-happen.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+replace lodash with deepmerge-ts

--- a/packages/studiocms/package.json
+++ b/packages/studiocms/package.json
@@ -152,6 +152,7 @@
 		"chalk": "^5.4.1",
 		"codemirror": "^5.49.0",
 		"commander": "^13.0.0",
+		"deepmerge-ts": "^7.1.5",
 		"diff": "^7.0.0",
 		"diff2html": "^3.4.51",
 		"dompurify": "^3.2.3",
@@ -159,7 +160,6 @@
 		"drizzle-orm": "^0.31.2",
 		"fuse.js": "^7.0.0",
 		"katex": "^0.16.21",
-		"lodash": "^4.17.21",
 		"magicast": "^0.3.5",
 		"mdast-util-from-markdown": "^2.0.2",
 		"mdast-util-to-markdown": "^2.1.1",
@@ -178,7 +178,6 @@
 	"devDependencies": {
 		"@types/codemirror": "5.60.10",
 		"@types/diff": "^7.0.1",
-		"@types/lodash": "^4.17.13",
 		"@types/mdast": "^4.0.4",
 		"@types/node": "catalog:",
 		"@types/nodemailer": "^6.4.17",

--- a/packages/studiocms/src/utils/configResolver.ts
+++ b/packages/studiocms/src/utils/configResolver.ts
@@ -1,6 +1,6 @@
 import { defineUtility } from 'astro-integration-kit';
 import { z } from 'astro/zod';
-import lo from 'lodash';
+import { deepmerge } from 'deepmerge-ts';
 import { StudioCMSCoreError } from '../errors.js';
 import {
 	type StudioCMSConfig,
@@ -68,7 +68,7 @@ function parseAndMerge<T extends z.ZodTypeAny>(
 	try {
 		const ZeroDefaultsSchema = deepRemoveDefaults(schema);
 		const parsedConfigFile = ZeroDefaultsSchema.parse(studioCMSConfigFile);
-		return lo.merge({}, inlineConfig, parsedConfigFile);
+		return deepmerge(inlineConfig, parsedConfigFile);
 	} catch (error) {
 		if (error instanceof Error) {
 			throw new StudioCMSCoreError(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       commander:
         specifier: ^13.0.0
         version: 13.0.0
+      deepmerge-ts:
+        specifier: ^7.1.5
+        version: 7.1.5
       diff:
         specifier: ^7.0.0
         version: 7.0.0
@@ -213,9 +216,6 @@ importers:
       katex:
         specifier: ^0.16.21
         version: 0.16.21
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
       magicast:
         specifier: ^0.3.5
         version: 0.3.5
@@ -268,9 +268,6 @@ importers:
       '@types/diff':
         specifier: ^7.0.1
         version: 7.0.1
-      '@types/lodash':
-        specifier: ^4.17.13
-        version: 4.17.13
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
@@ -1914,9 +1911,6 @@ packages:
   '@types/linkify-it@3.0.5':
     resolution: {integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==}
 
-  '@types/lodash@4.17.13':
-    resolution: {integrity: sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==}
-
   '@types/markdown-it@12.2.3':
     resolution: {integrity: sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==}
 
@@ -2427,6 +2421,10 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deepmerge-ts@7.1.5:
+    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+    engines: {node: '>=16.0.0'}
 
   default-browser-id@5.0.0:
     resolution: {integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==}
@@ -3338,9 +3336,6 @@ packages:
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -6507,8 +6502,6 @@ snapshots:
   '@types/linkify-it@3.0.5':
     optional: true
 
-  '@types/lodash@4.17.13': {}
-
   '@types/markdown-it@12.2.3':
     dependencies:
       '@types/linkify-it': 3.0.5
@@ -7222,6 +7215,8 @@ snapshots:
   deep-diff@1.0.2: {}
 
   deep-eql@5.0.2: {}
+
+  deepmerge-ts@7.1.5: {}
 
   default-browser-id@5.0.0: {}
 
@@ -8126,8 +8121,6 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.startcase@4.4.0: {}
-
-  lodash@4.17.21: {}
 
   longest-streak@3.1.0: {}
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes # <!-- If aplicable add an issue number to this PR so it can be closed otherwise feel free to remove this. -->
- What does this PR change? Give us a brief description.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Replaced the lodash library with deepmerge-ts for merging configuration objects.
  - Updated dependencies by adding deepmerge-ts and removing lodash and its type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->