### PR TITLE
fix(LoginPreview): add defaultLang prop for usage when middleware is not available

### DIFF
--- a/.changeset/open-tools-hang.md
+++ b/.changeset/open-tools-hang.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Fix missing variable during First time setup

--- a/packages/studiocms/src/components/dashboard/configuration/LoginPreview.astro
+++ b/packages/studiocms/src/components/dashboard/configuration/LoginPreview.astro
@@ -1,7 +1,7 @@
 ---
 import { Image } from 'astro:assets';
 import { validImages } from 'studiocms:auth/utils/validImages';
-import { useTranslations } from 'studiocms:i18n';
+import { type UiLanguageKeys, useTranslations } from 'studiocms:i18n';
 import { Card } from 'studiocms:ui/components/card';
 
 const imageFilter = (filterName: string) =>
@@ -33,9 +33,11 @@ const curves = getLoginImage('studiocms-curves');
 interface Props {
 	light?: ImageMetadata;
 	dark?: ImageMetadata;
+
+	defaultLang?: UiLanguageKeys;
 }
 
-const { light, dark } = Astro.props as Props;
+const { light, dark, defaultLang } = Astro.props as Props;
 
 const lightSrc = light ? light : blobs.light;
 const darkSrc = dark ? dark : blobs.dark;
@@ -55,7 +57,7 @@ const stringifyable = {
 	},
 };
 
-const lang = Astro.locals.StudioCMS.defaultLang;
+const lang = defaultLang || Astro.locals.StudioCMS.defaultLang;
 const t = useTranslations(lang, '@studiocms/dashboard:configuration');
 ---
 

--- a/packages/studiocms/src/routes/firstTimeSetupRoutes/1-start.astro
+++ b/packages/studiocms/src/routes/firstTimeSetupRoutes/1-start.astro
@@ -53,7 +53,7 @@ const ogSelectOptions = validImages.map(({ label, name: value }) => ({ label, va
                     <AccordionItem>
                         <div slot="summary">Login Page Preview</div>
 
-                        <LoginPreview />
+                        <LoginPreview defaultLang={'en'} />
                     </AccordionItem>
                 </Accordion>
 

--- a/playground/studiocms.config.mts
+++ b/playground/studiocms.config.mts
@@ -4,7 +4,7 @@ import wysiwyg from '@studiocms/wysiwyg';
 import { defineStudioCMSConfig } from 'studiocms/config';
 
 export default defineStudioCMSConfig({
-	dbStartPage: false,
+	dbStartPage: true,
 	verbose: true,
 	plugins: [md(), blog(), wysiwyg()],
 	features: {


### PR DESCRIPTION
This pull request addresses a missing variable issue during the first-time setup process and improves language handling in the `LoginPreview` component. The changes ensure that a default language is always set for translations, preventing errors when the language variable is missing.

**Bug Fixes and First-Time Setup Improvements:**

* Fixed a missing variable bug during the first-time setup by ensuring the `defaultLang` property is passed to the `LoginPreview` component, defaulting to `'en'` if not provided. [[1]](diffhunk://#diff-6c19387483bae9d2602ee476f13d3fec29e521a9923bb0a4afe42460c9626557R1-R5) [[2]](diffhunk://#diff-f66c82050bba1d03fbfec7dc9e9cec4f4c015e5582ab5718b61d91b9ae4d56feL56-R56)

**Internationalization and Language Handling:**

* Updated the `LoginPreview` component to accept an optional `defaultLang` prop and use it for translations, falling back to the global default language if not specified. [[1]](diffhunk://#diff-947740443175af60f21901c8a889a385b82a64b44a4ebbd8cafda9bfd940b302L4-R4) [[2]](diffhunk://#diff-947740443175af60f21901c8a889a385b82a64b44a4ebbd8cafda9bfd940b302R36-R40) [[3]](diffhunk://#diff-947740443175af60f21901c8a889a385b82a64b44a4ebbd8cafda9bfd940b302L58-R60)

**Configuration and Development Environment:**

* Changed the `dbStartPage` configuration in `studiocms.config.mts` from `false` to `true` to enable the database start page in the playground environment.