### PR TITLE
refactor(version-modal): fix date time and modal sizing

### DIFF
--- a/.changeset/rotten-lions-show.md
+++ b/.changeset/rotten-lions-show.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Unifies date-time config on last updated check for version check modal

--- a/packages/studiocms/src/components/dashboard/component-scripts/dateTimeListener.ts
+++ b/packages/studiocms/src/components/dashboard/component-scripts/dateTimeListener.ts
@@ -1,12 +1,10 @@
+import { DTConfig } from './dateWithTimeAndZone.js';
+
 export function dateTimeListener(id: string) {
 	const lastCheckedDate = document.getElementById(id) as HTMLTimeElement;
 
-	lastCheckedDate.textContent = new Date(lastCheckedDate.dateTime).toLocaleString(undefined, {
-		month: 'short',
-		day: 'numeric',
-		year: 'numeric',
-		hour: 'numeric',
-		minute: 'numeric',
-		timeZoneName: 'short',
-	});
+	lastCheckedDate.textContent = new Date(lastCheckedDate.dateTime).toLocaleString(
+		undefined,
+		DTConfig
+	);
 }

--- a/packages/studiocms/src/components/dashboard/component-scripts/dateWithTimeAndZone.ts
+++ b/packages/studiocms/src/components/dashboard/component-scripts/dateWithTimeAndZone.ts
@@ -1,9 +1,12 @@
+export const DTConfig: Intl.DateTimeFormatOptions = {
+	month: 'short',
+	day: 'numeric',
+	year: 'numeric',
+	hour: 'numeric',
+	minute: 'numeric',
+	timeZoneName: 'short',
+};
+
 export function dateWithTimeAndZone(date: Date) {
-	return date.toLocaleString(undefined, {
-		month: 'numeric',
-		day: 'numeric',
-		year: 'numeric',
-		hour: 'numeric',
-		minute: 'numeric',
-	});
+	return date.toLocaleString(undefined, DTConfig);
 }

--- a/packages/studiocms/src/components/dashboard/sidebar-modals/VersionModal.astro
+++ b/packages/studiocms/src/components/dashboard/sidebar-modals/VersionModal.astro
@@ -80,10 +80,17 @@ const lastChecked = new Date(latestVersion.lastCacheUpdate);
         </div>
     </div>
 </Modal>
+
+<style is:global>
+#version-modal.sui-modal.lg {
+  width: 800px !important;
+}
+</style>
+
 <style>
 	.version-modal-top-row {
         display: grid;
-        grid-template-columns: 1fr 1fr 2fr;
+        grid-template-columns: 1fr 1fr 3fr;
         gap: 1rem;
     }
 


### PR DESCRIPTION
This pull request focuses on unifying the date-time formatting configuration used across the version check modal and related dashboard components in `studiocms`. The main change is the introduction of a shared `DTConfig` object, which ensures consistent formatting for all date-time displays related to version checking. Additionally, there is a minor UI adjustment to the version modal.

**Date-Time Formatting Unification:**

* Introduced a shared `DTConfig` object in `dateWithTimeAndZone.ts` to centralize and standardize date-time formatting options. All relevant functions now use this configuration for consistency.
* Updated `dateTimeListener` in `dateTimeListener.ts` to use the new `DTConfig` for formatting, ensuring all displayed dates follow the unified format.
* The `dateWithTimeAndZone` function now leverages `DTConfig` for its formatting logic.

**UI Improvements:**

* Increased the width of the version modal and adjusted the grid column layout for better display of version information in `VersionModal.astro`.

**Documentation:**

* Added a changeset entry summarizing the unification of date-time config for the version check modal.