### PR TITLE
feat: enhance testing config and add new tests

### DIFF
--- a/.changeset/upset-cobras-press.md
+++ b/.changeset/upset-cobras-press.md
@@ -1,0 +1,5 @@
+---
+"@withstudiocms/effect": patch
+---
+
+Enhance tests

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,18 +3,121 @@ coverage:
     project:
       default:
         informational: true
+      # integrations:
+      #   informational: true
+      #   target: 80%
+      #   flags:
+      #     - integrations
+      # plugins:
+      #   informational: true
+      #   target: 80%
+      #   flags:
+      #     - plugins
+      tools-utils:
+        informational: true
+        target: 80%
+        flags:
+          - tools-utils
     patch:
       default:
         informational: true
-comment: #this is a top-level key
-  layout: "header, diff, flags, components" # show component info in the PR comment
+      # integrations:
+      #   informational: true
+      #   target: 80%
+      #   flags:
+      #     - integrations
+      # plugins:
+      #   informational: true
+      #   target: 80%
+      #   flags:
+      #     - plugins
+      tools-utils:
+        informational: true
+        target: 80%
+        flags:
+          - tools-utils
+
+comment:
+  layout: "header, diff, flags, components"
   behavior: default
-  require_changes: false # if true: only post the comment if coverage changes
-  require_base: false # [true :: must have a base report to post]
-  require_head: true # [true :: must have a head report to post]
+  require_changes: false
+  require_base: false
+  require_head: true
   hide_project_coverage: false
+
+flags:
+  integrations:
+    paths:
+      - packages/studiocms/**
+      - packages/@studiocms/devapps/**
+  plugins:
+    paths:
+      - packages/@studiocms/**
+    ignore:
+      - packages/@studiocms/devapps/**
+  tools-utils:
+    paths:
+      - packages/@withstudiocms/**
+
 component_management:
   individual_components:
+    # StudioCMS Integrations
+    - component_id: studiocms
+      name: "studiocms"
+      paths:
+        - packages/studiocms/**
+    - component_id: studiocms_devapps
+      name: "@studiocms/devapps"
+      paths:
+        - packages/@studiocms/devapps/**
+
+    # StudioCMS Plugins
+    - component_id: studiocms_auth0
+      name: "@studiocms/auth0"
+      paths:
+        - packages/@studiocms/auth0/**
+    - component_id: studiocms_blog
+      name: "@studiocms/blog"
+      paths:
+        - packages/@studiocms/blog/**
+    - component_id: studiocms_cloudinary-image-service
+      name: "@studiocms/cloudinary-image-service"
+      paths:
+        - packages/@studiocms/cloudinary-image-service/**
+    - component_id: studiocms_discord
+      name: "@studiocms/discord"
+      paths:
+        - packages/@studiocms/discord/**
+    - component_id: studiocms_github
+      name: "@studiocms/github"
+      paths:
+        - packages/@studiocms/github/**
+    - component_id: studiocms_google
+      name: "@studiocms/google"
+      paths:
+        - packages/@studiocms/google/**
+    - component_id: studiocms_html
+      name: "@studiocms/html"
+      paths:
+        - packages/@studiocms/html/**
+    - component_id: studiocms_markdoc
+      name: "@studiocms/markdoc"
+      paths:
+        - packages/@studiocms/markdoc/**
+    - component_id: studiocms_md
+      name: "@studiocms/md"
+      paths:
+        - packages/@studiocms/md/**
+    - component_id: studiocms_mdx
+      name: "@studiocms/mdx"
+      paths:
+        - packages/@studiocms/mdx/**
+    - component_id: studiocms_wysiwyg
+      name: "@studiocms/wysiwyg"
+      paths:
+        - packages/@studiocms/wysiwyg/**
+
+    # withstudiocms Tools and Utils
     - component_id: withstudiocms_auth_kit
       name: "@withstudiocms/auth-kit"
       paths:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -46,7 +46,7 @@
     {
       "groupName": "Effect Dependencies",
       "matchManagers": ["npm"],
-      "matchPackageNames": ["effect", "@effect/**", "!@effect/language-service"],
+      "matchPackageNames": ["effect", "@effect/**", "!@effect/language-service", "!@effect/vitest"],
       "labels": ["effect-deps"]
     },
     {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ci:typecheck:withstudiocms": "pnpm --filter @withstudiocms/* build && pnpm --filter @withstudiocms/* typecheck",
 
     "test": "vitest run",
+    "test:ui": "vitest --ui",
     "test:watch": "vitest",
     "ci:test": "vitest run --coverage",
 
@@ -48,6 +49,7 @@
     "@changesets/write": "^0.4.0",
     "@crowdin/crowdin-api-client": "^1.46.2",
 		"@effect/language-service": "^0.39.0",
+    "@effect/vitest": "^0.25.1",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",

--- a/packages/@withstudiocms/effect/README.md
+++ b/packages/@withstudiocms/effect/README.md
@@ -1,5 +1,7 @@
 # @withstudiocms/effect
 
+[![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=withstudiocms_effect)](https://codecov.io/github/withstudiocms/studiocms)
+
 This package contains various Effect utilities for StudioCMS/Astro projects
 
 ## Install

--- a/packages/@withstudiocms/effect/src/astro/middleware.ts
+++ b/packages/@withstudiocms/effect/src/astro/middleware.ts
@@ -4,6 +4,7 @@ import { runEffect } from '../index.js';
 import type { EffectMiddlewareHandler, EffectMiddlewareRouterEntry } from './types.js';
 import { buildMiddlewareSequence } from './utils/middleware.js';
 
+/* v8 ignore next 10 */
 /**
  * Defines an effect middleware by wrapping the provided handler function.
  * The middleware handler is executed within the `runEffect` context, allowing
@@ -15,6 +16,7 @@ import { buildMiddlewareSequence } from './utils/middleware.js';
 export const defineMiddleware = (fn: EffectMiddlewareHandler): MiddlewareHandler =>
 	_defineMiddleware(async (context, next) => await runEffect(fn(context, next)));
 
+/* v8 ignore next 12 */
 /**
  * Defines a middleware router that filters and applies middleware handlers based on path matching.
  *

--- a/packages/@withstudiocms/effect/src/astro/utils/api-route.ts
+++ b/packages/@withstudiocms/effect/src/astro/utils/api-route.ts
@@ -128,6 +128,7 @@ const SupportedContentTypeHeadersMap = {
 
 type SupportedContentType = keyof typeof SupportedContentTypeHeadersMap;
 
+/* v8 ignore start */
 /**
  * Validates the incoming API request based on the provided validation options.
  *
@@ -216,3 +217,5 @@ export async function validateRequest(
 
 	return null;
 }
+
+/* v8 ignore stop */

--- a/packages/@withstudiocms/effect/src/astro/utils/api-route.ts
+++ b/packages/@withstudiocms/effect/src/astro/utils/api-route.ts
@@ -33,6 +33,7 @@ export function getCorsHeaders(
 		context.request.headers.get('origin') ?? context.request.headers.get('Origin') ?? '';
 	// Handle origin according to configuration
 	const cfgOrigin = corsConfig.origin;
+	/* v8 ignore next 5 */
 	if (cfgOrigin === true) {
 		headers['Access-Control-Allow-Origin'] = '*';
 	} else if (typeof cfgOrigin === 'string') {
@@ -53,9 +54,10 @@ export function getCorsHeaders(
 			const methodsList = methodsSet.join(', ');
 			headers['Access-Control-Allow-Methods'] = methodsList;
 			// Only set `Allow` for preflight here to avoid overriding response-specific values.
-			if (!headers['Allow']) {
-				headers['Allow'] = methodsList;
+			if (!headers.Allow) {
+				headers.Allow = methodsList;
 			}
+			/* v8 ignore next 2 */
 		} else {
 			headers['Access-Control-Allow-Methods'] = normalized.join(', ');
 		}
@@ -71,6 +73,7 @@ export function getCorsHeaders(
 			headers['Access-Control-Allow-Headers'] = acrh;
 		}
 	}
+	/* v8 ignore next 12 */
 	// Handle credentials and adjust origin accordingly
 	if (corsConfig.credentials) {
 		headers['Access-Control-Allow-Credentials'] = 'true';
@@ -86,7 +89,7 @@ export function getCorsHeaders(
 	}
 	// When reflecting origin, set Vary: Origin for correct caching behavior
 	if (origin && headers['Access-Control-Allow-Origin'] === origin) {
-		headers['Vary'] = headers['Vary'] ? `${headers['Vary']}, Origin` : 'Origin';
+		headers.Vary = headers.Vary ? `${headers.Vary}, Origin` : 'Origin';
 	}
 	return headers;
 }

--- a/packages/@withstudiocms/effect/src/astro/utils/middleware.ts
+++ b/packages/@withstudiocms/effect/src/astro/utils/middleware.ts
@@ -32,12 +32,14 @@ export const matchFilterCheck = (
 	let cleanedPaths: string[];
 
 	if (typeof paths === 'string') {
+		/* v8 ignore next 4 */
 		if (paths.trim() === '') {
 			// If the string is empty, return defaultValue
 			return defaultValue;
 		}
 		cleanedPaths = [paths.trim()];
 	} else if (Array.isArray(paths)) {
+		/* v8 ignore next 6 */
 		if (paths.length === 0 || paths.every((p) => p.trim() === '')) {
 			// If the array is empty or all elements are empty strings, return defaultValue
 			return defaultValue;
@@ -101,6 +103,7 @@ export const sortByPriority = (a?: number | null, b?: number | null) => {
  * @param router - An array of middleware router entries, each specifying path matching rules and a handler.
  * @returns The result of executing the middleware sequence or the next middleware.
  */
+/* v8 ignore next 16 */
 export function buildMiddlewareSequence(
 	context: APIContext,
 	next: MiddlewareNext,

--- a/packages/@withstudiocms/effect/src/clack.ts
+++ b/packages/@withstudiocms/effect/src/clack.ts
@@ -52,7 +52,7 @@ export class ClackError extends Data.TaggedError('ClackError')<{ cause: unknown 
  * @param _try - A function to execute that may throw an error.
  * @returns An `Effect` that yields the result of the function or a `ClackError` if an error is thrown.
  */
-const useClackError = <A>(_try: () => A): Effect.Effect<A, ClackError> =>
+export const useClackError = <A>(_try: () => A): Effect.Effect<A, ClackError> =>
 	Effect.try({
 		try: _try,
 		catch: (cause) => new ClackError({ cause }),
@@ -65,7 +65,7 @@ const useClackError = <A>(_try: () => A): Effect.Effect<A, ClackError> =>
  * @param _try A function that returns a promise of type `A`.
  * @returns An `Effect` that resolves with the value of type `A` or fails with a `ClackError`.
  */
-const useClackErrorPromise = <A>(_try: () => Promise<A>): Effect.Effect<A, ClackError> =>
+export const useClackErrorPromise = <A>(_try: () => Promise<A>): Effect.Effect<A, ClackError> =>
 	Effect.tryPromise({
 		try: _try,
 		catch: (cause) => new ClackError({ cause }),

--- a/packages/@withstudiocms/effect/src/clack.ts
+++ b/packages/@withstudiocms/effect/src/clack.ts
@@ -71,6 +71,10 @@ const useClackErrorPromise = <A>(_try: () => Promise<A>): Effect.Effect<A, Clack
 		catch: (cause) => new ClackError({ cause }),
 	});
 
+/* v8 ignore start */
+
+// Current version of @clack/prompts has some issues with testing
+
 /**
  * Cancels the current Clack operation and optionally displays an error message.
  *
@@ -326,3 +330,5 @@ export const stream = {
 		useClackErrorPromise(() => ClackPrompts.stream.error(iterable))
 	),
 };
+
+/* v8 ignore stop */

--- a/packages/@withstudiocms/effect/src/deepmerge.ts
+++ b/packages/@withstudiocms/effect/src/deepmerge.ts
@@ -20,6 +20,7 @@ import { Effect } from './effect.js';
 export const deepmergeCustom = Effect.fn(<T>(fn: (deepmerge: typeof _deepmergeCustomSrc) => T) =>
 	Effect.try({
 		try: () => fn(_deepmergeCustomSrc),
+		/* v8 ignore next 4 */
 		catch: (cause) =>
 			new Error(
 				`Failed to run deepmerge callback: ${cause instanceof Error ? cause.message : String(cause)}`

--- a/packages/@withstudiocms/effect/test/astro/utils/middleware.test.ts
+++ b/packages/@withstudiocms/effect/test/astro/utils/middleware.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { handlerFilter, matchFilterCheck } from '../../../src/astro/utils/middleware.js';
+import {
+	handlerFilter,
+	matchFilterCheck,
+	sortByPriority,
+} from '../../../src/astro/utils/middleware.js';
 
 describe('Middleware Utils', () => {
 	describe('matchFilterCheck', () => {
@@ -70,6 +74,37 @@ describe('Middleware Utils', () => {
 			expect(handlerFilter([], [], '/foo')).toBe(true);
 			expect(handlerFilter('', '/foo', '/foo')).toBe(false);
 			expect(handlerFilter([], ['/foo'], '/foo')).toBe(false);
+		});
+
+		describe('sortByPriority', () => {
+			it('sorts lower numbers before higher numbers', () => {
+				expect(sortByPriority(1, 2)).toBeLessThan(0);
+				expect(sortByPriority(10, 5)).toBeGreaterThan(0);
+				expect(sortByPriority(3, 3)).toBe(0);
+			});
+
+			it('treats undefined as lowest priority (sorted last)', () => {
+				expect(sortByPriority(1, undefined)).toBeLessThan(0);
+				expect(sortByPriority(undefined, 1)).toBeGreaterThan(0);
+			});
+
+			it('treats null as lowest priority (sorted last)', () => {
+				expect(sortByPriority(1, null)).toBeLessThan(0);
+				expect(sortByPriority(null, 1)).toBeGreaterThan(0);
+			});
+
+			it('treats both undefined as equal', () => {
+				expect(sortByPriority(undefined, undefined)).toBe(0);
+			});
+
+			it('treats both null as equal', () => {
+				expect(sortByPriority(null, null)).toBe(0);
+			});
+
+			it('treats undefined and null as equal', () => {
+				expect(sortByPriority(undefined, null)).toBe(0);
+				expect(sortByPriority(null, undefined)).toBe(0);
+			});
 		});
 	});
 });

--- a/packages/@withstudiocms/effect/test/clack.test.ts
+++ b/packages/@withstudiocms/effect/test/clack.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from '@effect/vitest';
 import * as clack from '../src/clack';
-import { Effect } from '../src/effect.js';
+import { Effect, Exit } from '../src/effect.js';
 
 describe('clack', () => {
 	beforeEach(() => {
@@ -13,6 +13,46 @@ describe('clack', () => {
 				const err = new clack.ClackError({ cause: 'fail' });
 				expect(err._tag).toBe('ClackError');
 				expect(err.cause).toBe('fail');
+			})
+		);
+	});
+
+	describe('useClackError', () => {
+		it.effect('returns Effect that succeeds with value if no error is thrown', () =>
+			Effect.gen(function* () {
+				const result = yield* clack.useClackError(() => 42);
+				expect(result).toBe(42);
+			})
+		);
+
+		it.effect('returns Effect that fails with ClackError if error is thrown', () =>
+			Effect.gen(function* () {
+				const error = new Error('fail!');
+
+				const result = yield* Effect.exit(
+					clack.useClackError(() => {
+						throw error;
+					})
+				);
+
+				expect(result).toStrictEqual(Exit.fail(new clack.ClackError({ cause: error })));
+			})
+		);
+	});
+
+	describe('useClackErrorPromise', () => {
+		it.effect('returns Effect that succeeds with resolved value', () =>
+			Effect.gen(function* () {
+				const result = yield* clack.useClackErrorPromise(() => Promise.resolve('ok'));
+				expect(result).toBe('ok');
+			})
+		);
+
+		it.effect('returns Effect that fails with ClackError if promise rejects', () =>
+			Effect.gen(function* () {
+				const error = new Error('fail!');
+				const result = yield* Effect.exit(clack.useClackErrorPromise(() => Promise.reject(error)));
+				expect(result).toStrictEqual(Exit.fail(new clack.ClackError({ cause: error })));
 			})
 		);
 	});

--- a/packages/@withstudiocms/effect/test/clack.test.ts
+++ b/packages/@withstudiocms/effect/test/clack.test.ts
@@ -1,0 +1,19 @@
+import { beforeEach, describe, expect, it, vi } from '@effect/vitest';
+import * as clack from '../src/clack';
+import { Effect } from '../src/effect.js';
+
+describe('clack', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('ClackError', () => {
+		it.effect('should create a ClackError with cause', () =>
+			Effect.sync(() => {
+				const err = new clack.ClackError({ cause: 'fail' });
+				expect(err._tag).toBe('ClackError');
+				expect(err.cause).toBe('fail');
+			})
+		);
+	});
+});

--- a/packages/@withstudiocms/effect/test/effect.test.ts
+++ b/packages/@withstudiocms/effect/test/effect.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { appendSearchParamsToUrl, Effect, runEffect } from '../src/effect.js';
+import { describe, expect, it } from '@effect/vitest';
+import { appendSearchParamsToUrl, Effect, HTTPClient, runEffect } from '../src/effect.js';
 
 describe('Effect Utilities', () => {
 	it('runEffect resolves Effect with value', async () => {
@@ -27,4 +27,13 @@ describe('Effect Utilities', () => {
 		expect(resultUrl.searchParams.get('baz')).toBe('qux');
 		expect(resultUrl.toString()).toBe('https://example.com/?baz=qux');
 	});
+
+	it.effect('HTTPClient provides a retrying HttpClient instance', () =>
+		Effect.gen(function* () {
+			const client = yield* HTTPClient;
+			const response = yield* client.get('https://example.com');
+			const result = yield* response.text;
+			expect(result).toContain('<title>Example Domain</title>');
+		}).pipe(Effect.provide(HTTPClient.Default))
+	);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       '@effect/language-service':
         specifier: ^0.39.0
         version: 0.39.0
+      '@effect/vitest':
+        specifier: ^0.25.1
+        version: 0.25.1(effect@3.17.13)(vitest@3.2.4)
       '@types/node':
         specifier: 'catalog:'
         version: 22.16.3
@@ -1386,6 +1389,12 @@ packages:
     resolution: {integrity: sha512-+8xYvX4tjD7gKwGYzOyFh90I+ptdXzoNHLQTSa8kGh/xOVZMIGYb0VgLoNHE02UsuVrB+JJJuBmKLdd5TeDTPg==}
     peerDependencies:
       effect: ^3.17.0
+
+  '@effect/vitest@0.25.1':
+    resolution: {integrity: sha512-OMYvOU8iGed8GZXxgVBXlYtjG+jwWj5cJxFk0hOHOfTbCHXtdCMEWlXNba5zxbE7dBnW4srbnSYrP/NGGTC3qQ==}
+    peerDependencies:
+      effect: ^3.17.7
+      vitest: ^3.2.0
 
   '@effect/workflow@0.9.2':
     resolution: {integrity: sha512-BQw2wVCCdhC0FgSQXL62sefa8TV3sVP0ECRZS9CGnUtiCZiVkRDEeQlXErZkKVuVhtAqJLfngqtp8UkArLPYiw==}
@@ -6762,6 +6771,11 @@ snapshots:
   '@effect/typeclass@0.36.0(effect@3.17.13)':
     dependencies:
       effect: 3.17.13
+
+  '@effect/vitest@0.25.1(effect@3.17.13)(vitest@3.2.4)':
+    dependencies:
+      effect: 3.17.13
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.3)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@15.2.1(canvas@2.11.2))(tsx@4.20.3)(yaml@2.8.0)
 
   '@effect/workflow@0.9.2(@effect/platform@0.90.8(effect@3.17.13))(@effect/rpc@0.69.1(@effect/platform@0.90.8(effect@3.17.13))(effect@3.17.13))(effect@3.17.13)':
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
 				'vitest.config.ts',
 				'**/**/vitest.config.ts',
 				'**/**/@withstudiocms/auth-kit/scripts/**',
+				'**/**/scratchpad/**',
 			],
 		},
 	},


### PR DESCRIPTION
This pull request improves the test coverage and testing utilities for the `@withstudiocms/effect` package and updates the monorepo's coverage and dependency management configuration. The most significant changes include adding new tests, integrating `@effect/vitest` for enhanced Effect-based testing, and refining code coverage settings for better tracking and reporting.

**Testing Improvements:**

- Added comprehensive tests for the `clack` utilities, including `ClackError`, `useClackError`, and `useClackErrorPromise`, using `@effect/vitest` for Effect-based testing (`packages/@withstudiocms/effect/test/clack.test.ts`).
- Extended tests for middleware utilities, including new tests for `sortByPriority` in `middleware.test.ts` (`packages/@withstudiocms/effect/test/astro/utils/middleware.test.ts`).
- Updated `effect.test.ts` to use `@effect/vitest` and added a test for the `HTTPClient` Effect service (`packages/@withstudiocms/effect/test/effect.test.ts`). [[1]](diffhunk://#diff-750867f3bd1f3c058641402a88ec36d9a695b4b62c60aea72970f26e7ec5ce72L1-R2) [[2]](diffhunk://#diff-750867f3bd1f3c058641402a88ec36d9a695b4b62c60aea72970f26e7ec5ce72R30-R38)

**Dependency and Tooling Updates:**

- Added `@effect/vitest` as a dev dependency and updated the lockfile accordingly, enabling Effect-first testing patterns (`package.json`, `pnpm-lock.yaml`). [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R52) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR145-R147) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1393-R1398) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6775-R6779)
- Added a new `test:ui` script to run Vitest in UI mode (`package.json`).

**Coverage and CI Configuration:**

- Enhanced `.codecov.yml` to add granular flags and component management for integrations, plugins, and tools-utils, improving code coverage tracking and reporting by component (`.codecov.yml`).
- Added a Codecov badge to the `@withstudiocms/effect` README for visibility of coverage status (`packages/@withstudiocms/effect/README.md`).

**Minor Code Quality and Maintenance:**

- Added `/* v8 ignore ... */` comments throughout the codebase to improve code coverage accuracy by excluding non-essential or untestable lines from coverage reports (multiple files). [[1]](diffhunk://#diff-330ebdeb423232091afa07888a7d3e20947f5195dd5e058b736bf79faf79d260R36) [[2]](diffhunk://#diff-330ebdeb423232091afa07888a7d3e20947f5195dd5e058b736bf79faf79d260L56-R60) [[3]](diffhunk://#diff-330ebdeb423232091afa07888a7d3e20947f5195dd5e058b736bf79faf79d260R76) [[4]](diffhunk://#diff-330ebdeb423232091afa07888a7d3e20947f5195dd5e058b736bf79faf79d260L89-R92) [[5]](diffhunk://#diff-330ebdeb423232091afa07888a7d3e20947f5195dd5e058b736bf79faf79d260R131) [[6]](diffhunk://#diff-330ebdeb423232091afa07888a7d3e20947f5195dd5e058b736bf79faf79d260R220-R221) [[7]](diffhunk://#diff-0e66ddb7509b4298c063f61dfee2781a85dcf49a13cc3b38288c891b1f3a5648R7) [[8]](diffhunk://#diff-0e66ddb7509b4298c063f61dfee2781a85dcf49a13cc3b38288c891b1f3a5648R19) [[9]](diffhunk://#diff-a076dfae5e6397860dc263cc9ab0db3be0fa43c252128348f42175eca4f7e30aR35-R42) [[10]](diffhunk://#diff-a076dfae5e6397860dc263cc9ab0db3be0fa43c252128348f42175eca4f7e30aR106) [[11]](diffhunk://#diff-da341196cb3c0aad6f5cfb7e286d45a2fde4aebf84de57f38427148053d1036dR23) [[12]](diffhunk://#diff-e4ed596ec12e162e118dacced62ba0e929b2c645261c6b1b2f4b563ee9472fd5L68-R77) [[13]](diffhunk://#diff-e4ed596ec12e162e118dacced62ba0e929b2c645261c6b1b2f4b563ee9472fd5R333-R334)
- Exported `useClackError` and `useClackErrorPromise` from `clack.ts` for improved testability and external usage (`packages/@withstudiocms/effect/src/clack.ts`). [[1]](diffhunk://#diff-e4ed596ec12e162e118dacced62ba0e929b2c645261c6b1b2f4b563ee9472fd5L55-R55) [[2]](diffhunk://#diff-e4ed596ec12e162e118dacced62ba0e929b2c645261c6b1b2f4b563ee9472fd5L68-R77)

**Monorepo Maintenance:**

- Updated Renovate configuration to exclude `@effect/vitest` from the "Effect Dependencies" group, preventing unwanted grouping of test-only dependencies (`.github/renovate.json`).
- Added a changeset for the patch release of `@withstudiocms/effect` noting enhanced tests (`.changeset/upset-cobras-press.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Exposed new public utilities for Clack error handling.
  - Added a publicly available HTTP client helper.

- Documentation
  - Added a Codecov badge to the package README.

- Tests
  - Introduced unit tests for Clack utilities and middleware sorting.
  - Enabled a UI mode for running tests.

- Chores
  - Updated coverage settings and component/flag mapping for reporting.
  - Excluded scratchpad files from coverage.
  - Tweaked dependency update rules to exclude a specific package.
  - Added a patch changeset for the effect package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->