### PR TITLE
add testing for playground builds

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -13,6 +13,21 @@ on:
 concurrency: testing-${{ github.ref }}
 
 jobs:
+  test-build:
+    name: Run Test Build
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
+    steps:
+      - name: Check out code using Git
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Install Tools & Dependencies
+        uses: withstudiocms/automations/.github/actions/install@main
+
+      - name: Build packages and playground
+        run: pnpm build
+
   vitest:
     name: Run Vitest Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
+      ASTRO_DB_REMOTE_URL: ${{ secrets.ASTRO_DB_REMOTE_URL }}
+      ASTRO_DB_APP_TOKEN: ${{ secrets.ASTRO_DB_APP_TOKEN }}
+      CMS_ENCRYPTION_KEY: ${{ secrets.CMS_ENCRYPTION_KEY }}
     steps:
       - name: Check out code using Git
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
     "astrojs",
     "astrostudio",
     "astrostudiocms",
+    "automations",
     "bluwy",
     "buildkit",
     "CMSAPI",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "scripts": {
     "build": "pnpm build:studiocms && pnpm --filter node-playground build",
     "build:studiocms": "pnpm --filter studiocms --filter @studiocms/* build",
-    "build:docs": "pnpm build:studiocms && pnpm --filter docs build",
     "playground:dev": "pnpm --filter node-playground dev",
     "playground:push": "pnpm --filter node-playground db:push",
     "playground:preview": "pnpm --filter node-playground preview",


### PR DESCRIPTION
Prepare to migrate the playground to a new URL, and add auto testing of builds through CI.

Preview deployments for the playground have also been disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a new build job to the continuous integration workflow for improved package and playground builds.
  - Updated spell checker settings to recognize the word "automations."
  - Removed the "build:docs" script from available project scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->