### PR TITLE
fix: add 'studiocms-no-reply' to ignore_usernames in auto_review settings

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -36,6 +36,8 @@ reviews:
     ignore_title_keywords: []
     labels: []
     drafts: false
+    ignore_usernames:
+      - studiocms-no-reply
     base_branches: []
   finishing_touches:
     docstrings:


### PR DESCRIPTION
This pull request introduces a configuration update to the `.coderabbit.yaml` file. The main change is the addition of a new username to be ignored during the review process.

* Review configuration:
  * Added `studiocms-no-reply` to the `ignore_usernames` list, so pull requests from this user will be ignored by the review automation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated automated review configuration to ignore a specific no-reply account in auto-reviews, reducing noise and keeping review threads focused.
  - No changes to product features or behavior; this is a maintenance update to internal tooling only.
  - All other settings remain unchanged, and there is no impact on performance, user data, or compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->