### PR TITLE
fix(studiocms): Update font provider to Google Fonts due to fontsource not working

### DIFF
--- a/.changeset/sad-pandas-build.md
+++ b/.changeset/sad-pandas-build.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Fix Astro Fonts

--- a/packages/studiocms/src/index.ts
+++ b/packages/studiocms/src/index.ts
@@ -1461,8 +1461,8 @@ export const studiocms = defineIntegration({
 						experimental: {
 							fonts: [
 								{
-									provider: fontProviders.fontsource(),
-									name: 'Onest Variable',
+									provider: fontProviders.google(),
+									name: 'Onest',
 									cssVariable: '--scms-font-onest',
 									weights: ['100 900'],
 								},


### PR DESCRIPTION
Fontsource provider was not actually working, moved to google provider and now we are actually get font files... i hope to be able to switch back in the future

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with fonts by updating the font provider and font name used in the StudioCMS integration.

- **Chores**
  - Added a changeset entry to document the patch update for the font fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->