### PR TITLE
refactor(middleware): remove deprecated locals

### DIFF
--- a/.changeset/kind-games-dance.md
+++ b/.changeset/kind-games-dance.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Remove deprecated locals from middleware in favor of joined locals object

--- a/packages/studiocms/src/middleware/index.ts
+++ b/packages/studiocms/src/middleware/index.ts
@@ -59,14 +59,6 @@ export const onRequest = defineMiddlewareRouter([
 				latestVersion,
 			});
 
-			// Set deprecated locals for backward compatibility
-			context.locals.SCMSGenerator = `StudioCMS v${SCMSVersion}`;
-			context.locals.SCMSUiGenerator = `StudioCMS UI v${SCMSUiVersion}`;
-			context.locals.latestVersion = latestVersion;
-			context.locals.siteConfig = siteConfig ?? makeFallbackSiteConfig();
-			context.locals.defaultLang = defaultLang;
-			context.locals.routeMap = StudioCMSRoutes;
-
 			return next();
 		}),
 	},
@@ -102,11 +94,6 @@ export const onRequest = defineMiddlewareRouter([
 				emailVerificationEnabled,
 				userPermissionLevel,
 			});
-
-			// Set deprecated locals for backward compatibility
-			context.locals.userSessionData = userSessionData;
-			context.locals.emailVerificationEnabled = emailVerificationEnabled;
-			context.locals.userPermissionLevel = userPermissionLevel;
 
 			// Continue to the next middleware
 			return next();
@@ -176,9 +163,6 @@ export const onRequest = defineMiddlewareRouter([
 			yield* setLocals(context, SetLocal.PLUGINS, {
 				editorCSRFToken: csrfToken,
 			});
-
-			// Set deprecated locals for backward compatibility
-			context.locals.wysiwygCsrfToken = csrfToken;
 
 			return next();
 		}),

--- a/packages/studiocms/src/virtual.d.ts
+++ b/packages/studiocms/src/virtual.d.ts
@@ -606,52 +606,6 @@ interface StudioCMSLocals {
 
 declare namespace App {
 	interface Locals {
-		/**
-		 * @deprecated - use the new value from locals.StudioCMS object instead
-		 */
-		latestVersion: import('./virtuals/sdk/types/index').VersionCacheObject;
-		/**
-		 * @deprecated - use the new value from locals.StudioCMS object instead
-		 */
-		siteConfig: import('./virtuals/sdk/types/index').SiteConfigCacheObject;
-		/**
-		 * @deprecated - use the new value from locals.StudioCMS object instead
-		 */
-		userSessionData: import('./virtuals/auth/types').UserSessionData;
-		/**
-		 * @deprecated - use the new value from locals.StudioCMS object instead
-		 */
-		emailVerificationEnabled: boolean;
-		/**
-		 * @deprecated - use the new value from locals.StudioCMS object instead
-		 */
-		defaultLang: import('./virtuals/i18n/config').UiTranslationKey;
-		/**
-		 * @deprecated - use the new value from locals.StudioCMS object instead
-		 */
-		routeMap: typeof import('./virtuals/lib/routeMap').StudioCMSRoutes;
-		/**
-		 * @deprecated - use the new value from locals.StudioCMS object instead
-		 */
-		SCMSGenerator: string;
-		/**
-		 * @deprecated - use the new value from locals.StudioCMS object instead
-		 */
-		SCMSUiGenerator: string;
-		/**
-		 * @deprecated - use the new value from locals.StudioCMS object instead
-		 */
-		userPermissionLevel: {
-			isVisitor: boolean;
-			isEditor: boolean;
-			isAdmin: boolean;
-			isOwner: boolean;
-		};
-		/**
-		 * @deprecated - use the new value from locals.StudioCMS object instead
-		 */
-		wysiwygCsrfToken: string;
-
 		StudioCMS: StudioCMSLocals;
 	}
 }


### PR DESCRIPTION
This pull request removes deprecated locals from the `studiocms` middleware in favor of using a unified locals object. This change helps to clean up the codebase and reduces redundancy by ensuring that all necessary data is accessed through the joined locals object rather than legacy individual locals.

**Middleware locals cleanup:**

* Removed assignments of deprecated locals such as `SCMSGenerator`, `SCMSUiGenerator`, `latestVersion`, `siteConfig`, `defaultLang`, and `routeMap` in `packages/studiocms/src/middleware/index.ts`.
* Removed deprecated locals for user session data, email verification, and permission level in `packages/studiocms/src/middleware/index.ts`.
* Removed deprecated local for the WYSIWYG CSRF token in `packages/studiocms/src/middleware/index.ts`.

**Documentation:**

* Added a changeset describing the removal of deprecated locals in favor of a joined locals object. (.changeset/kind-games-dance.md)