### PR TITLE
feat(i18n): enhance translation loader to ignore files with over 10% missing strings

### DIFF
--- a/.changeset/wild-toys-laugh.md
+++ b/.changeset/wild-toys-laugh.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Tweaks i18n loader to ignore translations with more than 10% of the translations missing


### PR DESCRIPTION
This pull request introduces a patch to the StudioCMS internationalization (i18n) loader, improving the way translation files are imported and validated. The main enhancement is that translation files with more than 10% missing (empty or whitespace-only) strings are now ignored, preventing incomplete translations from being loaded into the system. This change adds several utility functions to check translation completeness and refactors the translation import logic to filter out low-quality translations.

**Internationalization (i18n) loader improvements:**

* Added utility functions (`checkStrings` and `checkThreshold`) to recursively count translation strings and determine if a translation file has more than 10% missing strings, ensuring that only sufficiently complete translations are loaded.
* Refactored the translation import process by introducing `verifyAndImportTranslation`, `translationMap`, and `filterCallback` functions to validate and filter translations before including them in the final set.
* Updated the logic for assembling the `serverUiTranslations` object: translations with excessive missing strings are now excluded, and translation files are filtered and processed asynchronously for better reliability and maintainability.

**Documentation and type improvements:**

* Improved comments and documentation for translation-related functions and constants, clarifying their purpose and usage.

**Minor technical update:**

* Updated the dynamic import for base English translations to use the `with: { type: 'json' }` option, improving compatibility with newer TypeScript versions.

These changes collectively make the i18n loader more robust by ensuring that only high-quality, sufficiently complete translations are loaded, which helps maintain a better user experience for non-English locales.