### PR TITLE
feat(get): add method to retrieve folder by name or ID

### DIFF
--- a/.changeset/busy-moons-mate.md
+++ b/.changeset/busy-moons-mate.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Add support for the SDK folder getter to get by name or ID instead of just ID, and add jsdoc comments to missing functions for the SDK

--- a/packages/studiocms/src/componentRegistry/runtime.ts
+++ b/packages/studiocms/src/componentRegistry/runtime.ts
@@ -67,11 +67,26 @@ export async function importComponentsKeys() {
 	return getRendererComponents();
 }
 
+/**
+ * Sets up a component proxy for the renderer.
+ *
+ * @param result - The SSRResult object from Astro.
+ * @returns A promise that resolves to a component proxy containing the components.
+ * @throws {StudioCMSRendererError} If there is an error during setup, it will be prefixed and logged.
+ */
 export async function setupRendererComponentProxy(result: SSRResult) {
 	const components = await getRendererComponents();
 	return createComponentProxy(result, components);
 }
 
+/**
+ * Creates a renderer function that transforms HTML content using the provided components and sanitization options.
+ *
+ * @param result - The SSRResult object from Astro.
+ * @param sanitizeOpts - Optional sanitization options for the HTML content.
+ * @param preRenderer - An optional function to preprocess the HTML content before rendering.
+ * @returns A function that takes HTML content as input and returns the transformed HTML.
+ */
 export async function createRenderer(
 	result: SSRResult,
 	sanitizeOpts?: SanitizeOptions,

--- a/packages/studiocms/src/consts.ts
+++ b/packages/studiocms/src/consts.ts
@@ -51,10 +51,24 @@ export type CurrentRESTAPIVersions = (typeof currentRESTAPIVersions)[number];
  */
 const baseDir = (path: string) => `studiocms/src/${path}`;
 
+/**
+ * Base Directory Functions
+ */
 const baseRoutesDir = (path: string) => baseDir(`routes/${path}`);
+
+/**
+ * Base Directory Functions for Middleware
+ */
 const baseMiddlewareDir = (path: string) => baseDir(`middleware/${path}`);
+
+/**
+ * Base Directory Functions for API Routes
+ */
 const baseAPIRoutesDir = (path: string) => baseRoutesDir(`api/${path}`);
 
+/**
+ * Base Directory Functions for REST API Routes
+ */
 const baseRestDir = (version: CurrentRESTAPIVersions) => (path: string) =>
 	baseRoutesDir(`api/rest/${version}/${path}`);
 
@@ -124,10 +138,26 @@ export const NotificationSettingsDefaults = {
 	requireAdminVerification: false,
 };
 
+/**
+ * Creates a standardized API route path for the dashboard.
+ *
+ * @param route - Optional additional path to append to the base dashboard API route.
+ * @returns A function that constructs the full API route path.
+ */
 export const dashboardAPIRoute = makeAPIRoute('dashboard');
 
+/**
+ * Creates a standardized API route path for authentication-related endpoints.
+ *
+ * @returns A function that constructs the full API route path for authentication.
+ */
 export const authAPIRoute = makeAPIRoute('auth');
 
+/**
+ * Creates a standardized API route path for the SDK.
+ *
+ * @returns A function that constructs the full API route path for the SDK.
+ */
 export const makeDashboardRoute = (route?: string | undefined) => {
 	let defaultRoute = 'dashboard';
 
@@ -138,6 +168,10 @@ export const makeDashboardRoute = (route?: string | undefined) => {
 	return (path: string) => `${defaultRoute}/${path}`;
 };
 
+/**
+ * Default values for the StudioCMS Markdown configuration.
+ * This configuration is used to set up the default behavior of Markdown rendering in StudioCMS.
+ */
 export const StudioCMSMarkdownDefaults = {
 	flavor: 'studiocms' as const,
 	autoLinkHeadings: false,

--- a/packages/studiocms/src/index.ts
+++ b/packages/studiocms/src/index.ts
@@ -178,7 +178,7 @@ export const studiocms = defineIntegration({
 					});
 
 					// Setup Scripts
-					scriptHandler(params, {
+					await scriptHandler(params, {
 						dbStartPage,
 						injectQuickActionsMenu,
 					});

--- a/packages/studiocms/src/pluginHandler.ts
+++ b/packages/studiocms/src/pluginHandler.ts
@@ -138,9 +138,9 @@ function verifyPluginRequires(sourceList: string[], requires: PluginRequire[]) {
 	const missingRequirements: { source: string; missing: string[] }[] = [];
 
 	for (const req of requires) {
-		const { source, requires } = req;
+		const { source, requires: requiredDeps } = req;
 
-		const missing = requires.filter((r) => !sourceList.includes(r));
+		const missing = requiredDeps.filter((r) => !sourceList.includes(r));
 		if (missing.length > 0) {
 			missingRequirements.push({ source, missing });
 		}

--- a/packages/studiocms/src/pluginHandler.ts
+++ b/packages/studiocms/src/pluginHandler.ts
@@ -112,11 +112,28 @@ export const defaultPlugin: StudioCMSPlugin = {
 	},
 };
 
+/**
+ * Represents a plugin requirement, specifying the source of the plugin and its dependencies.
+ *
+ * @property source - The identifier or path to the plugin source.
+ * @property requires - An array of strings listing the required dependencies for the plugin.
+ */
 type PluginRequire = {
 	source: string;
 	requires: string[];
 };
 
+/**
+ * Verifies that all required plugins are present in the source list.
+ *
+ * Iterates through the provided `requires` array, checking if each plugin's required dependencies
+ * are included in the `sourceList`. If any required plugins are missing, an error is thrown
+ * detailing which plugins are missing their dependencies.
+ *
+ * @param sourceList - An array of plugin names that are currently installed or available.
+ * @param requires - An array of objects describing each plugin and its required dependencies.
+ * @throws {StudioCMSError} If any plugin is missing required dependencies.
+ */
 function verifyPluginRequires(sourceList: string[], requires: PluginRequire[]) {
 	const missingRequirements: { source: string; missing: string[] }[] = [];
 
@@ -146,6 +163,17 @@ function verifyPluginRequires(sourceList: string[], requires: PluginRequire[]) {
 	}
 }
 
+/**
+ * Configuration options for the StudioCMS plugin handler.
+ *
+ * @property dbStartPage - Indicates whether to use the database for the start page.
+ * @property verbose - Enables verbose logging output.
+ * @property name - The name of the plugin or application.
+ * @property pkgVersion - The version of the package.
+ * @property plugins - An array of StudioCMSPlugin instances, or undefined if no plugins are provided.
+ * @property robotsTXTConfig - Configuration for robots.txt, either a boolean or a RobotsConfig object.
+ * @property dashboardRoute - A function that returns the dashboard route for a given path.
+ */
 type Options = {
 	dbStartPage: boolean;
 	verbose: boolean;
@@ -156,6 +184,29 @@ type Options = {
 	dashboardRoute: (path: string) => string;
 };
 
+/**
+ * Handles the setup and configuration of StudioCMS plugins during the Astro build process.
+ *
+ * This utility function is registered for the `astro:config:setup` hook and is responsible for:
+ * - Initializing and validating StudioCMS plugins, including checking minimum version requirements.
+ * - Collecting integrations, dashboard grid items, dashboard pages, plugin endpoints, renderers, image services, and other plugin-related data.
+ * - Invoking plugin hooks (`studiocms:astro:config`, `studiocms:config:setup`) to allow plugins to register their features and integrations.
+ * - Setting up virtual imports for plugin components, endpoints, renderers, and image services for use in the StudioCMS dashboard and editor.
+ * - Managing sitemap and robots.txt integrations based on plugin and configuration options.
+ * - Verifying plugin dependencies and requirements.
+ * - Logging information about installed plugins and their configuration.
+ *
+ * @param params - Parameters provided by Astro during the config setup phase, including the logger.
+ * @param options - StudioCMS configuration options, including plugins, dashboard route, robots.txt config, and other settings.
+ * @returns An object containing:
+ *   - `integrations`: Array of Astro integrations to be registered.
+ *   - `extraRoutes`: Additional routes to be injected into the Astro app (e.g., dashboard plugin pages).
+ *   - `safePluginList`: List of validated and processed plugins with their safe configuration data.
+ *   - `messages`: Informational messages about the plugin setup process.
+ *
+ * @throws {StudioCMSError} If a plugin specifies an invalid minimum version requirement or if no rendering plugins are found.
+ * @throws {AstroError} If no rendering plugins are installed.
+ */
 export const pluginHandler = defineUtility('astro:config:setup')(
 	async (params, options: Options) => {
 		const { logger } = params;

--- a/packages/studiocms/src/routeHandler.ts
+++ b/packages/studiocms/src/routeHandler.ts
@@ -3,6 +3,26 @@ import { authAPIRoute, dashboardAPIRoute, routesDir } from './consts.js';
 import { apiRoute, sdkRouteResolver, v1RestRoute } from './lib/index.js';
 import type { Route } from './types.js';
 
+/**
+ * Configuration options for the route handler.
+ *
+ * @property dbStartPage - Determines if the start page should be loaded from the database.
+ * @property shouldInject404Route - If true, injects a 404 route into the routing table.
+ * @property dashboardEnabled - Enables or disables the dashboard feature.
+ * @property dashboardRoute - Function to generate the dashboard route path.
+ * @property developerConfig - Developer-specific configuration.
+ * @property developerConfig.demoMode - Enables demo mode with optional credentials.
+ * @property extraRoutes - Additional custom routes to be included.
+ * @property authConfig - Authentication configuration.
+ * @property authConfig.enabled - Enables or disables authentication.
+ * @property authConfig.providers - Specifies which authentication providers are enabled.
+ * @property authConfig.providers.github - Enables GitHub authentication.
+ * @property authConfig.providers.discord - Enables Discord authentication.
+ * @property authConfig.providers.google - Enables Google authentication.
+ * @property authConfig.providers.auth0 - Enables Auth0 authentication.
+ * @property authConfig.providers.usernameAndPassword - Enables username and password authentication.
+ * @property authConfig.providers.usernameAndPasswordConfig.allowUserRegistration - Allows user registration via username and password.
+ */
 type Options = {
 	dbStartPage: boolean;
 	shouldInject404Route: boolean;
@@ -31,6 +51,27 @@ type Options = {
 	};
 };
 
+/**
+ * Handles the dynamic injection of routes based on configuration options.
+ *
+ * This utility is registered under the 'astro:config:setup' hook and is responsible for
+ * setting up all necessary routes for the application, including dashboard, authentication,
+ * API, and REST endpoints. Routes are conditionally enabled based on the provided options,
+ * such as dashboard status, authentication providers, demo mode, and extra custom routes.
+ *
+ * @param params - Contains route injection utilities, such as `injectRoute`.
+ * @param options - Configuration options for route setup, including:
+ *   - `dbStartPage`: Whether the database start page is enabled.
+ *   - `shouldInject404Route`: Whether to inject a 404 route.
+ *   - `dashboardEnabled`: Whether the dashboard is enabled.
+ *   - `dashboardRoute`: Function to resolve dashboard route patterns.
+ *   - `developerConfig.demoMode`: Whether the application is in demo mode.
+ *   - `extraRoutes`: Additional custom routes to inject.
+ *   - `authConfig`: Authentication configuration, including enabled providers and registration settings.
+ *
+ * The function builds a list of route definitions, conditionally enables them,
+ * and injects each enabled route using the provided `injectRoute` function.
+ */
 export const routeHandler = defineUtility('astro:config:setup')((params, options: Options) => {
 	const { injectRoute } = params;
 

--- a/packages/studiocms/src/routeHandler.ts
+++ b/packages/studiocms/src/routeHandler.ts
@@ -81,7 +81,7 @@ export const routeHandler = defineUtility('astro:config:setup')((params, options
 		dashboardEnabled,
 		dashboardRoute,
 		developerConfig: { demoMode },
-		extraRoutes,
+		extraRoutes = [],
 
 		authConfig: {
 			enabled: authEnabled,
@@ -96,6 +96,25 @@ export const routeHandler = defineUtility('astro:config:setup')((params, options
 		},
 	} = options;
 
+
+	/**
+	 * Defines the list of route configurations for the application.
+	 *
+	 * Each route object specifies:
+	 * - `pattern`: The URL pattern or API endpoint for the route.
+	 * - `entrypoint`: The file path to the handler or page for the route.
+	 * - `enabled`: A boolean or expression indicating if the route should be active, based on feature flags or runtime conditions.
+	 *
+	 * The routes array includes:
+	 * - Frontend page routes (e.g., start, done, 404)
+	 * - SDK and API endpoints for internal and external integrations
+	 * - Dashboard routes for content management, user management, configuration, and plugins
+	 * - Authentication API and pages (login, logout, register, provider callbacks)
+	 * - REST API endpoints for folders, pages, users, and settings
+	 * - Conditional routes based on dashboard, authentication, and demo mode flags
+	 *
+	 * This configuration enables dynamic route activation and modular handling of application features.
+	 */
 	const routes: Route[] = [
 		{
 			pattern: 'start',
@@ -454,11 +473,28 @@ export const routeHandler = defineUtility('astro:config:setup')((params, options
 		},
 	];
 
+	// If extraRoutes are provided, append them to the routes array
+	// This allows for additional custom routes to be injected without modifying the core route handler logic.
+	// Each route in extraRoutes should conform to the Route type.
+	// The extraRoutes array is optional and can be empty.
+	// If it is provided, it will be merged with the existing routes array.
+	// This is useful for plugins or extensions that need to add their own routes dynamically.
+	// The extraRoutes array is expected to contain Route objects with the same structure as defined above.
+	// Each route should have a `pattern`, `entrypoint`, and an `enabled`
+	// flag to determine if it should be active.
+	// This allows for flexible route management and extensibility.
 	if (extraRoutes.length > 0) {
 		routes.push(...extraRoutes);
 	}
 
-	// Inject Routes
+	// Inject Routes into Astro
+	// Iterate over each route in the routes array and inject it if it is enabled.
+	// The injectRoute function is called with the route's properties, excluding the `enabled`
+	// flag, which is used to determine if the route should be active.
+	// This allows for dynamic route injection based on the configuration options provided.
+	// Each route is injected with its pattern, entrypoint, and any other necessary properties.
+	// This enables the application to have a flexible routing system that can adapt to different configurations and
+	// feature flags.
 	for (const { enabled, ...rest } of routes) {
 		if (enabled) injectRoute({ ...rest, prerender: false });
 	}

--- a/packages/studiocms/src/scriptHandler.ts
+++ b/packages/studiocms/src/scriptHandler.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import { promises as fs } from 'node:fs';
 import { createResolver, defineUtility } from 'astro-integration-kit';
 import type { Script } from './types.js';
 
@@ -33,24 +33,51 @@ const { resolve } = createResolver(import.meta.url);
  * - Appends any extra scripts provided in the `extraScripts` option.
  * - Only scripts marked as `enabled` are injected at their specified stage.
  */
-export const scriptHandler = defineUtility('astro:config:setup')((params, options: Options) => {
+export const scriptHandler = defineUtility('astro:config:setup')(async (params, options: Options) => {
 	const { injectScript } = params;
 
 	const { dbStartPage, injectQuickActionsMenu, extraScripts } = options;
 
+	/**
+	 * An array of Script objects representing JavaScript files to be injected at specific stages of the page lifecycle.
+	 * Each script contains its content, the stage at which it should be injected, and a flag indicating whether it is enabled.
+	 *
+	 * @remarks
+	 * The first script in the array loads the 'user-quick-tools.js' file and is enabled only if `injectQuickActionsMenu` is true and `dbStartPage` is false.
+	 *
+	 * @example
+	 * ```
+	 * const scripts: Script[] = [
+	 *   {
+	 *     content: "...",
+	 *     stage: "page",
+	 *     enabled: true,
+	 *   },
+	 * ];
+	 * ```
+	 */
 	const scripts: Script[] = [
 		{
-			content: fs.readFileSync(resolve('./components/user-quick-tools.js'), 'utf-8'),
+			content: await fs.readFile(resolve('./components/user-quick-tools.js'), 'utf-8'),
 			stage: 'page',
 			enabled: injectQuickActionsMenu && !dbStartPage,
 		},
 	];
 
+	// If extraScripts are provided, append them to the scripts array
+	// This allows for additional scripts to be injected without modifying the core script handler logic.
+	// Each script in extraScripts should conform to the Script type.
+	// The extraScripts array is optional and can be empty.
+	// If it is provided, it will be merged with the existing scripts array.
 	if (extraScripts && extraScripts.length > 0) {
 		scripts.push(...extraScripts);
 	}
 
-	// Inject Scripts
+	// Inject Scripts into Astro
+	// Iterate over each script in the scripts array and inject it if it is enabled.
+	// The injectScript function is called with the stage and content of each script.
+	// This allows for dynamic script injection based on the configuration options provided.
+	// Each script is injected at its specified stage, allowing for flexible script management.
 	for (const { enabled, stage, content } of scripts) {
 		if (enabled) injectScript(stage, content);
 	}

--- a/packages/studiocms/src/scriptHandler.ts
+++ b/packages/studiocms/src/scriptHandler.ts
@@ -2,6 +2,13 @@ import fs from 'node:fs';
 import { createResolver, defineUtility } from 'astro-integration-kit';
 import type { Script } from './types.js';
 
+/**
+ * Represents configuration options for the script handler.
+ *
+ * @property dbStartPage - If true, enables the database start page.
+ * @property injectQuickActionsMenu - If true, injects the quick actions menu into the UI.
+ * @property extraScripts - Optional array of additional scripts to be included.
+ */
 type Options = {
 	dbStartPage: boolean;
 	injectQuickActionsMenu: boolean;
@@ -11,6 +18,21 @@ type Options = {
 // Resolver Function
 const { resolve } = createResolver(import.meta.url);
 
+/**
+ * Handles the injection of scripts during the Astro config setup phase.
+ *
+ * @utility astro:config:setup
+ * @param params - An object containing the `injectScript` function used to inject scripts at specific stages.
+ * @param options - Configuration options for script injection.
+ * @param options.dbStartPage - Indicates if the database start page is active; disables quick actions menu script if true.
+ * @param options.injectQuickActionsMenu - Enables injection of the quick actions menu script if true.
+ * @param options.extraScripts - An optional array of additional scripts to inject.
+ *
+ * @remarks
+ * - Reads and injects the `user-quick-tools.js` script if `injectQuickActionsMenu` is enabled and `dbStartPage` is false.
+ * - Appends any extra scripts provided in the `extraScripts` option.
+ * - Only scripts marked as `enabled` are injected at their specified stage.
+ */
 export const scriptHandler = defineUtility('astro:config:setup')((params, options: Options) => {
 	const { injectScript } = params;
 

--- a/packages/studiocms/src/sdk/effect/collectors.ts
+++ b/packages/studiocms/src/sdk/effect/collectors.ts
@@ -143,6 +143,13 @@ export class SDKCore_Collectors extends Effect.Service<SDKCore_Collectors>()('SD
 				})
 			);
 
+		/**
+		 * Transforms the collected page data to include only metadata.
+		 *
+		 * @param data - The page data to transform.
+		 * @returns A promise that resolves to the transformed page data.
+		 * @throws {UnknownException} If an error occurs during transformation.
+		 */
 		const transformPageDataToMetaOnly = <T extends CombinedPageData[] | CombinedPageData>(
 			data: T
 		): Effect.Effect<PageDataReturnType<T>, UnknownException, never> =>

--- a/packages/studiocms/src/sdk/effect/getVersionFromNPM.ts
+++ b/packages/studiocms/src/sdk/effect/getVersionFromNPM.ts
@@ -42,6 +42,13 @@ export class GetVersionFromNPM extends Effect.Service<GetVersionFromNPM>()(
 				})
 			);
 
+			/**
+			 * Retrieves the version of an NPM package.
+			 *
+			 * @param pkg - The name of the NPM package.
+			 * @param ver - The version tag or number (defaults to 'latest').
+			 * @returns An Effect that resolves to the version string of the specified package.
+			 */
 			const get = (pkg: string, ver = 'latest') =>
 				Effect.gen(function* () {
 					const response = yield* httpClient

--- a/packages/studiocms/src/sdk/effect/parsers.ts
+++ b/packages/studiocms/src/sdk/effect/parsers.ts
@@ -65,6 +65,10 @@ export class SDKCore_Parsers extends Effect.Service<SDKCore_Parsers>()(
 						}),
 				});
 
+			/**
+			 * Fixes the diff items by parsing the `pageMetaData` field.
+			 * @param items - The diff items to be fixed, can be a single item or an array.
+			 */
 			const fixDiff = <T extends diffItem | diffItem[]>(
 				items: T
 			): Effect.Effect<DiffReturnType<T>, SDKCoreError, never> =>

--- a/packages/studiocms/src/sdk/modules/auth.ts
+++ b/packages/studiocms/src/sdk/modules/auth.ts
@@ -56,6 +56,13 @@ export class SDKCore_AUTH extends Effect.Service<SDKCore_AUTH>()(
 
 			const AUTH = {
 				verifyEmail: {
+					/**
+					 * Retrieves an email verification token by its ID.
+					 *
+					 * @param id - The ID of the email verification token to retrieve.
+					 * @returns A promise that resolves to the email verification token if found, otherwise undefined.
+					 * @throws {StudioCMS_SDK_Error} If an error occurs while retrieving the token.
+					 */
 					get: dbService.makeQuery((ex, id: string) =>
 						ex((db) =>
 							db
@@ -75,6 +82,13 @@ export class SDKCore_AUTH extends Effect.Service<SDKCore_AUTH>()(
 							})
 						)
 					),
+					/**
+					 * Creates a new email verification token in the database.
+					 *
+					 * @param userId - The ID of the user to create the token for.
+					 * @returns A promise that resolves to the created email verification token.
+					 * @throws {StudioCMS_SDK_Error} If an error occurs while creating the token.
+					 */
 					create: (userId: string) =>
 						Effect.gen(function* () {
 							yield* dbService.execute((db) =>
@@ -109,6 +123,13 @@ export class SDKCore_AUTH extends Effect.Service<SDKCore_AUTH>()(
 									),
 							})
 						),
+					/**
+					 * Deletes an email verification token from the database.
+					 *
+					 * @param userId - The ID of the user associated with the token.
+					 * @returns A promise that resolves to the deletion response.
+					 * @throws {StudioCMS_SDK_Error} If an error occurs while deleting the token.
+					 */
 					delete: dbService.makeQuery((ex, userId: string) =>
 						ex((db) =>
 							db

--- a/packages/studiocms/src/sdk/modules/clear.ts
+++ b/packages/studiocms/src/sdk/modules/clear.ts
@@ -35,6 +35,13 @@ export class SDKCore_CLEAR extends Effect.Service<SDKCore_CLEAR>()(
 
 			const CLEAR = {
 				page: {
+
+					/**
+					 * Clears a cached page by its ID.
+					 * @param id - The ID of the page to clear from the cache.
+					 * @returns An Effect that resolves when the operation is complete.
+					 * @throws {UnknownException} If an error occurs during the clearing process.
+					 */
 					byId: (id: string) =>
 						Effect.gen(function* () {
 							const status = yield* isCacheEnabled;
@@ -47,6 +54,13 @@ export class SDKCore_CLEAR extends Effect.Service<SDKCore_CLEAR>()(
 								UnknownException: (cause) => _ClearUnknownError('CLEAR.page.byId', cause),
 							})
 						),
+
+					/**
+					 * Clears cached pages by their slug.
+					 * @param slug - The slug of the page to clear from the cache.
+					 * @returns An Effect that resolves when the operation is complete.
+					 * @throws {UnknownException} If an error occurs during the clearing process.
+					 */
 					bySlug: (slug: string) =>
 						Effect.gen(function* () {
 							const status = yield* isCacheEnabled;
@@ -71,6 +85,15 @@ export class SDKCore_CLEAR extends Effect.Service<SDKCore_CLEAR>()(
 							})
 						),
 				},
+
+				/**
+				 * Clears all cached pages, folder trees, and folder lists.
+				 * @remarks
+				 * This method checks if the cache is enabled before clearing the pages, folder tree, and folder list.
+				 * If the cache is not enabled, it simply returns without performing any action.
+				 * @returns An Effect that resolves when the operation is complete.
+				 * @throws {UnknownException} If an error occurs during the clearing process.
+				 */
 				pages: () =>
 					Effect.gen(function* () {
 						const status = yield* isCacheEnabled;
@@ -86,6 +109,15 @@ export class SDKCore_CLEAR extends Effect.Service<SDKCore_CLEAR>()(
 							UnknownException: (cause) => _ClearUnknownError('CLEAR.pages', cause),
 						})
 					),
+				
+				/**
+				 * Clears the cached latest version information.
+				 * @remarks
+				 * This method checks if the cache is enabled before clearing the latest version.
+				 * If the cache is not enabled, it simply returns without performing any action.
+				 * @returns An Effect that resolves when the operation is complete.
+				 * @throws {UnknownException} If an error occurs during the clearing process.
+				 */
 				latestVersion: () =>
 					Effect.gen(function* () {
 						const status = yield* isCacheEnabled;
@@ -98,6 +130,14 @@ export class SDKCore_CLEAR extends Effect.Service<SDKCore_CLEAR>()(
 							UnknownException: (cause) => _ClearUnknownError('CLEAR.latestVersion', cause),
 						})
 					),
+				/**
+				 * Clears the cached folder tree and page folder tree.
+				 * @remarks
+				 * This method checks if the cache is enabled before clearing the folder tree and page folder tree.
+				 * If the cache is not enabled, it simply returns without performing any action.
+				 * @returns An Effect that resolves when the operation is complete.
+				 * @throws {UnknownException} If an error occurs during the clearing process.
+				 */
 				folderTree: () =>
 					Effect.gen(function* () {
 						const status = yield* isCacheEnabled;
@@ -111,6 +151,15 @@ export class SDKCore_CLEAR extends Effect.Service<SDKCore_CLEAR>()(
 							UnknownException: (cause) => _ClearUnknownError('CLEAR.folderTree', cause),
 						})
 					),
+				
+				/**
+				 * Clears the cached folder list.
+				 * @remarks
+				 * This method checks if the cache is enabled before clearing the folder list.
+				 * If the cache is not enabled, it simply returns without performing any action.
+				 * @returns An Effect that resolves when the operation is complete.
+				 * @throws {UnknownException} If an error occurs during the clearing process.
+				 */
 				folderList: () =>
 					Effect.gen(function* () {
 						const status = yield* isCacheEnabled;

--- a/packages/studiocms/src/sdk/modules/get.ts
+++ b/packages/studiocms/src/sdk/modules/get.ts
@@ -125,6 +125,16 @@ export class SDKCore_GET extends Effect.Service<SDKCore_GET>()(
 				SDKCore_Collectors,
 			]);
 
+			/**
+			 * Validates the pagination input by ensuring that `limit` and `offset` are non-negative values.
+			 * If `limit` is zero, it sets a default value of 10.
+			 * Returns the validated (and possibly modified) pagination input.
+			 * If validation fails, yields an `SDKCoreError` with a descriptive message.
+			 *
+			 * @template P - Type extending `PaginateInput`.
+			 * @param paginate - The pagination input to validate.
+			 * @returns The validated pagination input or fails with an error if validation fails.
+			 */
 			const validatePagination = Effect.fn(function* <P extends PaginateInput>(paginate: P) {
 				if (paginate.limit < 0 || paginate.offset < 0) {
 					return yield* Effect.fail(
@@ -142,6 +152,17 @@ export class SDKCore_GET extends Effect.Service<SDKCore_GET>()(
 				return paginate;
 			});
 
+			/**
+			 * Retrieves a folder from the database by its ID or name.
+			 *
+			 * This function queries the `tsPageFolderStructure` table for a folder whose `id` or `name`
+			 * matches the provided `idOrName` parameter. If no matching folder is found, it fails with a
+			 * `LibSQLDatabaseError`.
+			 *
+			 * @param idOrName - The ID or name of the folder to retrieve.
+			 * @returns The folder data if found.
+			 * @throws {SDKCoreError} If the folder is not found in the database.
+			 */
 			const getFolderByNameOrId = Effect.fn(function* (idOrName: string) {
 				const data = yield* dbService.execute((db) =>
 					db
@@ -173,6 +194,14 @@ export class SDKCore_GET extends Effect.Service<SDKCore_GET>()(
 				metaOnly?: boolean
 			): Effect.Effect<MetaOnlyPageData[], SDKCoreError, never>;
 
+			/**
+			 * Retrieves all pages associated with a given package name, optionally using a provided folder tree and returning only metadata if specified.
+			 *
+			 * @param packageName - The name of the package to fetch pages for.
+			 * @param tree - Optional. A pre-built folder tree to use for organizing pages. If not provided, the folder tree will be built automatically.
+			 * @param metaOnly - Optional. If true, returns only metadata for each page; otherwise, returns combined page data. Defaults to false.
+			 * @returns An Effect that resolves to an array of page data, either as `MetaOnlyPageData[]` or `CombinedPageData[]` depending on `metaOnly`.
+			 */
 			function _getPackagesPages(packageName: string, tree?: FolderNode[], metaOnly = false) {
 				return Effect.gen(function* () {
 					const pagesRaw = yield* dbService.execute((db) =>
@@ -205,6 +234,16 @@ export class SDKCore_GET extends Effect.Service<SDKCore_GET>()(
 				metaOnly?: boolean
 			): Effect.Effect<MetaOnlyPageDataCacheObject, SDKCoreError, never>;
 
+			/**
+			 * Retrieves a page by its ID, with an option to return only metadata.
+			 *
+			 * @param id - The ID of the page to retrieve.
+			 * @param metaOnly - If `true`, returns only metadata for the page. Defaults to `false`.
+			 * @returns An `Effect` that yields the page data or metadata, depending on `metaOnly`.
+			 *
+			 * @throws UnknownException - If an unknown error occurs during retrieval.
+			 * @throws LibSQLDatabaseError - If a database error occurs during retrieval.
+			 */
 			function _getPageById(id: string, metaOnly = false) {
 				const getPage = (id: string, tree?: FolderNode[]) =>
 					Effect.gen(function* () {
@@ -279,6 +318,16 @@ export class SDKCore_GET extends Effect.Service<SDKCore_GET>()(
 				metaOnly?: boolean
 			): Effect.Effect<MetaOnlyPageDataCacheObject, SDKCoreError, never>;
 
+			/**
+			 * Retrieves a page by its slug, with an option to return only metadata.
+			 *
+			 * @param slug - The slug of the page to retrieve.
+			 * @param metaOnly - If `true`, returns only metadata for the page. Defaults to `false`.
+			 * @returns An `Effect` that yields the page data or metadata, depending on `metaOnly`.
+			 *
+			 * @throws UnknownException - If an unknown error occurs during retrieval.
+			 * @throws LibSQLDatabaseError - If a database error occurs during retrieval.
+			 */
 			function _getPageBySlug(slug: string, metaOnly = false) {
 				const getPage = (iSlug: string, tree?: FolderNode[]) =>
 					Effect.gen(function* () {
@@ -360,6 +409,22 @@ export class SDKCore_GET extends Effect.Service<SDKCore_GET>()(
 				paginate?: PaginateInput
 			): Effect.Effect<MetaOnlyPageDataCacheObject[], SDKCoreError, never>;
 
+			/**
+			 * Retrieves all pages from the database or cache, with options for including drafts,
+			 * hiding the default index page, returning only metadata, and paginating results.
+			 *
+			 * - If caching is enabled, attempts to return cached pages and updates expired cache entries.
+			 * - If caching is disabled, fetches pages directly from the database.
+			 * - Supports filtering by draft status and default index visibility.
+			 * - Can return either full page data or metadata only.
+			 * - Supports pagination via the `paginate` parameter.
+			 *
+			 * @param includeDrafts - Whether to include draft pages in the results. Defaults to `false`.
+			 * @param hideDefaultIndex - Whether to exclude the default index page from the results. Defaults to `false`.
+			 * @param metaOnly - Whether to return only metadata for each page. Defaults to `false`.
+			 * @param paginate - Optional pagination input specifying `limit` and `offset`.
+			 * @returns An `Effect` that yields an array of page data or metadata, depending on `metaOnly`.
+			 */
 			function _getAllPages(
 				includeDrafts = false,
 				hideDefaultIndex = false,
@@ -489,6 +554,22 @@ export class SDKCore_GET extends Effect.Service<SDKCore_GET>()(
 				paginate?: PaginateInput
 			): Effect.Effect<MetaOnlyPageDataCacheObject[], SDKCoreError, never>;
 
+			/**
+			 * Retrieves pages within a specified folder by its ID or name, supporting various filtering and pagination options.
+			 *
+			 * This function handles both cached and non-cached scenarios, fetching pages from the database or cache as appropriate.
+			 * It supports filtering drafts, hiding default index pages, returning only metadata, and paginating results.
+			 *
+			 * @param idOrName - The ID or name of the folder to retrieve pages from.
+			 * @param includeDrafts - Whether to include draft pages in the results. Defaults to `false`.
+			 * @param hideDefaultIndex - Whether to exclude default index pages from the results. Defaults to `false`.
+			 * @param metaOnly - If `true`, returns only metadata for each page. Defaults to `false`.
+			 * @param paginate - Optional pagination input specifying `limit` and `offset`.
+			 * @returns An `Effect` that yields an array of page data or metadata, depending on `metaOnly`.
+			 *
+			 * @throws UnknownException - If an unknown error occurs during retrieval.
+			 * @throws LibSQLDatabaseError - If a database error occurs during retrieval.
+			 */
 			function _folderPages(
 				idOrName: string,
 				includeDrafts = false,
@@ -639,6 +720,16 @@ export class SDKCore_GET extends Effect.Service<SDKCore_GET>()(
 				);
 			}
 
+			/**
+			 * Retrieves the list of permissions for users with the specified rank.
+			 *
+			 * This function queries the database for all permitted users and existing users,
+			 * then verifies and returns the permissions associated with the given rank.
+			 * Handles database errors by invoking a custom error handler.
+			 *
+			 * @param rank - The rank of users to retrieve permissions for. Must be one of 'owner', 'admin', 'editor', or 'visitor'.
+			 * @returns An Effect that resolves to the verified permissions for the specified rank, or handles database errors.
+			 */
 			const getPermissionsByRank = (rank: 'owner' | 'admin' | 'editor' | 'visitor') =>
 				Effect.gen(function* () {
 					const currentPermittedUsers = yield* dbService.execute((db) =>
@@ -840,6 +931,14 @@ export class SDKCore_GET extends Effect.Service<SDKCore_GET>()(
 							})
 						),
 				},
+
+				/**
+				 * Retrieves a folder by ID.
+				 *
+				 * @param id - The ID of the folder to retrieve.
+				 * @returns A promise that resolves to the folder data.
+				 * @throws {StudioCMS_SDK_Error} If an error occurs while getting the folder.
+				 */
 				folder: dbService.makeQuery((ex, id: string) =>
 					ex((db) =>
 						db.select().from(tsPageFolderStructure).where(eq(tsPageFolderStructure.id, id)).get()
@@ -850,6 +949,16 @@ export class SDKCore_GET extends Effect.Service<SDKCore_GET>()(
 						})
 					)
 				),
+
+				/**
+				 * Retrieves the site configuration, with caching support.
+				 * If caching is enabled, it checks the cache for an existing site config.
+				 * If the cache is expired or not available, it fetches the site config from the database
+				 * and updates the cache.
+				 * @returns An `Effect` that yields the site config.
+				 * @throws UnknownException - If an unknown error occurs during retrieval.
+				 * @throws LibSQLDatabaseError - If a database error occurs during retrieval.
+				 */
 				siteConfig: () =>
 					Effect.gen(function* () {
 						const status = yield* isCacheEnabled;
@@ -906,6 +1015,16 @@ export class SDKCore_GET extends Effect.Service<SDKCore_GET>()(
 								_clearLibSQLError('GET.siteConfig', cause),
 						})
 					),
+
+				/**
+				 * Retrieves the folder tree structure, with caching support.
+				 * If caching is enabled, it checks the cache for an existing folder tree.
+				 * If the cache is expired or not available, it fetches the folder tree from the database
+				 * and updates the cache.
+				 * @returns An `Effect` that yields the folder tree.
+				 * @throws UnknownException - If an unknown error occurs during retrieval.
+				 * @throws LibSQLDatabaseError - If a database error occurs during retrieval.
+				 */
 				folderTree: () =>
 					Effect.gen(function* () {
 						const status = yield* isCacheEnabled;
@@ -934,6 +1053,16 @@ export class SDKCore_GET extends Effect.Service<SDKCore_GET>()(
 								_clearLibSQLError('GET.folderTree', cause),
 						})
 					),
+
+				/**
+				 * Retrieves the folder tree structure, with caching support.
+				 * If caching is enabled, it checks the cache for an existing folder tree.
+				 * If the cache is expired or not available, it fetches the folder tree from the database
+				 * and updates the cache.
+				 * @returns An `Effect` that yields the folder tree.
+				 * @throws UnknownException - If an unknown error occurs during retrieval.
+				 * @throws LibSQLDatabaseError - If a database error occurs during retrieval.
+				 */
 				pageFolderTree: (hideDefaultIndex = false) =>
 					Effect.gen(function* () {
 						const status = yield* isCacheEnabled;
@@ -1004,6 +1133,16 @@ export class SDKCore_GET extends Effect.Service<SDKCore_GET>()(
 								_clearLibSQLError('GET.pageFolderTree', cause),
 						})
 					),
+
+				/**
+				 * Retrieves a list of available folders, with caching support.
+				 * If caching is enabled, it checks the cache for an existing folder list.
+				 * If the cache is expired or not available, it fetches the folder list from the database
+				 * and updates the cache.
+				 * @returns An `Effect` that yields the folder list.
+				 * @throws UnknownException - If an unknown error occurs during retrieval.
+				 * @throws LibSQLDatabaseError - If a database error occurs during retrieval.
+				 */
 				folderList: () =>
 					Effect.gen(function* () {
 						const status = yield* isCacheEnabled;
@@ -1032,6 +1171,11 @@ export class SDKCore_GET extends Effect.Service<SDKCore_GET>()(
 								_clearLibSQLError('GET.folderList', cause),
 						})
 					),
+				/**
+				 * Retrieves the latest version of StudioCMS from NPM, with caching support.
+				 * @returns An `Effect` that yields the latest version of StudioCMS.
+				 * @throws UnknownException - If an unknown error occurs during retrieval.
+				 */
 				latestVersion: () =>
 					Effect.gen(function* () {
 						const status = yield* isCacheEnabled;
@@ -1060,11 +1204,71 @@ export class SDKCore_GET extends Effect.Service<SDKCore_GET>()(
 						})
 					),
 				page: {
+					/**
+					 * Retrieves a page by its ID, with an option to return only metadata.
+					 *
+					 * @param id - The ID of the page to retrieve.
+					 * @param metaOnly - If `true`, returns only metadata for the page. Defaults to `false`.
+					 * @returns An `Effect` that yields the page data or metadata, depending on `metaOnly`.
+					 *
+					 * @throws UnknownException - If an unknown error occurs during retrieval.
+					 * @throws LibSQLDatabaseError - If a database error occurs during retrieval.
+					 */
 					byId: _getPageById,
+					/**
+					 * Retrieves a page by its slug, with an option to return only metadata.
+					 *
+					 * @param slug - The slug of the page to retrieve.
+					 * @param metaOnly - If `true`, returns only metadata for the page. Defaults to `false`.
+					 * @returns An `Effect` that yields the page data or metadata, depending on `metaOnly`.
+					 *
+					 * @throws UnknownException - If an unknown error occurs during retrieval.
+					 * @throws LibSQLDatabaseError - If a database error occurs during retrieval.
+					 */
 					bySlug: _getPageBySlug,
 				},
+				/**
+				 * Retrieves pages within a specified folder by its ID or name, supporting various filtering and pagination options.
+				 *
+				 * This function handles both cached and non-cached scenarios, fetching pages from the database or cache as appropriate.
+				 * It supports filtering drafts, hiding default index pages, returning only metadata, and paginating results.
+				 *
+				 * @param idOrName - The ID or name of the folder to retrieve pages from.
+				 * @param includeDrafts - Whether to include draft pages in the results. Defaults to `false`.
+				 * @param hideDefaultIndex - Whether to exclude default index pages from the results. Defaults to `false`.
+				 * @param metaOnly - If `true`, returns only metadata for each page. Defaults to `false`.
+				 * @param paginate - Optional pagination input specifying `limit` and `offset`.
+				 * @returns An `Effect` that yields an array of page data or metadata, depending on `metaOnly`.
+				 *
+				 * @throws UnknownException - If an unknown error occurs during retrieval.
+				 * @throws LibSQLDatabaseError - If a database error occurs during retrieval.
+				 */
 				folderPages: _folderPages,
+				/**
+				 * Retrieves all pages associated with a given package name, optionally using a provided folder tree and returning only metadata if specified.
+				 *
+				 * @param packageName - The name of the package to fetch pages for.
+				 * @param tree - Optional. A pre-built folder tree to use for organizing pages. If not provided, the folder tree will be built automatically.
+				 * @param metaOnly - Optional. If true, returns only metadata for each page; otherwise, returns combined page data. Defaults to false.
+				 * @returns An Effect that resolves to an array of page data, either as `MetaOnlyPageData[]` or `CombinedPageData[]` depending on `metaOnly`.
+				 */
 				packagePages: _getPackagesPages,
+				/**
+				 * Retrieves all pages from the database or cache, with options for including drafts,
+				 * hiding the default index page, returning only metadata, and paginating results.
+				 *
+				 * - If caching is enabled, attempts to return cached pages and updates expired cache entries.
+				 * - If caching is disabled, fetches pages directly from the database.
+				 * - Supports filtering by draft status and default index visibility.
+				 * - Can return either full page data or metadata only.
+				 * - Supports pagination via the `paginate` parameter.
+				 *
+				 * @param includeDrafts - Whether to include draft pages in the results. Defaults to `false`.
+				 * @param hideDefaultIndex - Whether to exclude the default index page from the results. Defaults to `false`.
+				 * @param metaOnly - Whether to return only metadata for each page. Defaults to `false`.
+				 * @param paginate - Optional pagination input specifying `limit` and `offset`.
+				 * @returns An `Effect` that yields an array of page data or metadata, depending on `metaOnly`.
+				 */
 				pages: _getAllPages,
 			};
 

--- a/packages/studiocms/src/sdk/modules/notificationSettings.ts
+++ b/packages/studiocms/src/sdk/modules/notificationSettings.ts
@@ -41,6 +41,12 @@ export class SDKCore_NotificationSettings extends Effect.Service<SDKCore_Notific
 
 			const notificationSettings = {
 				site: {
+
+					/**
+					 * Retrieves the site-wide notification settings.
+					 * @returns An Effect that resolves to the current notification settings.
+					 * @throws SDKCoreError when a database error occurs.
+					 */
 					get: () =>
 						Effect.gen(function* () {
 							const data = yield* dbService.execute((db) =>
@@ -75,6 +81,13 @@ export class SDKCore_NotificationSettings extends Effect.Service<SDKCore_Notific
 									),
 							})
 						),
+
+					/**
+					 * Updates the site-wide notification settings.
+					 * @param settings - The new notification settings to be updated.
+					 * @returns An Effect that resolves to the updated settings.
+					 * @throws SDKCoreError when a database error occurs.
+					 */
 					update: dbService.makeQuery((ex, settings: tsNotificationSettingsInsert) =>
 						ex((db) =>
 							db

--- a/packages/studiocms/src/sdk/modules/post.ts
+++ b/packages/studiocms/src/sdk/modules/post.ts
@@ -484,6 +484,13 @@ export class SDKCore_POST extends Effect.Service<SDKCore_POST>()(
 							}
 						}),
 				},
+
+				/**
+				 * Inserts a new folder into the database and updates the cache.
+				 * @param data - The data to insert into the page folder structure table.
+				 * @returns A promise that resolves to the inserted folder.
+				 * @throws {StudioCMS_SDK_Error} If an error occurs while inserting the folder.
+				 */
 				folder: (data: tsPageFolderSelect) =>
 					Effect.gen(function* () {
 						const newEntry = yield* POST.databaseEntry.folder(data);
@@ -496,6 +503,13 @@ export class SDKCore_POST extends Effect.Service<SDKCore_POST>()(
 
 						return newEntry;
 					}),
+
+				/**
+				 * Inserts a new page into the database and updates the cache.
+				 * @param data - The data to insert into the page data and page content tables.
+				 * @returns A promise that resolves to the inserted page data.
+				 * @throws {StudioCMS_SDK_Error} If an error occurs while inserting the page.
+				 */
 				page: (data: {
 					pageData: tsPageDataSelect;
 					pageContent: CombinedInsertContent;

--- a/packages/studiocms/src/sdk/modules/resetTokenBucket.ts
+++ b/packages/studiocms/src/sdk/modules/resetTokenBucket.ts
@@ -56,6 +56,12 @@ export class SDKCore_ResetTokenBucket extends Effect.Service<SDKCore_ResetTokenB
 			]);
 
 			const resetTokenBucket = {
+
+				/**
+				 * Creates a new reset token for the specified user and stores it in the database.
+				 * @param userId - The ID of the user for whom to create the reset token.
+				 * @returns An effect yielding the created reset token record.
+				 */
 				new: (userId: string): Effect.Effect<tsUserResetTokensSelect, SDKCoreError, never> =>
 					Effect.gen(function* () {
 						const token = yield* generateToken(userId);
@@ -79,6 +85,12 @@ export class SDKCore_ResetTokenBucket extends Effect.Service<SDKCore_ResetTokenB
 								),
 						})
 					),
+
+				/**
+				 * Deletes all reset tokens associated with the specified user.
+				 * @param userId - The ID of the user whose reset tokens should be deleted.
+				 * @returns An effect yielding void.
+				 */
 				delete: (userId: string): Effect.Effect<void, SDKCoreError, never> =>
 					dbService
 						.execute((db) =>
@@ -95,6 +107,12 @@ export class SDKCore_ResetTokenBucket extends Effect.Service<SDKCore_ResetTokenB
 									),
 							})
 						),
+
+				/**
+				 * Validates whether a given token is valid and exists for a user.
+				 * @param token - The reset token to validate.
+				 * @returns An effect yielding a boolean indicating token validity.
+				 */
 				check: (token: string): Effect.Effect<boolean, SDKCoreError, never> =>
 					Effect.gen(function* () {
 						const { isValid, userId } = yield* testToken(token);

--- a/packages/studiocms/src/sdk/modules/rest_api.ts
+++ b/packages/studiocms/src/sdk/modules/rest_api.ts
@@ -39,6 +39,13 @@ export class SDKCore_REST_API extends Effect.Service<SDKCore_REST_API>()(
 
 			const REST_API = {
 				tokens: {
+
+					/**
+					 * Retrieves all API tokens for a specific user.
+					 * @param userId - The ID of the user whose tokens are to be retrieved.
+					 * @returns An Effect that resolves to an array of API keys for the user.
+					 * @throws {LibSQLDatabaseError} If a database error occurs during the operation.
+					 */
 					get: dbService.makeQuery((ex, userId: string) =>
 						ex((db) => db.select().from(tsAPIKeys).where(eq(tsAPIKeys.userId, userId))).pipe(
 							Effect.catchTags({
@@ -47,6 +54,14 @@ export class SDKCore_REST_API extends Effect.Service<SDKCore_REST_API>()(
 							})
 						)
 					),
+
+					/**
+					 * Creates a new API token for a user with the specified description.
+					 * @param userId - The ID of the user for whom to create the token.
+					 * @param description - A description for the API key.
+					 * @returns An Effect that resolves to the created API key record.
+					 * @throws {LibSQLDatabaseError} If a database error occurs during the operation.
+					 */
 					new: (userId: string, description: string) =>
 						Effect.gen(function* () {
 							const key = yield* generateToken(userId, true);
@@ -71,6 +86,14 @@ export class SDKCore_REST_API extends Effect.Service<SDKCore_REST_API>()(
 									_clearLibSQLError('REST_API.tokens.new', cause),
 							})
 						),
+
+					/**
+					 * Deletes an API token for a user by its ID.
+					 * @param userId - The ID of the user whose token is to be deleted.
+					 * @param tokenId - The ID of the API token to delete.
+					 * @returns An Effect that resolves when the token is successfully deleted.
+					 * @throws {LibSQLDatabaseError} If a database error occurs during the operation.
+					 */
 					delete: (userId: string, tokenId: string) =>
 						dbService
 							.execute((db) =>
@@ -84,6 +107,13 @@ export class SDKCore_REST_API extends Effect.Service<SDKCore_REST_API>()(
 										_clearLibSQLError('REST_API.tokens.delete', cause),
 								})
 							),
+
+					/**
+					 * Verifies an API key and retrieves the associated user ID and rank.
+					 * @param key - The API key to verify.
+					 * @returns An Effect that resolves to an object containing userId, key, and rank if valid, or false if invalid.
+					 * @throws {LibSQLDatabaseError} If a database error occurs during the verification.
+					 */
 					verify: (key: string) =>
 						Effect.gen(function* () {
 							const apiKey = yield* dbService.execute((db) =>

--- a/packages/studiocms/src/sdk/modules/update.ts
+++ b/packages/studiocms/src/sdk/modules/update.ts
@@ -188,6 +188,11 @@ export class SDKCore_UPDATE extends Effect.Service<SDKCore_UPDATE>()(
 						})
 					)
 				),
+				/**
+				 * Updates the folder tree structure and cache.
+				 * @returns An Effect that resolves when the folder tree is updated.
+				 * @throws {LibSQLDatabaseError} If a database error occurs during the update.
+				 */
 				folderTree: Effect.gen(function* () {
 					const status = yield* isCacheEnabled;
 					yield* CLEAR.folderTree();
@@ -201,6 +206,11 @@ export class SDKCore_UPDATE extends Effect.Service<SDKCore_UPDATE>()(
 							_clearLibSQLError('UPDATE.folderTree', cause),
 					})
 				),
+				/**
+				 * Updates the folder list and cache.
+				 * @returns An Effect that resolves when the folder list is updated.
+				 * @throws {LibSQLDatabaseError} If a database error occurs during the update.
+				 */
 				folderList: Effect.gen(function* () {
 					const status = yield* isCacheEnabled;
 					yield* CLEAR.folderList();
@@ -214,6 +224,12 @@ export class SDKCore_UPDATE extends Effect.Service<SDKCore_UPDATE>()(
 							_clearLibSQLError('UPDATE.folderList', cause),
 					})
 				),
+				/**
+				 * Updates a folder in the database and refreshes related caches.
+				 * @param data - The folder data to update.
+				 * @returns An Effect that resolves to the updated folder data.
+				 * @throws {LibSQLDatabaseError} If a database error occurs during the update.
+				 */
 				folder: (data: tsPageFolderSelect) =>
 					Effect.gen(function* () {
 						const updated = yield* dbService.execute((db) =>
@@ -235,6 +251,11 @@ export class SDKCore_UPDATE extends Effect.Service<SDKCore_UPDATE>()(
 								_clearLibSQLError('UPDATE.folder', cause),
 						})
 					),
+				/**
+				 * Updates the latest StudioCMS version in the cache.
+				 * @returns An Effect that resolves to the latest version.
+				 * @throws {UnknownException} If an error occurs while fetching the latest version.
+				 */
 				latestVersion: () =>
 					Effect.gen(function* () {
 						const status = yield* isCacheEnabled;
@@ -252,6 +273,13 @@ export class SDKCore_UPDATE extends Effect.Service<SDKCore_UPDATE>()(
 							UnknownException: (cause) => _ClearUnknownError('UPDATE.latestVersion', cause),
 						})
 					),
+				/**
+				 * Updates the site configuration in the database and cache.
+				 * @param data - The new site configuration data.
+				 * @returns An Effect that resolves to the updated site configuration.
+				 * @throws {LibSQLDatabaseError} If a database error occurs during the update.
+				 * @throws {UnknownException} If an unknown error occurs during the update.
+				 */
 				siteConfig: (data: SiteConfig) =>
 					Effect.gen(function* () {
 						const status = yield* isCacheEnabled;
@@ -279,6 +307,14 @@ export class SDKCore_UPDATE extends Effect.Service<SDKCore_UPDATE>()(
 						})
 					),
 				page: {
+					/**
+					 * Updates a page by its ID, including content and data, and refreshes caches.
+					 * @param id - The ID of the page to update.
+					 * @param data - The new page data and content to update.
+					 * @returns An Effect that resolves to the updated page data.
+					 * @throws {LibSQLDatabaseError} If a database error occurs during the update.
+					 * @throws {UnknownException} If an unknown error occurs during the update.
+					 */
 					byId: (
 						id: string,
 						data: {
@@ -318,6 +354,14 @@ export class SDKCore_UPDATE extends Effect.Service<SDKCore_UPDATE>()(
 							})
 						);
 					},
+					/**
+					 * Updates a page by its slug, including content and data, and refreshes caches.
+					 * @param slug - The slug of the page to update.
+					 * @param data - The new page data and content to update.
+					 * @returns An Effect that resolves to the updated page data.
+					 * @throws {LibSQLDatabaseError} If a database error occurs during the update.
+					 * @throws {UnknownException} If an unknown error occurs during the update.
+					 */
 					bySlug: (
 						slug: string,
 						data: {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #628  <!-- If applicable add an issue number to this PR so it can be closed otherwise feel free to remove this. -->
- What does this PR change? Give us a brief description.

Add new helper function to get folders by name or ID, and then allow the `get.folderPages` helper to grab by usage of either. Also adds a bunch of jsDocs

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now retrieve folders in the SDK by either name or ID, expanding previous retrieval options.

* **Documentation**
  * Extensive JSDoc comments have been added across the codebase, providing clear descriptions for functions, methods, types, and configuration options. This improves clarity and maintainability for users referencing the SDK's API and configuration.
  * All major SDK modules now include detailed documentation for their methods, parameters, return values, and error handling.

* **Improvements**
  * Script handling during setup is now asynchronous to ensure completion before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->