### PR TITLE
docs: update README for clarity and organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ To see how to get started with StudioCMS, check out the [StudioCMS Docs](https:/
 
 > [!IMPORTANT]
 > This project is still in early development and it is not yet ready for production use. If you encounter any issues or have ideas for new features, please let us know by [opening an issue](https://github.com/withstudiocms/studiocms/issues/new/choose) on our GitHub repository.
+>
+> During our `0.1.0-beta.x` phase, breaking changes may ship in patch releases.
 
 ## Packages in this repository
 
@@ -32,11 +34,11 @@ To see how to get started with StudioCMS, check out the [StudioCMS Docs](https:/
 | [@studiocms/discord](./packages/@studiocms/discord/) | Authentication | Not Yet Available |
 | [@studiocms/github](./packages/@studiocms/github/) | Authentication | Not Yet Available |
 | [@studiocms/google](./packages/@studiocms/google/) | Authentication | Not Yet Available |
-| [@studiocms/html](./packages/@studiocms/html) | Renderer | Not Yet Available |
-| [@studiocms/markdoc](./packages/@studiocms/markdoc) | Renderer | Not Yet Available |
-| [@studiocms/md](./packages/@studiocms/md) | Renderer | Not Yet Available |
-| [@studiocms/mdx](./packages/@studiocms/mdx) | Renderer | Not Yet Available |
-| [@studiocms/wysiwyg](./packages/@studiocms/wysiwyg) | Renderer | Not Yet Available |
+| [@studiocms/html](./packages/@studiocms/html/) | Renderer | Not Yet Available |
+| [@studiocms/markdoc](./packages/@studiocms/markdoc/) | Renderer | Not Yet Available |
+| [@studiocms/md](./packages/@studiocms/md/) | Renderer | Not Yet Available |
+| [@studiocms/mdx](./packages/@studiocms/mdx/) | Renderer | Not Yet Available |
+| [@studiocms/wysiwyg](./packages/@studiocms/wysiwyg/) | Renderer | Not Yet Available |
 | [@studiocms/cloudinary-image-service](./packages/@studiocms/cloudinary-image-service/) | Image Service | Not Yet Available |
 | [@studiocms/blog](./packages/@studiocms/blog/) | Front-End | Not Yet Available |
 
@@ -53,32 +55,32 @@ To see how to get started with StudioCMS, check out the [StudioCMS Docs](https:/
 
 ## Getting Started with our Development Playground
 
-The StudioCMS Playground is intended for usage when developing studiocms within the mono-repo and should not be used to directly test or host StudioCMS. If your goal is to test our CMS, please use our latest release from [NPM](https://npm.im/studiocms)
+The StudioCMS Playground is intended for usage when developing StudioCMS within the monorepo and should not be used to directly test or host StudioCMS. If your goal is to test our CMS, please use our latest release from [npm](https://npm.im/studiocms).
 
 Steps to get a running playground should be the following:
 
 - Clone the GitHub repository
 - Run `pnpm i --frozen-lockfile`
-- Change `dbStartPage` in the node playground's [StudioCMS config](./playground/studiocms.config.mjs) config to `true`
+- Change `dbStartPage` in the Node playground's [StudioCMS config](./playground/studiocms.config.mjs) to `true`.
 - Ensure `.env` variables are configured (see [`.env.demo`](./playground/.env.demo) for an example of available environment variables)
 - Run the following in this order:
   - `pnpm build:studiocms` - Build the StudioCMS packages (required to get the current table schema for the StudioCMS integration)
   - `pnpm playground:push` - Push to your libSQL database assigned via environment variables
   - `pnpm dev` - Starts the Dev server connected to the linked database (as well as builds all repo packages)
 
-Once that process completes successfully you are ready to navigate to http://localhost:4321/start and follow the instructions to get your database initialized.
+Once that process completes successfully you are ready to navigate to `http://localhost:4321/start` and follow the instructions to get your database initialized.
 
-Once complete you will be redirected and asked to shutdown and change the config option `dbStartPage` to `false` at which point that will enable full functionality of the CMS. you can now restart the dev server with `pnpm dev` to continue working with our development playground.
+Once complete, you will be redirected and asked to shut down and change the config option `dbStartPage` to `false`. This enables full functionality of the CMS. You can now restart the dev server with `pnpm dev` to continue working with our development playground.
 
-That will give you a running dev environment of what we work with daily.
+That will give you the dev environment we work with daily.
 
-To start the playground again use the command `pnpm dev`
+To start the playground again, use the command `pnpm dev`.
 
 ## Our ToolSet
 
 For an up-to-date list of our main tools check out our [`.prototools`](.prototools) file
 
-For more information about Proto checkout [Proto's Website](https://moonrepo.dev/proto)
+For more information about Proto, check out [Proto's website](https://moonrepo.dev/proto).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,81 @@
 
 [![NPM Version](https://img.shields.io/npm/v/studiocms)](https://npm.im/studiocms)
 [![Formatted with Biome](https://img.shields.io/badge/Formatted_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev/)
-[![Built with Astro](https://astro.badg.es/v2/built-with-astro/tiny.svg)](https://astro.build)
 [![Crowdin](https://badges.crowdin.net/studiocms/localized.svg)](https://crowdin.com/project/studiocms)
-[![pkg.pr.new](https://pkg.pr.new/badge/withstudiocms/studiocms?style=flat&color=000&logoSize=auto)](https://pkg.pr.new/~/withstudiocms/studiocms)
+[![pkg.pr.new](https://img.shields.io/badge/Continuous%20Releases-pkg.pr.new-8A2BE2?logo=pkgsrc&logoColor=FFF)](https://pkg.pr.new/~/withstudiocms/studiocms)
+[![Built with Astro](https://astro.badg.es/v2/built-with-astro/tiny.svg)](https://astro.build)
 
-This is an SSR CMS built with AstroDB for the Astro Ecosystem.
+StudioCMS is an SSR Headless CMS built with AstroDB for the Astro Ecosystem.
 
-To see how to get started, check out the [StudioCMS Docs](./packages/studiocms/README.md).
+To see how to get started with StudioCMS, check out the [StudioCMS Docs](https://docs.studiocms.dev).
 
 > [!IMPORTANT]
 > This project is still in early development and it is not yet ready for production use. If you encounter any issues or have ideas for new features, please let us know by [opening an issue](https://github.com/withstudiocms/studiocms/issues/new/choose) on our GitHub repository.
 
-## Sponsors
+## Packages in this repository
 
-<a href="https://tur.so/studiocms" rel="sponsored" target="_blank"><img src="https://turso.tech/logokit/turso-logo-illustrated.svg" width="400px" alt="Turso logo" /></a>
-<a href="https://www.skip2.net/?utm_source=studiocms" rel="sponsored" target="_blank"><img src="https://www.skip2.net/images/logo.svg" width="400px" alt="Skip2 logo" /></a>
+### Astro Integrations
+
+| Package | Test Coverage |
+| ------- | ------------- |
+| [studiocms](./packages/studiocms/) | Not Yet Available |
+| [@studiocms/devapps](./packages/@studiocms/devapps/) | Not Yet Available |
+
+### StudioCMS Plugins
+
+| Package | Category | Test Coverage |
+| ------- | -------- | ------------- |
+| [@studiocms/auth0](./packages/@studiocms/auth0/) | Authentication | Not Yet Available |
+| [@studiocms/discord](./packages/@studiocms/discord/) | Authentication | Not Yet Available |
+| [@studiocms/github](./packages/@studiocms/github/) | Authentication | Not Yet Available |
+| [@studiocms/google](./packages/@studiocms/google/) | Authentication | Not Yet Available |
+| [@studiocms/html](./packages/@studiocms/html) | Renderer | Not Yet Available |
+| [@studiocms/markdoc](./packages/@studiocms/markdoc) | Renderer | Not Yet Available |
+| [@studiocms/md](./packages/@studiocms/md) | Renderer | Not Yet Available |
+| [@studiocms/mdx](./packages/@studiocms/mdx) | Renderer | Not Yet Available |
+| [@studiocms/wysiwyg](./packages/@studiocms/wysiwyg) | Renderer | Not Yet Available |
+| [@studiocms/cloudinary-image-service](./packages/@studiocms/cloudinary-image-service/) | Image Service | Not Yet Available |
+| [@studiocms/blog](./packages/@studiocms/blog/) | Front-End | Not Yet Available |
+
+### Tools and Utilities
+
+| Package | Test Coverage |
+| ------- | ------------- |
+| [@withstudiocms/auth-kit](./packages/@withstudiocms/auth-kit/) | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=withstudiocms_auth_kit)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@withstudiocms/buildkit](./packages/@withstudiocms/buildkit/) | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=withstudiocms_buildkit)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@withstudiocms/component-registry](./packages/@withstudiocms/component-registry/) | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=withstudiocms_component_registry)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@withstudiocms/config-utils](./packages/@withstudiocms/config-utils/) | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=withstudiocms_config_utils)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@withstudiocms/effect](./packages/@withstudiocms/effect/) | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=withstudiocms_effect)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@withstudiocms/internal_helpers](./packages/@withstudiocms/internal_helpers/) | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=withstudiocms_internal_helpers)](https://codecov.io/github/withstudiocms/studiocms) |
+
+## Getting Started with our Development Playground
+
+The StudioCMS Playground is intended for usage when developing studiocms within the mono-repo and should not be used to directly test or host StudioCMS. If your goal is to test our CMS, please use our latest release from [NPM](https://npm.im/studiocms)
+
+Steps to get a running playground should be the following:
+
+- Clone the GitHub repository
+- Run `pnpm i --frozen-lockfile`
+- Change `dbStartPage` in the node playground's [StudioCMS config](./playground/studiocms.config.mjs) config to `true`
+- Ensure `.env` variables are configured (see [`.env.demo`](./playground/.env.demo) for an example of available environment variables)
+- Run the following in this order:
+  - `pnpm build:studiocms` - Build the StudioCMS packages (required to get the current table schema for the StudioCMS integration)
+  - `pnpm playground:push` - Push to your libSQL database assigned via environment variables
+  - `pnpm dev` - Starts the Dev server connected to the linked database (as well as builds all repo packages)
+
+Once that process completes successfully you are ready to navigate to http://localhost:4321/start and follow the instructions to get your database initialized.
+
+Once complete you will be redirected and asked to shutdown and change the config option `dbStartPage` to `false` at which point that will enable full functionality of the CMS. you can now restart the dev server with `pnpm dev` to continue working with our development playground.
+
+That will give you a running dev environment of what we work with daily.
+
+To start the playground again use the command `pnpm dev`
+
+## Our ToolSet
+
+For an up-to-date list of our main tools check out our [`.prototools`](.prototools) file
+
+For more information about Proto checkout [Proto's Website](https://moonrepo.dev/proto)
 
 ## Contributing
 
@@ -38,39 +98,10 @@ Please note that by contributing to this project, you agree to our [Code of Cond
 
 We have an active community of developers on the StudioCMS [Discord Server](https://chat.studiocms.dev/). Feel free to join and connect with other contributors, ask questions, or discuss ideas related to this project or other StudioCMS projects.
 
-## Our ToolSet
+## Sponsors
 
-For an up-to-date list of our main tools check out our [`.prototools`](.prototools) file
-
-For more information about Proto checkout [Proto's Website](https://moonrepo.dev/proto)
-
-## How to use the playgrounds
-
-At the moment these are the current steps for setting up the main StudioCMS playground.
-
-This is intended for testing and development, since we have not yet released a package to play with use these instruction _at your own risk_ This project is still very experimental
-
-The primary playground is the [Node Playground](./playground/)
-
-Steps to get a running playground should be the following:
-
-- Clone the GitHub repository
-- Run `pnpm i --frozen-lockfile`
-- Change `dbStartPage` in the node playground's [StudioCMS config](./playground/studiocms.config.mjs) config to `true`
-- Ensure `.env` variables are configured (see [`.env.demo`](./playground/.env.demo) for an example of available environment variables)
-
-  Commands to run:
-
-  - `pnpm playground:push` - Push to your libSQL database assigned via environment variables
-  - `pnpm dev` - Starts the Dev server connected to the linked database (as well as builds all repo packages)
-
-Once that process completes successfully you are ready to navigate to http://localhost:4321/start and follow the instructions to get started.
-
-It will redirect and ask you to shutdown and change the above mentioned config option `dbStartPage` to `false` at which point that will enable full functionality of the CMS. you can now restart the dev server with `pnpm dev` to continue viewing your new site!
-
-That will give you a running dev environment of what we work with daily.
-
-To start the playground again use the command `pnpm dev`
+<a href="https://tur.so/studiocms" rel="sponsored" target="_blank"><img src="https://turso.tech/logokit/turso-logo-illustrated.svg" width="400px" alt="Turso logo" /></a>
+<a href="https://www.skip2.net/?utm_source=studiocms" rel="sponsored" target="_blank"><img src="https://www.skip2.net/images/logo.svg" width="400px" alt="Skip2 logo" /></a>
 
 ## Licensing
 

--- a/packages/studiocms/README.md
+++ b/packages/studiocms/README.md
@@ -4,6 +4,8 @@ StudioCMS is a dedicated Astro native content management system (CMS) built on t
 
 > [!IMPORTANT]
 > This project is still in early development and it is not yet ready for production use. If you encounter any issues or have ideas for new features, please let us know by [opening an issue](https://github.com/withstudiocms/studiocms/issues/new/choose) on our GitHub repository.
+>
+> During our `0.1.0-beta.x` phase, breaking changes may ship in patch releases.
 
 ## Sponsor
 


### PR DESCRIPTION
This pull request makes significant improvements to the `README.md` to provide clearer documentation, a more organized structure, and up-to-date project information. The changes include a new overview, reorganization of package listings, improved setup instructions for the development playground, and better contribution guidelines.

Documentation and Project Overview:

* Updated the project introduction to clarify StudioCMS as an SSR Headless CMS and improved the "Getting Started" section with a direct link to the documentation.
* Added and reorganized badges at the top for clarity and consistency, including updating the pkg.pr.new badge and repositioning the Astro badge.

Package Organization:

* Introduced detailed tables listing all packages in the repository, categorized by Astro Integrations, Plugins, and Tools/Utilities, along with their test coverage status.

Development Playground Instructions:

* Rewrote and expanded the instructions for setting up and using the StudioCMS development playground, making the process clearer and easier to follow.

Contribution and Community:

* Improved and reorganized the contribution guidelines, including clearer sections for bug reports, feature requests, and code contributions, and moved the sponsors section to the end.
* Enhanced the community engagement section, providing a more prominent invitation to join the Discord server. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Rebranded project to StudioCMS and updated introductory copy.
  * Updated “Get Started” link to external documentation site.
  * Added beta-phase caveat noting patch releases in 0.1.0-beta.x may include breaking changes.
  * Refreshed badges (Continuous Releases, Built with Astro) and ordering.
  * Reorganized README with package listings, integrations/plugins, Tools & Utilities table.
  * Added Development Playground guide, onboarding flow, and sponsor logos (Turso, Skip2).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->