### PR TITLE
fix(playground): update site URL to use playground domain

### DIFF
--- a/playground/astro.config.mts
+++ b/playground/astro.config.mts
@@ -8,7 +8,7 @@ import { getCoolifyURL } from './hostUtils';
 
 // https://astro.build/config
 export default defineConfig({
-	site: getCoolifyURL(true) || 'https://next-demo.studiocms.dev',
+	site: getCoolifyURL(true) || 'https://playground.studiocms.dev',
 	output: 'server',
 	adapter: node({ mode: 'standalone' }),
 	security: {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes # <!-- If aplicable add an issue number to this PR so it can be closed otherwise feel free to remove this. -->
- What does this PR change? Give us a brief description.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default site URL in the configuration to use a new fallback address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->