### PR TITLE
refactor(i18n): restructure internationalization module and update imports

### DIFF
--- a/.changeset/deep-queens-cough.md
+++ b/.changeset/deep-queens-cough.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Renames internal i18n file to server.ts instead of index.ts

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -45,8 +45,7 @@
     },
     {
       "groupName": "Effect Dependencies",
-      "matchFileNames": ["packages/@withstudiocms/effect/**"],
-      "matchPackageNames": ["effect", "@effect/**"],
+      "matchPackageNames": ["effect", "@effect/**", "!@effect/language-service"],
       "labels": ["effect-deps"]
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -45,6 +45,7 @@
     },
     {
       "groupName": "Effect Dependencies",
+      "matchManagers": ["npm"],
       "matchPackageNames": ["effect", "@effect/**", "!@effect/language-service"],
       "labels": ["effect-deps"]
     },

--- a/packages/studiocms/src/index.ts
+++ b/packages/studiocms/src/index.ts
@@ -310,7 +310,7 @@ export const studiocms = defineIntegration({
 							'studiocms:auth/scripts/three': ambientScripts(['./virtuals/auth/scripts/three.js']),
 							'studiocms:i18n/virtual': `export const availableTranslationFileKeys = ${JSON.stringify(availableTranslationFileKeys)};`,
 							'studiocms:i18n': dynamicWithAstroVirtual({
-								dynamicExports: ['./virtuals/i18n/index.js'],
+								dynamicExports: ['./virtuals/i18n/server.js'],
 								astroComponents: {
 									LanguageSelector: './virtuals/i18n/LanguageSelector.astro',
 								},

--- a/packages/studiocms/src/virtual.d.ts
+++ b/packages/studiocms/src/virtual.d.ts
@@ -125,19 +125,19 @@ declare module 'studiocms:i18n/virtual' {
 }
 
 declare module 'studiocms:i18n' {
-	export const staticPaths: typeof import('./virtuals/i18n/index.js').staticPaths;
-	export const getLangFromUrl: typeof import('./virtuals/i18n/index.js').getLangFromUrl;
-	export const useTranslations: typeof import('./virtuals/i18n/index.js').useTranslations;
-	export const useTranslatedPath: typeof import('./virtuals/i18n/index.js').useTranslatedPath;
-	export const languageSelectorOptions: typeof import('./virtuals/i18n/index.js').languageSelectorOptions;
-	export const getCurrentURLPath: typeof import('./virtuals/i18n/index.js').getCurrentURLPath;
-	export const switchLanguage: typeof import('./virtuals/i18n/index.js').switchLanguage;
-	export type UiLanguageKeys = import('./virtuals/i18n/index.js').UiLanguageKeys;
-	export type UiTranslations = import('./virtuals/i18n/index.js').UiTranslations;
-	export const defaultLang: typeof import('./virtuals/i18n/index.js').defaultLang;
+	export type UiLanguageKeys = import('./virtuals/i18n/server').UiLanguageKeys;
+	export type UiTranslations = import('./virtuals/i18n/server').UiTranslations;
+	export const staticPaths: typeof import('./virtuals/i18n/server').staticPaths;
+	export const getLangFromUrl: typeof import('./virtuals/i18n/server').getLangFromUrl;
+	export const useTranslations: typeof import('./virtuals/i18n/server').useTranslations;
+	export const useTranslatedPath: typeof import('./virtuals/i18n/server').useTranslatedPath;
+	export const getCurrentURLPath: typeof import('./virtuals/i18n/server').getCurrentURLPath;
+	export const switchLanguage: typeof import('./virtuals/i18n/server').switchLanguage;
+	export const defaultLang: typeof import('./virtuals/i18n/server').defaultLang;
 }
 
 declare module 'studiocms:i18n/client' {
+	export type UiTranslationKey = import('./virtuals/i18n/client').UiTranslationKey;
 	export const $localeSettings: typeof import('./virtuals/i18n/client').$localeSettings;
 	export const $locale: typeof import('./virtuals/i18n/client').$locale;
 	export const format: typeof import('./virtuals/i18n/client').format;
@@ -148,7 +148,6 @@ declare module 'studiocms:i18n/client' {
 	export const updateElmLabel: typeof import('./virtuals/i18n/client').updateElmLabel;
 	export const defaultLang: typeof import('./virtuals/i18n/client').defaultLang;
 	export const uiTranslationsAvailable: typeof import('./virtuals/i18n/client').uiTranslationsAvailable;
-	export type UiTranslationKey = import('./virtuals/i18n/client').UiTranslationKey;
 	export const pageHeaderUpdater: typeof import('./virtuals/i18n/client').pageHeaderUpdater;
 	export const updateSelectElmLabel: typeof import('./virtuals/i18n/client').updateSelectElmLabel;
 	export const updateElmPlaceholder: typeof import('./virtuals/i18n/client').updateElmPlaceholder;

--- a/packages/studiocms/src/virtual.d.ts
+++ b/packages/studiocms/src/virtual.d.ts
@@ -134,6 +134,7 @@ declare module 'studiocms:i18n' {
 	export const getCurrentURLPath: typeof import('./virtuals/i18n/server').getCurrentURLPath;
 	export const switchLanguage: typeof import('./virtuals/i18n/server').switchLanguage;
 	export const defaultLang: typeof import('./virtuals/i18n/server').defaultLang;
+	export const LanguageSelector: typeof import('./virtuals/i18n/LanguageSelector.astro').default;
 }
 
 declare module 'studiocms:i18n/client' {

--- a/packages/studiocms/src/virtuals/i18n/LanguageSelector.astro
+++ b/packages/studiocms/src/virtuals/i18n/LanguageSelector.astro
@@ -1,5 +1,5 @@
 ---
-import { languageSelectorOptions } from './index.js';
+import { languageSelectorOptions } from './config.js';
 
 // TODO: Update the language selector's styles to match StudioCMS's new design
 ---

--- a/packages/studiocms/src/virtuals/i18n/config.ts
+++ b/packages/studiocms/src/virtuals/i18n/config.ts
@@ -292,6 +292,17 @@ export type ClientUiTranslations = Record<UiTranslationKey, ComponentsJSON>;
 export const uiTranslationsAvailable = Object.keys(serverUiTranslations) as UiTranslationKey[];
 
 /**
+ * Represents an option for selecting a language in the UI.
+ *
+ * @property key - The translation key associated with the language option.
+ * @property value - The display value for the language option.
+ */
+export interface LanguageSelectorOption {
+	key: UiTranslationKey;
+	value: string;
+}
+
+/**
  * Generates an array of language selector options from the available server UI translations.
  * Each option contains a `key` representing the language code and a `value` representing the display name of the language.
  *
@@ -300,7 +311,9 @@ export const uiTranslationsAvailable = Object.keys(serverUiTranslations) as UiTr
  *
  * @returns An array of objects, each with `key` and `value` properties for language selection.
  */
-export const languageSelectorOptions = Object.keys(serverUiTranslations).map((key) => ({
-	key,
-	value: serverUiTranslations[key].displayName,
-}));
+export const languageSelectorOptions: LanguageSelectorOption[] = Object.keys(serverUiTranslations)
+	.map((key) => ({
+		key: key as UiTranslationKey,
+		value: serverUiTranslations[key].displayName,
+	}))
+	.sort((a, b) => a.value.localeCompare(b.value));

--- a/packages/studiocms/src/virtuals/i18n/config.ts
+++ b/packages/studiocms/src/virtuals/i18n/config.ts
@@ -298,8 +298,8 @@ export const uiTranslationsAvailable = Object.keys(serverUiTranslations) as UiTr
  * @property value - The display value for the language option.
  */
 export interface LanguageSelectorOption {
-	key: UiTranslationKey;
-	value: string;
+	readonly key: UiTranslationKey;
+	readonly value: string;
 }
 
 /**
@@ -312,8 +312,9 @@ export interface LanguageSelectorOption {
  * @returns An array of objects, each with `key` and `value` properties for language selection.
  */
 export const languageSelectorOptions: LanguageSelectorOption[] = Object.keys(serverUiTranslations)
-	.map((key) => ({
-		key: key as UiTranslationKey,
-		value: serverUiTranslations[key].displayName,
-	}))
-	.sort((a, b) => a.value.localeCompare(b.value));
+	.map((key) => {
+		const displayName = serverUiTranslations[key]?.displayName;
+		const value = typeof displayName === 'string' && displayName.trim() ? displayName : String(key);
+		return { key: key as UiTranslationKey, value };
+	})
+	.sort((a, b) => a.value.localeCompare(b.value, undefined, { sensitivity: 'base' }));

--- a/packages/studiocms/src/virtuals/i18n/config.ts
+++ b/packages/studiocms/src/virtuals/i18n/config.ts
@@ -290,3 +290,17 @@ export type ClientUiTranslations = Record<UiTranslationKey, ComponentsJSON>;
  * The UI translations available in the StudioCMS app.
  */
 export const uiTranslationsAvailable = Object.keys(serverUiTranslations) as UiTranslationKey[];
+
+/**
+ * Generates an array of language selector options from the available server UI translations.
+ * Each option contains a `key` representing the language code and a `value` representing the display name of the language.
+ *
+ * @remarks
+ * This is typically used to populate language selection dropdowns in the UI.
+ *
+ * @returns An array of objects, each with `key` and `value` properties for language selection.
+ */
+export const languageSelectorOptions = Object.keys(serverUiTranslations).map((key) => ({
+	key,
+	value: serverUiTranslations[key].displayName,
+}));

--- a/packages/studiocms/src/virtuals/i18n/server.ts
+++ b/packages/studiocms/src/virtuals/i18n/server.ts
@@ -106,21 +106,6 @@ export function useTranslatedPath(
 }
 
 /**
- * Generates an array of language selector options from the `uiTranslations` object.
- * Each option contains a `key` and a `value` where:
- * - `key` is a language key from `UiLanguageKeys`.
- * - `value` is the display name of the language.
- *
- * @returns An array of objects representing language selector options.
- */
-export const languageSelectorOptions = Object.keys(uiTranslations).map((key) => {
-	return {
-		key: key as UiLanguageKeys,
-		value: uiTranslations[key as UiLanguageKeys].displayName,
-	};
-});
-
-/**
  * Extracts the language key from the given URL's pathname.
  *
  * @param url - The URL object from which to extract the language key.


### PR DESCRIPTION
This pull request refactors the internal i18n (internationalization) module in the StudioCMS integration for improved organization and clarity. The main changes involve renaming the primary i18n file, moving the `languageSelectorOptions` logic to a more appropriate location, and updating import paths to reflect these changes.

**i18n File Structure Refactor:**
* Renamed the main i18n module file from `index.ts` to `server.ts` for clarity and better alignment with its purpose. (`.changeset/deep-queens-cough.md`, [.changeset/deep-queens-cough.mdR1-R5](diffhunk://#diff-fe1e858bc5e664571d39b47ca01d5b522fa693140146d2e26a8a7d3207bde85aR1-R5))
* Updated all internal references to the i18n module from `index.js` to `server.js` in the integration setup (`packages/studiocms/src/index.ts`).

**Language Selector Logic Improvements:**
* Moved the `languageSelectorOptions` export from the i18n server module to the dedicated config file (`config.ts`), centralizing configuration and improving maintainability. (`packages/studiocms/src/virtuals/i18n/config.ts`, [packages/studiocms/src/virtuals/i18n/config.tsR293-R306](diffhunk://#diff-657dcf566dee0b239e984cf9f2f274711f39b492b33ec884de2779e8f837ded9R293-R306))
* Updated the import of `languageSelectorOptions` in the `LanguageSelector.astro` component to use the new config file instead of the previous index. (`packages/studiocms/src/virtuals/i18n/LanguageSelector.astro`, [packages/studiocms/src/virtuals/i18n/LanguageSelector.astroL2-R2](diffhunk://#diff-737e0382a455811e211441970d7da7d6b240236446cbef8b56279a454a918f76L2-R2))
* Removed the duplicate definition of `languageSelectorOptions` from the newly renamed `server.ts` file to avoid redundancy. (`packages/studiocms/src/virtuals/i18n/server.ts`, [packages/studiocms/src/virtuals/i18n/server.tsL108-L122](diffhunk://#diff-bb8bf16019214fb0e0adc66d6145329f99e50b83c9e66888a2b9e6ec2296ddc7L108-L122))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - i18n surface reorganized toward a server-focused implementation; related imports adjusted.
  - Language selector options moved to a dedicated config source; UI and behavior unchanged.

- Chores
  - Added a changeset entry for a patch release.
  - Dependency update rules broadened to package-name filtering with an explicit exclusion for one package.

- Developer Experience
  - Public type and module organization updated for a clearer i18n surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->