### PR TITLE
feat: add integration tests and update configurations for testing utilities

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -23,6 +23,6 @@
   "access": "public",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",
-  "ignore": ["node-playground"],
+  "ignore": ["node-playground", "@test-config-utils/integration-utils"],
   "privatePackages": false
 }

--- a/.changeset/ripe-flies-scream.md
+++ b/.changeset/ripe-flies-scream.md
@@ -2,4 +2,4 @@
 "@withstudiocms/config-utils": patch
 ---
 
-Add integration tests
+Add integration tests for @withstudiocms/config-utils.

--- a/.changeset/ripe-flies-scream.md
+++ b/.changeset/ripe-flies-scream.md
@@ -1,0 +1,5 @@
+---
+"@withstudiocms/config-utils": patch
+---
+
+Add integration tests

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -131,6 +131,7 @@
     "Libravatar",
     "libsql",
     "LIBSQLCLIENT",
+    "linkedom",
     "linkify",
     "liverender",
     "loginsignup",

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -29,7 +29,11 @@ const baseAstroWorkspaceConfig = {
 const baseWithStudioCMSConfig = {
 	entry: ['src/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}', 'test/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}'],
 	project: ['**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}'],
-	ignore: ['**/node_modules/**', '**/dist/**', '**/scratchpad/**'],
+	ignore: ['**/node_modules/**', '**/dist/**', '**/scratchpad/**', '**/example.config.mjs'],
+};
+const buildKitWithStudioCMSConfig = {
+	...baseWithStudioCMSConfig,
+	entry: ['lib/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}', 'test/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}'],
 };
 
 /**
@@ -75,7 +79,6 @@ const atWithStudioCMSPackages = [
 	'auth-kit',
 	'config-utils',
 	'effect',
-	'buildkit',
 	'component-registry',
 	'internal_helpers',
 ] as const;
@@ -141,6 +144,7 @@ const config: KnipConfig = {
 			// biome-ignore lint/suspicious/noExplicitAny: This is a dynamic object construction
 			{} as Record<string, any>
 		),
+		'packages/@withstudiocms/build-kit': buildKitWithStudioCMSConfig,
 		playground: {
 			ignoreDependencies: ['sharp'],
 			astro: {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "studiocms": "workspace:*",
     "typescript": "catalog:",
 		"ts-patch": "^3.3.0",
-    "vitest": "^3.2.4",
-    "linkedom": "^0.18.12"
+    "vitest": "^3.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,12 +54,14 @@
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "@withstudiocms/buildkit": "workspace:*",
+    "@inox-tools/astro-tests": "^0.8.0",
     "execa": "^9.6.0",
     "knip": "^5.63.1",
     "pkg-pr-new": "^0.0.59",
     "studiocms": "workspace:*",
     "typescript": "catalog:",
 		"ts-patch": "^3.3.0",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "linkedom": "^0.18.12"
   }
 }

--- a/packages/@withstudiocms/config-utils/README.md
+++ b/packages/@withstudiocms/config-utils/README.md
@@ -1,5 +1,7 @@
 # @withstudiocms/config-utils
 
+[![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=withstudiocms_config_utils)](https://codecov.io/github/withstudiocms/studiocms)
+
 Collection of utilities for working with config files and Astro integrations.
 
 ## License

--- a/packages/@withstudiocms/config-utils/src/astro-integration-utils.ts
+++ b/packages/@withstudiocms/config-utils/src/astro-integration-utils.ts
@@ -5,6 +5,8 @@ import type { ConfigResolverBuilderOpts, WatchConfigFileOptions } from './types.
 import { findConfig } from './watcher.js';
 import { parseAndMerge, parseConfig } from './zod-utils.js';
 
+/* v8 ignore start */
+// This function is tested indirectly via the integration tests in this package
 /**
  * Builds a config resolver utility for Astro integrations.
  *
@@ -72,7 +74,10 @@ export const configResolverBuilder = <S extends z.ZodTypeAny>({
 			return mergedConfig;
 		}
 	);
+/* v8 ignore stop */
 
+/* v8 ignore start */
+// This function is tested indirectly via the integration tests in this package
 /**
  * Creates an Astro integration utility that watches for changes in the first existing configuration file
  * found in the provided `configPaths`. When a configuration file is detected, it is registered for watching
@@ -98,3 +103,4 @@ export const watchConfigFileBuilder = ({ configPaths }: WatchConfigFileOptions) 
 			return;
 		}
 	);
+/* v8 ignore stop */

--- a/packages/@withstudiocms/config-utils/test/fixtures/integration-utils/astro.config.mts
+++ b/packages/@withstudiocms/config-utils/test/fixtures/integration-utils/astro.config.mts
@@ -1,0 +1,48 @@
+import { configResolverBuilder, watchConfigFileBuilder } from '@withstudiocms/config-utils';
+import type { AstroIntegration } from 'astro';
+import { defineConfig } from 'astro/config';
+import { z } from 'astro/zod';
+import { addVirtualImports } from 'astro-integration-kit';
+
+const configPaths = ['example.config.mjs'];
+
+const zodSchema = z.object({
+	foo: z.string().optional(),
+	bar: z.number().min(0).optional(),
+});
+
+const label = 'test-integration';
+
+const testIntegration: AstroIntegration = {
+	name: label,
+	hooks: {
+		'astro:config:setup': async (params) => {
+			const watchConfigFile = watchConfigFileBuilder({ configPaths });
+			const configResolver = configResolverBuilder({
+				configPaths,
+				label,
+				zodSchema,
+			});
+
+			watchConfigFile(params);
+
+			const resolvedConfig = await configResolver(params, {});
+
+			addVirtualImports(params, {
+				name: label,
+				imports: {
+					'virtual:test-config': `export const config = ${JSON.stringify(resolvedConfig)}`,
+				},
+			});
+		},
+	},
+};
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [testIntegration],
+	output: 'static',
+	devToolbar: {
+		enabled: false,
+	},
+});

--- a/packages/@withstudiocms/config-utils/test/fixtures/integration-utils/example.config.mjs
+++ b/packages/@withstudiocms/config-utils/test/fixtures/integration-utils/example.config.mjs
@@ -1,0 +1,4 @@
+export default {
+	foo: 'hello world',
+	bar: 42,
+};

--- a/packages/@withstudiocms/config-utils/test/fixtures/integration-utils/package.json
+++ b/packages/@withstudiocms/config-utils/test/fixtures/integration-utils/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@test/integration-utils",
+  "name": "@test-config-utils/integration-utils",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/packages/@withstudiocms/config-utils/test/fixtures/integration-utils/package.json
+++ b/packages/@withstudiocms/config-utils/test/fixtures/integration-utils/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@test/integration-utils",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "@withstudiocms/config-utils": "workspace:*",
+    "astro": "catalog:astrojs",
+    "astro-integration-kit": "catalog:"
+  }
+}

--- a/packages/@withstudiocms/config-utils/test/fixtures/integration-utils/src/pages/index.ts
+++ b/packages/@withstudiocms/config-utils/test/fixtures/integration-utils/src/pages/index.ts
@@ -1,0 +1,10 @@
+// @ts-expect-error: virtual module
+import { config } from 'virtual:test-config';
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = () => {
+	return new Response(JSON.stringify(config), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+};

--- a/packages/@withstudiocms/config-utils/test/fixtures/integration-utils/tsconfig.json
+++ b/packages/@withstudiocms/config-utils/test/fixtures/integration-utils/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "files": [],
+  "exclude": ["dist"],
+  "include": ["**/*", ".astro/types.d.ts"]
+}

--- a/packages/@withstudiocms/config-utils/test/integration-utils.test.ts
+++ b/packages/@withstudiocms/config-utils/test/integration-utils.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { type DevServer, type Fixture, loadFixture, MockFunction } from './test-utils.js';
 
-describe('Web Vitals integration basics', () => {
+describe('Config Utils Integration Utility tests', () => {
 	let fixture: Fixture;
 	let devServer: DevServer;
 	let consoleErrorMock: MockFunction<Console, 'error'>;

--- a/packages/@withstudiocms/config-utils/test/integration-utils.test.ts
+++ b/packages/@withstudiocms/config-utils/test/integration-utils.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { type DevServer, type Fixture, loadFixture, MockFunction } from './test-utils.js';
+
+describe('Web Vitals integration basics', () => {
+	let fixture: Fixture;
+	let devServer: DevServer;
+	let consoleErrorMock: MockFunction<Console, 'error'>;
+
+	beforeAll(async () => {
+		consoleErrorMock = new MockFunction(console, 'error');
+		fixture = await loadFixture({ root: './fixtures/integration-utils/' });
+		devServer = await fixture.startDevServer({});
+	});
+
+	afterAll(async () => {
+		consoleErrorMock.restore();
+		await devServer.stop();
+	});
+
+	beforeEach(() => {
+		consoleErrorMock.reset();
+	});
+
+	describe('the integration loads and serves basic config over endpoint', () => {
+		let res: Response;
+
+		beforeAll(async () => {
+			res = await fixture.fetch('/', {
+				method: 'GET',
+			});
+		});
+
+		it('the endpoint responds with 200', () => {
+			expect(res.status).toBe(200);
+		});
+
+		it('the endpoint responds with the expected config', async () => {
+			const json = await res.json();
+			expect(json).toEqual({ bar: 42, foo: 'hello world' });
+		});
+	});
+});

--- a/packages/@withstudiocms/config-utils/test/test-utils.ts
+++ b/packages/@withstudiocms/config-utils/test/test-utils.ts
@@ -1,0 +1,52 @@
+import {
+	loadFixture as baseLoadFixture,
+	type DevServer,
+	type Fixture,
+} from '@inox-tools/astro-tests/astroFixture';
+
+type InlineConfig = Omit<Parameters<typeof baseLoadFixture>[0], 'root'> & {
+	root: string;
+};
+
+export type { Fixture, DevServer };
+
+export function loadFixture(inlineConfig: InlineConfig) {
+	if (!inlineConfig?.root) throw new Error("Must provide { root: './fixtures/...' }");
+
+	// resolve the relative root (i.e. "./fixtures/tailwindcss") to a full filepath
+	// without this, the main `loadFixture` helper will resolve relative to `packages/astro/test`
+	return baseLoadFixture({
+		...inlineConfig,
+		root: new URL(inlineConfig.root, import.meta.url).toString(),
+	});
+}
+
+export function startOfHourISOString() {
+	const date = new Date();
+	date.setMinutes(0, 0, 0);
+	return date.toISOString();
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: This is fine
+export class MockFunction<T extends Record<K, (...args: any[]) => void>, K extends keyof T> {
+	calls: Parameters<T[K]>[] = [];
+	object: T;
+	property: K;
+	original: T[K];
+
+	constructor(object: T, property: K) {
+		this.object = object;
+		this.property = property;
+		this.original = object[property];
+		// @ts-ignore
+		object[property] = (...args: Parameters<T[K]>) => {
+			this.calls.push(args);
+		};
+	}
+	restore() {
+		this.object[this.property] = this.original;
+	}
+	reset() {
+		this.calls = [];
+	}
+}

--- a/packages/@withstudiocms/config-utils/test/utils/tryCatch.test.ts
+++ b/packages/@withstudiocms/config-utils/test/utils/tryCatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { tryCatch } from '../../src/utils/tryCatch.js';
+import { tryCatch } from '../../src/utils/index.js';
 
 describe('tryCatch', () => {
 	describe('with synchronous functions', () => {

--- a/packages/@withstudiocms/config-utils/vitest.config.ts
+++ b/packages/@withstudiocms/config-utils/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineProject({
 	test: {
 		environment: 'node',
 		include: ['**/*.test.ts'],
+		exclude: ['**/fixtures/**', '**/test-utils.ts'],
 	},
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -656,6 +656,9 @@ importers:
       astro:
         specifier: catalog:astrojs
         version: 5.13.7(@types/node@24.3.0)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0)
+      astro-integration-kit:
+        specifier: 'catalog:'
+        version: 0.19.0(astro@5.13.7(@types/node@24.3.0)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0))
 
   packages/@withstudiocms/effect:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       '@effect/vitest':
         specifier: ^0.25.1
         version: 0.25.1(effect@3.17.13)(vitest@3.2.4)
+      '@inox-tools/astro-tests':
+        specifier: ^0.8.0
+        version: 0.8.0(astro@5.13.7(@types/node@22.16.3)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0))
       '@types/node':
         specifier: 'catalog:'
         version: 22.16.3
@@ -163,6 +166,9 @@ importers:
       knip:
         specifier: ^5.63.1
         version: 5.63.1(@types/node@22.16.3)(typescript@5.9.2)
+      linkedom:
+        specifier: ^0.18.12
+        version: 0.18.12(canvas@2.11.2)
       pkg-pr-new:
         specifier: ^0.0.59
         version: 0.0.59
@@ -641,6 +647,15 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.16.3
+
+  packages/@withstudiocms/config-utils/test/fixtures/integration-utils:
+    dependencies:
+      '@withstudiocms/config-utils':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: catalog:astrojs
+        version: 5.13.7(@types/node@24.3.0)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0)
 
   packages/@withstudiocms/effect:
     dependencies:
@@ -1705,6 +1720,11 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@inox-tools/astro-tests@0.8.0':
+    resolution: {integrity: sha512-FAzJ0Yv2w8dR82OxNZzrML0mxktnXvsSaGcsOTk8RZxyrH9nWdmZB+3Tb0oAEPEyWgoXHmE7n/l8JsCMC5iD4g==}
+    peerDependencies:
+      astro: ^5.13.3
 
   '@inox-tools/modular-station@0.7.0':
     resolution: {integrity: sha512-XumkSTPonuAQHk4gWwXxDOoKIYig5gskmk9QJJ8+ow7uZMeW/brcX+Mx2RtStI8BkdPGlasYANx0zaSNOa4z8A==}
@@ -3129,6 +3149,9 @@ packages:
   cssom@0.4.4:
     resolution: {integrity: sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==}
 
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
+
   cssstyle@2.3.0:
     resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
     engines: {node: '>=8'}
@@ -4137,6 +4160,15 @@ packages:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
     cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
+
+  linkedom@0.18.12:
+    resolution: {integrity: sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: '>= 2'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -5342,6 +5374,9 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
+
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
 
@@ -5367,6 +5402,10 @@ packages:
 
   undici@7.12.0:
     resolution: {integrity: sha512-GrKEsc3ughskmGA9jevVlIOPMiiAHJ4OFUtaAH+NhfTUSiZ1wMPIQqQvAJUrJspFXJt3EBWgpAeoHEDVT1IBug==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.16.0:
+    resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
     engines: {node: '>=20.18.1'}
 
   unicode-properties@1.4.1:
@@ -5790,6 +5829,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.1.8:
+    resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -6978,6 +7020,21 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.3':
     optional: true
+
+  '@inox-tools/astro-tests@0.8.0(astro@5.13.7(@types/node@22.16.3)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0))':
+    dependencies:
+      '@astrojs/internal-helpers': 0.7.2
+      '@astrojs/markdown-remark': 6.3.6
+      '@inox-tools/utils': 0.7.0
+      astro: 5.13.7(@types/node@22.16.3)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0)
+      debug: 4.4.1
+      fast-glob: 3.3.3
+      shiki: 3.12.2
+      strip-ansi: 7.1.2
+      undici: 7.16.0
+      zod: 4.1.8
+    transitivePeerDependencies:
+      - supports-color
 
   '@inox-tools/modular-station@0.7.0(astro@5.13.7(@types/node@22.16.3)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0))':
     dependencies:
@@ -8787,6 +8844,8 @@ snapshots:
   cssom@0.4.4:
     optional: true
 
+  cssom@0.5.0: {}
+
   cssstyle@2.3.0:
     dependencies:
       cssom: 0.3.8
@@ -9879,6 +9938,16 @@ snapshots:
       '@libsql/linux-x64-gnu': 0.5.22
       '@libsql/linux-x64-musl': 0.5.22
       '@libsql/win32-x64-msvc': 0.5.22
+
+  linkedom@0.18.12(canvas@2.11.2):
+    dependencies:
+      css-select: 5.2.2
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 10.0.0
+      uhyphen: 0.2.0
+    optionalDependencies:
+      canvas: 2.11.2
 
   locate-path@5.0.0:
     dependencies:
@@ -11514,6 +11583,8 @@ snapshots:
 
   ufo@1.6.1: {}
 
+  uhyphen@0.2.0: {}
+
   ultrahtml@1.6.0: {}
 
   uncrypto@0.1.3: {}
@@ -11531,6 +11602,8 @@ snapshots:
   undici@6.21.3: {}
 
   undici@7.12.0: {}
+
+  undici@7.16.0: {}
 
   unicode-properties@1.4.1:
     dependencies:
@@ -11920,5 +11993,7 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.1.8: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,9 +166,6 @@ importers:
       knip:
         specifier: ^5.63.1
         version: 5.63.1(@types/node@22.16.3)(typescript@5.9.2)
-      linkedom:
-        specifier: ^0.18.12
-        version: 0.18.12(canvas@2.11.2)
       pkg-pr-new:
         specifier: ^0.0.59
         version: 0.0.59
@@ -3152,9 +3149,6 @@ packages:
   cssom@0.4.4:
     resolution: {integrity: sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==}
 
-  cssom@0.5.0:
-    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
-
   cssstyle@2.3.0:
     resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
     engines: {node: '>=8'}
@@ -4163,15 +4157,6 @@ packages:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
     cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
-
-  linkedom@0.18.12:
-    resolution: {integrity: sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      canvas: '>= 2'
-    peerDependenciesMeta:
-      canvas:
-        optional: true
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -5376,9 +5361,6 @@ packages:
 
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
-
-  uhyphen@0.2.0:
-    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
 
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
@@ -8847,8 +8829,6 @@ snapshots:
   cssom@0.4.4:
     optional: true
 
-  cssom@0.5.0: {}
-
   cssstyle@2.3.0:
     dependencies:
       cssom: 0.3.8
@@ -9941,16 +9921,6 @@ snapshots:
       '@libsql/linux-x64-gnu': 0.5.22
       '@libsql/linux-x64-musl': 0.5.22
       '@libsql/win32-x64-msvc': 0.5.22
-
-  linkedom@0.18.12(canvas@2.11.2):
-    dependencies:
-      css-select: 5.2.2
-      cssom: 0.5.0
-      html-escaper: 3.0.3
-      htmlparser2: 10.0.0
-      uhyphen: 0.2.0
-    optionalDependencies:
-      canvas: 2.11.2
 
   locate-path@5.0.0:
     dependencies:
@@ -11585,8 +11555,6 @@ snapshots:
   typescript@5.9.2: {}
 
   ufo@1.6.1: {}
-
-  uhyphen@0.2.0: {}
 
   ultrahtml@1.6.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,5 +46,6 @@ catalogs:
 packages:
   - "packages/@studiocms/*"
   - "packages/@withstudiocms/*"
+  - "packages/@withstudiocms/*/test/fixtures/*"
   - "packages/*"
   - "playground"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,8 @@ export default defineConfig({
 				'**/**/vitest.config.ts',
 				'**/**/@withstudiocms/auth-kit/scripts/**',
 				'**/**/scratchpad/**',
+				'**/**/test/fixtures/**',
+				'**/**/test/test-utils.ts',
 			],
 		},
 	},


### PR DESCRIPTION
This pull request adds integration tests for the `@withstudiocms/config-utils` package, ensuring its utilities work correctly within an Astro integration. It introduces new test fixtures, supporting utilities, and configuration changes to enable and isolate these tests. Additionally, some minor improvements and dependency updates are included.

**Integration Testing Infrastructure:**

* Added a full integration test fixture under `test/fixtures/integration-utils` including an Astro config, example config file, test endpoint, and supporting package files to validate config loading in a real Astro environment. [[1]](diffhunk://#diff-4658bc251e9a0f3cb9b31d22235d44faa62ad15f82ccceb9448d84116dbfca09R1-R48) [[2]](diffhunk://#diff-ead6ec9e4d1f122fcf76b3e35ed8ae6fcd5933cb26f873b773615bd775351fd8R1-R4) [[3]](diffhunk://#diff-9b1cc93c4d8b9dd3c048f188de0e9f692acab71da35aea29312ae41016e5316fR1-R15) [[4]](diffhunk://#diff-65a8b7c8dd6be11ac5b82cc16a115709fe334edcc3854454b49ce549bc111f82R1-R10) [[5]](diffhunk://#diff-2c4f46da9a40245083b61e8b9837315e6aae5e08a731abdc6d6eed19248f6cf9R1-R6)
* Created `integration-utils.test.ts` to run integration tests that verify the config utils load and serve config as expected via an endpoint.
* Introduced `test-utils.ts` with helpers for loading fixtures and mocking functions, used by the new integration tests.

**Test Coverage and Exclusions:**

* Marked core utility functions in `astro-integration-utils.ts` with `v8 ignore` comments to indicate they are covered indirectly via integration tests. [[1]](diffhunk://#diff-949543835c2095a5ac02d4805e51d3acac6a2f35fcbd7d94606fd3dcf45f36f7R8-R9) [[2]](diffhunk://#diff-949543835c2095a5ac02d4805e51d3acac6a2f35fcbd7d94606fd3dcf45f36f7R77-R80) [[3]](diffhunk://#diff-949543835c2095a5ac02d4805e51d3acac6a2f35fcbd7d94606fd3dcf45f36f7R106)
* Updated `vitest.config.ts` and package-specific config to exclude test fixtures and utilities from standard test runs, ensuring isolation of integration tests. [[1]](diffhunk://#diff-ab47432e9b96e948a0aa36db064c5c822d7a6988d58fdf63a7971d8907d4f722R7) [[2]](diffhunk://#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92R41-R42)

**Dependency and Tooling Updates:**

* Added `@inox-tools/astro-tests` as a dev dependency for integration test support and updated `pnpm-lock.yaml` accordingly. (F7739143R1, [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR148-R150) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1724-R1728) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR7009-R7023)
* Included new fixture paths in the workspace and test runner configuration for proper discovery.

**Miscellaneous:**

* Added a changeset to document the addition of integration tests.
* Minor code cleanup and test import fix in `tryCatch.test.ts`.

These changes ensure robust, real-world testing of the config utilities in an Astro integration context, improving confidence in their correctness and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end integration tests validating config resolution and serving via an endpoint.
  * Introduced test fixtures, a fixture package, and test utilities; updated test discovery and coverage to exclude fixtures and helpers.

* **Chores**
  * Updated workspace and tooling to include new test fixtures and a build-kit workspace.
  * Expanded ignore lists and spelling dictionary; added a dev dependency to support Astro testing.
  * Prepared a patch release changeset.

* **Documentation**
  * Added a Codecov badge to the Config Utils README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->