### PR TITLE
feat: introduce more testing for the `@withstudiocms/component-registry` package

### DIFF
--- a/.changeset/whole-times-wash.md
+++ b/.changeset/whole-times-wash.md
@@ -1,0 +1,5 @@
+---
+"@withstudiocms/component-registry": patch
+---
+
+Add tests for `@withstudiocms/component-registry`

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -27,8 +27,11 @@ const baseAstroWorkspaceConfig = {
  * @property ignore - Glob patterns specifying files or directories to ignore in the workspace.
  */
 const baseWithStudioCMSConfig = {
-	entry: ['src/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}', 'test/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}'],
-	project: ['**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}'],
+	entry: [
+		'src/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}',
+		'test/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,astro}',
+	],
+	project: ['**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,astro}'],
 	ignore: ['**/node_modules/**', '**/dist/**', '**/scratchpad/**', '**/example.config.mjs'],
 };
 const buildKitWithStudioCMSConfig = {
@@ -104,6 +107,9 @@ const extras = (pkg: string) => {
 		},
 		'auth-kit': {
 			ignoreUnresolved: [/^\.\/lists\/[^/]*\.js$/],
+		},
+		'component-registry': {
+			ignoreDependencies: ['test'],
 		},
 	};
 	const supportsExtras = Object.keys(extrasMap).includes(pkg);

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -108,9 +108,6 @@ const extras = (pkg: string) => {
 		'auth-kit': {
 			ignoreUnresolved: [/^\.\/lists\/[^/]*\.js$/],
 		},
-		'component-registry': {
-			ignoreDependencies: ['test'],
-		},
 	};
 	const supportsExtras = Object.keys(extrasMap).includes(pkg);
 	return supportsExtras ? extrasMap[pkg] : {};
@@ -151,6 +148,15 @@ const config: KnipConfig = {
 			{} as Record<string, any>
 		),
 		'packages/@withstudiocms/build-kit': buildKitWithStudioCMSConfig,
+		'packages/@withstudiocms/*/test/fixtures/*': {
+			ignore: ['**/*'],
+		},
+		'packages/@studiocms/*/test/fixtures/*': {
+			ignore: ['**/*'],
+		},
+		'packages/@studiocms/*/tests/fixtures/*': {
+			ignore: ['**/*'],
+		},
 		playground: {
 			ignoreDependencies: ['sharp'],
 			astro: {

--- a/packages/@withstudiocms/component-registry/README.md
+++ b/packages/@withstudiocms/component-registry/README.md
@@ -1,5 +1,7 @@
 # @withstudiocms/component-registry
 
+[![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=withstudiocms_component_registry)](https://codecov.io/github/withstudiocms/studiocms)
+
 Create a virtual Astro Component registry with ease.
 
 ## Install

--- a/packages/@withstudiocms/component-registry/src/component-proxy/decoder/decode-codepoint.ts
+++ b/packages/@withstudiocms/component-registry/src/component-proxy/decoder/decode-codepoint.ts
@@ -38,6 +38,7 @@ const decodeMap = new Map([
 export const fromCodePoint: (...codePoints: number[]) => string =
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, n/no-unsupported-features/es-builtins
 	String.fromCodePoint ??
+	/* v8 ignore start */
 	((codePoint: number): string => {
 		let output = '';
 
@@ -50,6 +51,7 @@ export const fromCodePoint: (...codePoints: number[]) => string =
 		output += String.fromCharCode(codePoint);
 		return output;
 	});
+	/* v8 ignore stop */
 
 /**
  * Replace the given code point with a replacement character if it is a

--- a/packages/@withstudiocms/component-registry/src/component-proxy/decoder/util.ts
+++ b/packages/@withstudiocms/component-registry/src/component-proxy/decoder/util.ts
@@ -370,7 +370,9 @@ export class EntityDecoder {
 			}
 		}
 
+		/* v8 ignore start */
 		return -1;
+		/* v8 ignore stop */
 	}
 
 	/**
@@ -415,6 +417,7 @@ export class EntityDecoder {
 		return consumed;
 	}
 
+	/* v8 ignore start */
 	/**
 	 * Signal to the parser that the end of the input was reached.
 	 *
@@ -423,7 +426,6 @@ export class EntityDecoder {
 	 * @returns The number of characters consumed.
 	 */
 	end(): number {
-		/* v8 ignore start */
 		switch (this.state) {
 			case EntityDecoderState.NamedEntity: {
 				// Emit a named entity if we have one.
@@ -448,8 +450,8 @@ export class EntityDecoder {
 				return 0;
 			}
 		}
-		/* v8 ignore stop */
 	}
+	/* v8 ignore stop */
 }
 
 /**

--- a/packages/@withstudiocms/component-registry/src/component-proxy/decoder/util.ts
+++ b/packages/@withstudiocms/component-registry/src/component-proxy/decoder/util.ts
@@ -155,6 +155,7 @@ export class EntityDecoder {
 				return this.stateNamedEntity(input, offset);
 			}
 
+			/* v8 ignore start */
 			case EntityDecoderState.NumericStart: {
 				return this.stateNumericStart(input, offset);
 			}
@@ -170,6 +171,7 @@ export class EntityDecoder {
 			case EntityDecoderState.NamedEntity: {
 				return this.stateNamedEntity(input, offset);
 			}
+			/* v8 ignore stop */
 		}
 	}
 
@@ -183,9 +185,11 @@ export class EntityDecoder {
 	 * @returns The number of characters that were consumed, or -1 if the entity is incomplete.
 	 */
 	private stateNumericStart(input: string, offset: number): number {
+		/* v8 ignore start */
 		if (offset >= input.length) {
 			return -1;
 		}
+		/* v8 ignore stop */
 
 		if ((input.charCodeAt(offset) | TO_LOWER_BIT) === CharCodes.LOWER_X) {
 			this.state = EntityDecoderState.NumericHex;
@@ -228,9 +232,11 @@ export class EntityDecoder {
 			}
 		}
 
+		/* v8 ignore start */
 		this.addToNumericResult(input, startIndex, offset, 16);
 
 		return -1;
+		/* v8 ignore stop */
 	}
 
 	/**
@@ -255,9 +261,11 @@ export class EntityDecoder {
 			}
 		}
 
+		/* v8 ignore start */
 		this.addToNumericResult(input, startIndex, offset, 10);
 
 		return -1;
+		/* v8 ignore stop */
 	}
 
 	/**
@@ -275,20 +283,25 @@ export class EntityDecoder {
 	 */
 	private emitNumericEntity(lastCp: number, expectedLength: number): number {
 		// Ensure we consumed at least one digit.
+		/* v8 ignore start */
 		if (this.consumed <= expectedLength) {
 			this.errors?.absenceOfDigitsInNumericCharacterReference(this.consumed);
 			return 0;
 		}
+		/* v8 ignore stop */
 
 		// Figure out if this is a legit end of the entity
 		if (lastCp === CharCodes.SEMI) {
 			this.consumed += 1;
+			/* v8 ignore start */
 		} else if (this.decodeMode === DecodingMode.Strict) {
 			return 0;
 		}
+		/* v8 ignore stop */
 
 		this.emitCodePoint(replaceCodePoint(this.result), this.consumed);
 
+		/* v8 ignore start */
 		if (this.errors) {
 			if (lastCp !== CharCodes.SEMI) {
 				this.errors.missingSemicolonAfterCharacterReference();
@@ -296,6 +309,7 @@ export class EntityDecoder {
 
 			this.errors.validateNumericCharacterReference(this.result);
 		}
+		/* v8 ignore stop */
 
 		return this.consumed;
 	}
@@ -391,10 +405,12 @@ export class EntityDecoder {
 			valueLength === 1 ? decodeTree[result] & ~BinTrieFlags.VALUE_LENGTH : decodeTree[result + 1],
 			consumed
 		);
+		/* v8 ignore start */
 		if (valueLength === 3) {
 			// For multi-byte values, we need to emit the second byte.
 			this.emitCodePoint(decodeTree[result + 2], consumed);
 		}
+		/* v8 ignore stop */
 
 		return consumed;
 	}
@@ -463,10 +479,12 @@ function getDecoder(decodeTree: Uint16Array) {
 				offset + 1
 			);
 
+			/* v8 ignore start */
 			if (length < 0) {
 				lastIndex = offset + decoder.end();
 				break;
 			}
+			/* v8 ignore stop */
 
 			lastIndex = offset + length;
 			// If `length` is 0, skip the current `&` and continue.

--- a/packages/@withstudiocms/component-registry/src/component-proxy/decoder/util.ts
+++ b/packages/@withstudiocms/component-registry/src/component-proxy/decoder/util.ts
@@ -407,6 +407,7 @@ export class EntityDecoder {
 	 * @returns The number of characters consumed.
 	 */
 	end(): number {
+		/* v8 ignore start */
 		switch (this.state) {
 			case EntityDecoderState.NamedEntity: {
 				// Emit a named entity if we have one.
@@ -431,6 +432,7 @@ export class EntityDecoder {
 				return 0;
 			}
 		}
+		/* v8 ignore stop */
 	}
 }
 

--- a/packages/@withstudiocms/component-registry/src/component-proxy/index.ts
+++ b/packages/@withstudiocms/component-registry/src/component-proxy/index.ts
@@ -40,6 +40,7 @@ export function createComponentProxy(
 					try {
 						const normalized = JSON.parse(JSON.stringify(props.code ?? ''));
 						props = { ...props, code: decode(String(normalized)) };
+						/* v8 ignore start */
 					} catch (err) {
 						console.warn(
 							`Failed to decode code prop for component "${lowerKey}". Falling back to raw string.`,
@@ -48,6 +49,7 @@ export function createComponentProxy(
 						const safe = typeof props.code === 'string' ? props.code : String(props.code ?? '');
 						props = { ...props, code: decode(safe) };
 					}
+					/* v8 ignore end */
 				}
 				const output = await _testProps.renderJSX(
 					result,

--- a/packages/@withstudiocms/component-registry/src/component-proxy/index.ts
+++ b/packages/@withstudiocms/component-registry/src/component-proxy/index.ts
@@ -7,6 +7,12 @@ import { decode } from './decoder/index.js';
 
 export * from './decoder/index.js';
 
+interface TestProps {
+	renderJSX: typeof renderJSX;
+	jsx: typeof jsx;
+	__unsafeHTML: typeof __unsafeHTML;
+}
+
 /**
  * Creates a proxy for components that can either be strings or functions.
  * If the component is a string, it is directly assigned to the proxy.
@@ -17,7 +23,11 @@ export * from './decoder/index.js';
  * @param _components - An optional record of components to be proxied. Defaults to an empty object.
  * @returns A record of proxied components.
  */
-export function createComponentProxy(result: SSRResult, _components: ComponentType = {}) {
+export function createComponentProxy(
+	result: SSRResult,
+	_components: ComponentType = {},
+	_testProps: TestProps = { jsx, __unsafeHTML, renderJSX }
+): ComponentType {
 	// Avoid prototype pollution on special keys like __proto__/constructor
 	const components: ComponentType = Object.create(null);
 	for (const [rawKey, value] of Object.entries(_components)) {
@@ -39,11 +49,11 @@ export function createComponentProxy(result: SSRResult, _components: ComponentTy
 						props = { ...props, code: decode(safe) };
 					}
 				}
-				const output = await renderJSX(
+				const output = await _testProps.renderJSX(
 					result,
-					jsx(value, { ...props, 'set:html': children?.value })
+					_testProps.jsx(value, { ...props, 'set:html': children?.value })
 				);
-				return __unsafeHTML(output);
+				return _testProps.__unsafeHTML(output);
 			};
 		}
 	}

--- a/packages/@withstudiocms/component-registry/src/errors.ts
+++ b/packages/@withstudiocms/component-registry/src/errors.ts
@@ -19,9 +19,11 @@ export function prefixError(err: Error, prefix: string): Error {
 		try {
 			err.message = `${prefix}:\n${err.message}`;
 			return err;
+			/* v8 ignore start */
 		} catch {
 			// Any errors here are ok, there's fallback code below
 		}
+		/* v8 ignore stop */
 	}
 
 	// If that failed, create a new error with the desired message and attempt to keep the stack

--- a/packages/@withstudiocms/component-registry/src/index.ts
+++ b/packages/@withstudiocms/component-registry/src/index.ts
@@ -1,6 +1,9 @@
+/* v8 ignore start */
+// These exports are ignored by v8 coverage as they are just re-exports
 export * from './component-proxy/index.js';
 export * from './errors.js';
 export * from './registry/index.js';
 export * from './transform-html.js';
 export * from './types.js';
 export * from './utils.js';
+/* v8 ignore stop */

--- a/packages/@withstudiocms/component-registry/src/registry/PropsParser.ts
+++ b/packages/@withstudiocms/component-registry/src/registry/PropsParser.ts
@@ -212,6 +212,7 @@ export class PropsParser extends Effect.Service<PropsParser>()('PropsParser', {
 							throw new Error('No Props interface or type found in frontmatter');
 						}
 
+						/* v8 ignore start */
 						// Find the complete Props definition by counting braces
 						const propsSubstring = frontmatter.substring(propsStart);
 						let braceCount = 0;
@@ -248,6 +249,7 @@ export class PropsParser extends Effect.Service<PropsParser>()('PropsParser', {
 
 						const propsDefinition = propsSubstring.substring(0, i + 1).replace(/^export\s+/, '');
 						return propsDefinition;
+						/* v8 ignore stop */
 					},
 					catch: (error) => {
 						console.error('Error extracting props from Astro file:', error);

--- a/packages/@withstudiocms/component-registry/src/registry/PropsParser.ts
+++ b/packages/@withstudiocms/component-registry/src/registry/PropsParser.ts
@@ -160,12 +160,12 @@ export class PropsParser extends Effect.Service<PropsParser>()('PropsParser', {
 								}
 								/* v8 ignore start */
 								results.push({ name: typeName, props });
-								/* v8 ignore stop */
 							} else {
 								console.log(
 									`Type alias ${typeName} is not a type literal, kind: ${typeNode?.getKindName()}`
 								);
 							}
+							/* v8 ignore stop */
 						}
 
 						return results;

--- a/packages/@withstudiocms/component-registry/src/registry/PropsParser.ts
+++ b/packages/@withstudiocms/component-registry/src/registry/PropsParser.ts
@@ -39,6 +39,7 @@ export class PropsParser extends Effect.Service<PropsParser>()('PropsParser', {
 
 										// Handle different tag types
 										switch (tagName) {
+											/* v8 ignore start */
 											case 'param': {
 												// @param {type} name description
 												const paramInfo = tag.getStructure();
@@ -50,6 +51,7 @@ export class PropsParser extends Effect.Service<PropsParser>()('PropsParser', {
 												});
 												break;
 											}
+											/* v8 ignore stop */
 											case 'default': {
 												defaultValue = commentText;
 												jsDocTags.push({
@@ -70,6 +72,7 @@ export class PropsParser extends Effect.Service<PropsParser>()('PropsParser', {
 											case 'internal':
 											case 'beta':
 											case 'alpha':
+											/* v8 ignore start */
 											case 'experimental': {
 												jsDocTags.push({
 													tagName,
@@ -84,6 +87,7 @@ export class PropsParser extends Effect.Service<PropsParser>()('PropsParser', {
 													text: commentText,
 												});
 											}
+											/* v8 ignore stop */
 										}
 									}
 								}
@@ -154,8 +158,9 @@ export class PropsParser extends Effect.Service<PropsParser>()('PropsParser', {
 										});
 									}
 								}
-
+								/* v8 ignore start */
 								results.push({ name: typeName, props });
+								/* v8 ignore stop */
 							} else {
 								console.log(
 									`Type alias ${typeName} is not a type literal, kind: ${typeNode?.getKindName()}`
@@ -165,6 +170,7 @@ export class PropsParser extends Effect.Service<PropsParser>()('PropsParser', {
 
 						return results;
 					},
+					/* v8 ignore start */
 					catch: (error) => {
 						console.error('Error parsing component props:', error);
 						return new ComponentRegistryError({
@@ -172,6 +178,7 @@ export class PropsParser extends Effect.Service<PropsParser>()('PropsParser', {
 							cause: error,
 						});
 					},
+					/* v8 ignore stop */
 				}),
 
 			extractPropsFromAstroFile: (astroFileContent: string) =>

--- a/packages/@withstudiocms/component-registry/src/registry/Registry.ts
+++ b/packages/@withstudiocms/component-registry/src/registry/Registry.ts
@@ -61,10 +61,12 @@ export class ComponentRegistry extends Effect.Service<ComponentRegistry>()('Comp
 					const parsed = yield* parser.parseComponentProps(propsDefinition).pipe(
 						Effect.mapError(
 							(error) =>
+								/* v8 ignore start */
 								new ComponentRegistryError({
 									message: `Failed to register component ${name}`,
 									cause: error,
 								})
+							/* v8 ignore stop */
 						)
 					);
 

--- a/packages/@withstudiocms/component-registry/src/registry/handler.ts
+++ b/packages/@withstudiocms/component-registry/src/registry/handler.ts
@@ -72,6 +72,8 @@ export const resolver = Effect.fn(function* (base: string) {
 	);
 });
 
+/* v8 ignore start */
+// Tests are handled indirectly via the integration in `test/registry-test.test.ts`
 /**
  * Handles the setup and registration of components in the component registry during the Astro config setup phase.
  *
@@ -249,3 +251,4 @@ export const componentRegistryHandler = defineUtility('astro:config:setup')(
 			}).pipe(Effect.provide(ComponentRegistry.Default))
 		)
 );
+/* v8 ignore stop */

--- a/packages/@withstudiocms/component-registry/src/registry/handler.ts
+++ b/packages/@withstudiocms/component-registry/src/registry/handler.ts
@@ -59,7 +59,7 @@ export type ComponentRegistryHandlerOptions = z.infer<typeof ComponentRegistryHa
  * const resolveEffect = resolver('/components');
  * const result = yield* resolveEffect((resolve) => resolve('Button'));
  */
-const resolver = Effect.fn(function* (base: string) {
+export const resolver = Effect.fn(function* (base: string) {
 	const { resolve: _resolve } = createResolver(base);
 	return Effect.fn((fn: (resolve: (...path: Array<string>) => string) => string) =>
 		Effect.try({

--- a/packages/@withstudiocms/component-registry/test/component-proxy/decoder/decode-codepoint.test.ts
+++ b/packages/@withstudiocms/component-registry/test/component-proxy/decoder/decode-codepoint.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+	decodeCodePoint,
+	fromCodePoint,
+	replaceCodePoint,
+} from '../../../src/component-proxy/decoder/decode-codepoint.js';
+
+describe('decode-codepoint', () => {
+	describe('fromCodePoint', () => {
+		it('returns correct string for BMP code points', () => {
+			expect(fromCodePoint(0x41)).toBe('A');
+			expect(fromCodePoint(0x20ac)).toBe('€');
+		});
+
+		it('returns correct string for astral code points', () => {
+			expect(fromCodePoint(0x1f600)).toBe('😀');
+			expect(fromCodePoint(0x1d306)).toBe('𝌆');
+		});
+
+		it('returns correct string for multiple code points', () => {
+			expect(fromCodePoint(0x41, 0x42, 0x43)).toBe('ABC');
+		});
+	});
+
+	describe('replaceCodePoint', () => {
+		it('returns replacement character for surrogate code points', () => {
+			expect(replaceCodePoint(0xd800)).toBe(0xfffd);
+			expect(replaceCodePoint(0xdfff)).toBe(0xfffd);
+		});
+
+		it('returns replacement character for code points above Unicode range', () => {
+			expect(replaceCodePoint(0x110000)).toBe(0xfffd);
+		});
+
+		it('returns mapped value for C1 controls', () => {
+			expect(replaceCodePoint(128)).toBe(8364); // €
+			expect(replaceCodePoint(136)).toBe(710); // ˆ
+			expect(replaceCodePoint(153)).toBe(8482); // ™
+		});
+
+		it('returns code point unchanged if not mapped or invalid', () => {
+			expect(replaceCodePoint(0x41)).toBe(0x41);
+			expect(replaceCodePoint(0x20ac)).toBe(0x20ac);
+		});
+	});
+
+	describe('decodeCodePoint', () => {
+		it('decodes mapped C1 control code points', () => {
+			expect(decodeCodePoint(128)).toBe('€');
+			expect(decodeCodePoint(136)).toBe('ˆ');
+			expect(decodeCodePoint(153)).toBe('™');
+		});
+
+		it('decodes regular code points', () => {
+			expect(decodeCodePoint(0x41)).toBe('A');
+			expect(decodeCodePoint(0x20ac)).toBe('€');
+		});
+
+		it('returns replacement character for invalid code points', () => {
+			expect(decodeCodePoint(0xd800)).toBe('�');
+			expect(decodeCodePoint(0x110000)).toBe('�');
+		});
+	});
+});

--- a/packages/@withstudiocms/component-registry/test/component-proxy/decoder/decode-data-html.test.ts
+++ b/packages/@withstudiocms/component-registry/test/component-proxy/decoder/decode-data-html.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { htmlDecodeTree } from '../../../src/component-proxy/decoder/decode-data-html.js';
+
+describe('htmlDecodeTree', () => {
+	it('should be defined', () => {
+		expect(htmlDecodeTree).toBeDefined();
+	});
+
+	it('should be an instance of Uint16Array', () => {
+		expect(htmlDecodeTree).toBeInstanceOf(Uint16Array);
+	});
+
+	it('should have a non-zero length', () => {
+		expect(htmlDecodeTree.length).toBeGreaterThan(0);
+	});
+
+	it('should contain only numbers', () => {
+		for (let i = 0; i < htmlDecodeTree.length; i++) {
+			expect(typeof htmlDecodeTree[i]).toBe('number');
+		}
+	});
+
+	it('should have values in the valid Uint16 range', () => {
+		for (let i = 0; i < htmlDecodeTree.length; i++) {
+			expect(htmlDecodeTree[i]).toBeGreaterThanOrEqual(0);
+			expect(htmlDecodeTree[i]).toBeLessThanOrEqual(0xffff);
+		}
+	});
+});

--- a/packages/@withstudiocms/component-registry/test/component-proxy/decoder/decode-data-xml.test.ts
+++ b/packages/@withstudiocms/component-registry/test/component-proxy/decoder/decode-data-xml.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { xmlDecodeTree } from '../../../src/component-proxy/decoder/decode-data-xml.js';
+
+describe('xmlDecodeTree', () => {
+	it('should be a Uint16Array', () => {
+		expect(xmlDecodeTree).toBeInstanceOf(Uint16Array);
+	});
+
+	it('should have the expected length', () => {
+		// The length should match the number of characters in the string
+		const expectedLength =
+			'\u0200aglq\t\x15\x18\x1b\u026d\x0f\0\0\x12p;\u4026os;\u4027t;\u403et;\u403cuot;\u4022'
+				.length;
+		expect(xmlDecodeTree.length).toBe(expectedLength);
+	});
+
+	it('should contain the correct char codes', () => {
+		const source =
+			'\u0200aglq\t\x15\x18\x1b\u026d\x0f\0\0\x12p;\u4026os;\u4027t;\u403et;\u403cuot;\u4022';
+		const expected = Array.from(source).map((c) => c.charCodeAt(0));
+		expect(Array.from(xmlDecodeTree)).toEqual(expected);
+	});
+});

--- a/packages/@withstudiocms/component-registry/test/component-proxy/decoder/index.test.ts
+++ b/packages/@withstudiocms/component-registry/test/component-proxy/decoder/index.test.ts
@@ -1,0 +1,56 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: allowed in tests */
+import { describe, expect, it } from 'vitest';
+import {
+	type DecodingOptions,
+	decode,
+	EntityLevel,
+} from '../../../src/component-proxy/decoder/index';
+
+// Mock util.js functions for isolated testing if needed
+// But here, let's assume decodeHTML and decodeXML work as expected
+
+describe('decode', () => {
+	it('decodes XML entities by default', () => {
+		// &lt; = <
+		expect(decode('&lt;tag&gt;')).toBe('<tag>');
+		// &amp; = &
+		expect(decode('foo &amp; bar')).toBe('foo & bar');
+	});
+
+	it('decodes XML entities when EntityLevel.XML is specified', () => {
+		expect(decode('&lt;tag&gt;', EntityLevel.XML)).toBe('<tag>');
+	});
+
+	it('decodes HTML entities when EntityLevel.HTML is specified', () => {
+		// &copy; is only in HTML, not XML
+		expect(decode('&copy;', EntityLevel.HTML)).toBe('©');
+		// &amp; is in both
+		expect(decode('foo &amp; bar', EntityLevel.HTML)).toBe('foo & bar');
+	});
+
+	it('decodes HTML entities when options.level is HTML', () => {
+		const options: DecodingOptions = { level: EntityLevel.HTML };
+		expect(decode('&copy;', options)).toBe('©');
+	});
+
+	it('decodes XML entities when options.level is XML', () => {
+		const options: DecodingOptions = { level: EntityLevel.XML };
+		expect(decode('&lt;tag&gt;', options)).toBe('<tag>');
+	});
+
+	it('passes mode to decodeHTML when level is HTML', () => {
+		// This test assumes decodeHTML respects the mode argument.
+		// We'll just check that the function doesn't throw and decodes as expected.
+		const options: DecodingOptions = { level: EntityLevel.HTML, mode: 'Strict' as any };
+		expect(decode('&copy;', options)).toBe('©');
+	});
+
+	it('ignores mode when level is XML', () => {
+		const options: DecodingOptions = { level: EntityLevel.XML, mode: 'Legacy' as any };
+		expect(decode('&lt;tag&gt;', options)).toBe('<tag>');
+	});
+
+	it('returns input unchanged if there are no entities', () => {
+		expect(decode('plain text')).toBe('plain text');
+	});
+});

--- a/packages/@withstudiocms/component-registry/test/component-proxy/decoder/util.test.ts
+++ b/packages/@withstudiocms/component-registry/test/component-proxy/decoder/util.test.ts
@@ -82,11 +82,10 @@ describe('determineBranch', () => {
 	it('returns -1 for invalid branch', () => {
 		expect(determineBranch(htmlDecodeTree, 0, 0, 9999)).toBe(-1);
 	});
-	it('returns a valid index for a valid branch', () => {
-		// This is a low-level test; we check that for '&' (38) in the root, we get a valid index
-		const idx = determineBranch(htmlDecodeTree, htmlDecodeTree[0], 1, 38);
+	it('returns a non -1 index for a valid branch (example: "a" -> 0x61) in the root', () => {
+		const idx = determineBranch(htmlDecodeTree, htmlDecodeTree[0], 1, 0x61);
 		expect(typeof idx).toBe('number');
-		expect(idx).toBe(-1);
+		expect(idx).not.toBe(-1);
 	});
 });
 

--- a/packages/@withstudiocms/component-registry/test/component-proxy/decoder/util.test.ts
+++ b/packages/@withstudiocms/component-registry/test/component-proxy/decoder/util.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+	decodeHTML,
+	decodeHTMLAttribute,
+	decodeHTMLStrict,
+	decodeXML,
+	determineBranch,
+	fromCodePoint,
+	htmlDecodeTree,
+	replaceCodePoint,
+} from '../../../src/component-proxy/decoder/util.js';
+
+describe('decodeHTML', () => {
+	it('decodes named HTML entities (legacy mode)', () => {
+		expect(decodeHTML('foo &amp; bar')).toBe('foo & bar');
+		expect(decodeHTML('2 &lt; 3 &gt; 1')).toBe('2 < 3 > 1');
+		expect(decodeHTML('Euro: &euro;')).toBe('Euro: €');
+	});
+
+	it('decodes numeric HTML entities', () => {
+		expect(decodeHTML('A&#65;B')).toBe('AAB');
+		expect(decodeHTML('A&#x41;B')).toBe('AAB');
+		expect(decodeHTML('Smile: &#128512;')).toBe('Smile: 😀');
+	});
+
+	it('handles incomplete or invalid entities gracefully', () => {
+		expect(decodeHTML('foo &invalid bar')).toBe('foo &invalid bar');
+		expect(decodeHTML('foo &amp bar')).toBe('foo & bar');
+		expect(decodeHTML('foo & bar')).toBe('foo & bar');
+	});
+
+	it('supports DecodingMode.Legacy by default', () => {
+		expect(decodeHTML('foo &amp bar')).toBe('foo & bar');
+		expect(decodeHTML('foo &amp; bar')).toBe('foo & bar');
+	});
+});
+
+describe('decodeHTMLStrict', () => {
+	it('decodes only semicolon-terminated entities', () => {
+		expect(decodeHTMLStrict('foo &amp; bar')).toBe('foo & bar');
+		expect(decodeHTMLStrict('foo &amp bar')).toBe('foo &amp bar');
+		expect(decodeHTMLStrict('foo &lt; bar')).toBe('foo < bar');
+	});
+});
+
+describe('decodeHTMLAttribute', () => {
+	it('decodes entities in attribute mode', () => {
+		expect(decodeHTMLAttribute('Tom &amp; Jerry')).toBe('Tom & Jerry');
+		expect(decodeHTMLAttribute('x &lt y')).toBe('x < y');
+		expect(decodeHTMLAttribute('foo &amp bar')).toBe('foo & bar');
+	});
+});
+
+describe('decodeXML', () => {
+	it('decodes XML entities strictly', () => {
+		expect(decodeXML('foo &amp; bar')).toBe('foo & bar');
+		expect(decodeXML('foo &lt; bar')).toBe('foo < bar');
+		expect(decodeXML('foo &amp bar')).toBe('foo &amp bar');
+		expect(decodeXML('foo &unknown; bar')).toBe('foo &unknown; bar');
+	});
+});
+
+describe('fromCodePoint', () => {
+	it('returns string for valid code points', () => {
+		expect(fromCodePoint(65)).toBe('A');
+		expect(fromCodePoint(0x1f600)).toBe('😀');
+	});
+});
+
+describe('replaceCodePoint', () => {
+	it('returns replacement character for invalid code points', () => {
+		expect(replaceCodePoint(0x110000)).toBe(0xfffd);
+		expect(replaceCodePoint(-1)).toBe(-1);
+	});
+	it('returns code point for valid code points', () => {
+		expect(replaceCodePoint(65)).toBe(65);
+		expect(replaceCodePoint(0x1f600)).toBe(0x1f600);
+	});
+});
+
+describe('determineBranch', () => {
+	it('returns -1 for invalid branch', () => {
+		expect(determineBranch(htmlDecodeTree, 0, 0, 9999)).toBe(-1);
+	});
+	it('returns a valid index for a valid branch', () => {
+		// This is a low-level test; we check that for '&' (38) in the root, we get a valid index
+		const idx = determineBranch(htmlDecodeTree, htmlDecodeTree[0], 1, 38);
+		expect(typeof idx).toBe('number');
+		expect(idx).toBe(-1);
+	});
+});
+
+describe('decodeHTML (edge cases)', () => {
+	it('returns input if no entities present', () => {
+		expect(decodeHTML('plain text')).toBe('plain text');
+	});
+	it('handles multiple entities', () => {
+		expect(decodeHTML('&lt;&gt;&amp;')).toBe('<>&');
+	});
+	it('handles empty string', () => {
+		expect(decodeHTML('')).toBe('');
+	});
+});

--- a/packages/@withstudiocms/component-registry/test/component-proxy/index.test.ts
+++ b/packages/@withstudiocms/component-registry/test/component-proxy/index.test.ts
@@ -29,4 +29,34 @@ describe('createComponentProxy', () => {
 		expect(proxy.mycomponent).toBeDefined();
 		expect(typeof proxy.mycomponent).toBe('function');
 	});
+
+	it('proxies function components and processes props and children', async () => {
+		const mockRenderJSX = vi.fn().mockResolvedValue('<div>hello - world</div>');
+		const mockJSX = vi.fn().mockReturnValue('<div></div>');
+		const mockUnsafeHTML = vi.fn().mockReturnValue('<div>hello - world</div>');
+
+		const proxy = createComponentProxy(
+			result,
+			{
+				MyComponent: (props: any, children: any) => {
+					return `<div>${props.text} - ${children?.value || ''}</div>`;
+				},
+			},
+			{
+				renderJSX: mockRenderJSX,
+				jsx: mockJSX,
+				__unsafeHTML: mockUnsafeHTML,
+			}
+		);
+
+		const output = await proxy.mycomponent({ text: 'hello' }, { value: 'world' });
+
+		expect(mockJSX).toHaveBeenCalledWith(expect.any(Function), {
+			text: 'hello',
+			'set:html': 'world',
+		});
+		expect(mockRenderJSX).toHaveBeenCalledWith(result, '<div></div>');
+		expect(mockUnsafeHTML).toHaveBeenCalledWith('<div>hello - world</div>');
+		expect(output).toBe('<div>hello - world</div>');
+	});
 });

--- a/packages/@withstudiocms/component-registry/test/component-proxy/index.test.ts
+++ b/packages/@withstudiocms/component-registry/test/component-proxy/index.test.ts
@@ -1,0 +1,21 @@
+import type { SSRResult } from 'astro';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createComponentProxy } from '../../src/component-proxy/index.js';
+
+describe('createComponentProxy', () => {
+	let result: SSRResult;
+
+	beforeEach(() => {
+		result = {} as SSRResult;
+	});
+
+	it('returns an empty object if no components are provided', () => {
+		const proxy = createComponentProxy(result);
+		expect(proxy).toEqual(Object.create(null));
+	});
+
+	it('proxies string components directly', () => {
+		const proxy = createComponentProxy(result, { Foo: 'bar' });
+		expect(proxy.foo).toBe('bar');
+	});
+});

--- a/packages/@withstudiocms/component-registry/test/component-proxy/index.test.ts
+++ b/packages/@withstudiocms/component-registry/test/component-proxy/index.test.ts
@@ -1,3 +1,4 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: allowed in tests */
 import type { SSRResult } from 'astro';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createComponentProxy } from '../../src/component-proxy/index.js';
@@ -58,5 +59,72 @@ describe('createComponentProxy', () => {
 		expect(mockRenderJSX).toHaveBeenCalledWith(result, '<div></div>');
 		expect(mockUnsafeHTML).toHaveBeenCalledWith('<div>hello - world</div>');
 		expect(output).toBe('<div>hello - world</div>');
+	});
+
+	it('decodes code prop for CodeBlock and CodeSpan components', async () => {
+		const encoded = btoa('console.log("Hello, World!");');
+		const mockRenderJSX = vi.fn().mockResolvedValue('<pre>console.log("Hello, World!");</pre>');
+		const mockJSX = vi.fn().mockReturnValue('<pre></pre>');
+		const mockUnsafeHTML = vi.fn().mockReturnValue('<pre>console.log("Hello, World!");</pre>');
+
+		const proxy = createComponentProxy(
+			result,
+			{
+				CodeBlock: (props: any) => {
+					return `<pre>${props.code}</pre>`;
+				},
+				CodeSpan: (props: any) => {
+					return `<code>${props.code}</code>`;
+				},
+			},
+			{
+				renderJSX: mockRenderJSX,
+				jsx: mockJSX,
+				__unsafeHTML: mockUnsafeHTML,
+			}
+		);
+
+		const outputBlock = await proxy.codeblock({ code: encoded }, null);
+		expect(mockRenderJSX).toHaveBeenCalledWith(result, '<pre></pre>');
+		expect(mockUnsafeHTML).toHaveBeenCalledWith('<pre>console.log("Hello, World!");</pre>');
+		expect(outputBlock).toBe('<pre>console.log("Hello, World!");</pre>');
+
+		const outputSpan = await proxy.codespan({ code: encoded }, null);
+		expect(mockRenderJSX).toHaveBeenCalledWith(result, '<pre></pre>');
+		expect(mockUnsafeHTML).toHaveBeenCalledWith('<pre>console.log("Hello, World!");</pre>');
+		expect(outputSpan).toBe('<pre>console.log("Hello, World!");</pre>');
+	});
+
+	it('handles decoding errors gracefully', async () => {
+		const invalidEncoded = '!!!invalid-base64!!!';
+		const mockRenderJSX = vi.fn().mockResolvedValue('<pre>!!!invalid-base64!!!</pre>');
+		const mockJSX = vi.fn().mockReturnValue('<pre></pre>');
+		const mockUnsafeHTML = vi.fn().mockReturnValue('<pre>!!!invalid-base64!!!</pre>');
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		const proxy = createComponentProxy(
+			result,
+			{
+				CodeBlock: (props: any) => {
+					return `<pre>${props.code}</pre>`;
+				},
+			},
+			{
+				renderJSX: mockRenderJSX,
+				jsx: mockJSX,
+				__unsafeHTML: mockUnsafeHTML,
+			}
+		);
+
+		const output = await proxy.codeblock({ code: invalidEncoded }, null);
+		expect(mockJSX).toHaveBeenCalledWith(expect.any(Function), {
+			code: '!!!invalid-base64!!!',
+			'set:html': undefined,
+		});
+		expect(mockRenderJSX).toHaveBeenCalledWith(result, '<pre></pre>');
+		expect(mockUnsafeHTML).toHaveBeenCalledWith('<pre>!!!invalid-base64!!!</pre>');
+		expect(output).toBe('<pre>!!!invalid-base64!!!</pre>');
+
+		consoleWarnSpy.mockRestore();
 	});
 });

--- a/packages/@withstudiocms/component-registry/test/component-proxy/index.test.ts
+++ b/packages/@withstudiocms/component-registry/test/component-proxy/index.test.ts
@@ -1,5 +1,5 @@
 import type { SSRResult } from 'astro';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createComponentProxy } from '../../src/component-proxy/index.js';
 
 describe('createComponentProxy', () => {
@@ -17,5 +17,16 @@ describe('createComponentProxy', () => {
 	it('proxies string components directly', () => {
 		const proxy = createComponentProxy(result, { Foo: 'bar' });
 		expect(proxy.foo).toBe('bar');
+	});
+
+	it('proxies function components correctly', async () => {
+		const proxy = createComponentProxy(result, {
+			MyComponent: (props: any, children: any) => {
+				return `<div>${props.text} - ${children?.value || ''}</div>`;
+			},
+		});
+
+		expect(proxy.mycomponent).toBeDefined();
+		expect(typeof proxy.mycomponent).toBe('function');
 	});
 });

--- a/packages/@withstudiocms/component-registry/test/errors.test.ts
+++ b/packages/@withstudiocms/component-registry/test/errors.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { ComponentProxyError, prefixError, toComponentProxyError } from '../src/errors.js';
+
+describe('ComponentProxyError', () => {
+	it('should set message, hint, stack, and name', () => {
+		const err = new ComponentProxyError('msg', 'hint', 'stacktrace');
+		expect(err).toBeInstanceOf(ComponentProxyError);
+		expect(err.message).toBe('msg');
+		expect(err.hint).toBe('hint');
+		expect(err.stack).toBe('stacktrace');
+		expect(err.name).toBe('Component Proxy Error');
+	});
+
+	it('should inherit from AstroError', () => {
+		const err = new ComponentProxyError('msg', 'hint');
+		expect(err instanceof ComponentProxyError).toBe(true);
+	});
+});
+
+describe('prefixError', () => {
+	it('should prefix the message of a standard Error', () => {
+		const err = new Error('original');
+		const result = prefixError(err, 'PREFIX');
+		expect(result.message).toBe('PREFIX:\noriginal');
+		expect(result).toBe(err);
+	});
+
+	it('should handle errors without a message property', () => {
+		const err = {};
+		const result = prefixError(err as Error, 'PREFIX');
+		expect(result).toBeInstanceOf(Error);
+		expect(result.message.startsWith('PREFIX')).toBe(true);
+	});
+
+	it('should preserve stack and cause if possible', () => {
+		const err = new Error('fail');
+		err.stack = 'stacktrace';
+		// @ts-ignore
+		err.cause = new Error('cause');
+		const result = prefixError(err, 'PFX');
+		expect(result.stack).toBe('stacktrace');
+		// cause may not be set if the original error had a message property
+		// so only check if it's a new error
+		if (result !== err) {
+			expect(result.cause).toBe(err);
+		}
+	});
+
+	it('should handle null/undefined error gracefully', () => {
+		// @ts-expect-error purposely breaking type for test
+		const result = prefixError(undefined, 'PFX');
+		expect(result).toBeInstanceOf(Error);
+		expect(result.message.startsWith('PFX')).toBe(true);
+	});
+
+	it('toComponentProxyError should wrap error with prefix and return ComponentProxyError', () => {
+		const original = new Error('original error');
+		original.stack = 'stacktrace';
+		const result = ComponentProxyError.prototype.constructor
+			? toComponentProxyError(original, 'PREFIX')
+			: undefined;
+		expect(result).toBeInstanceOf(ComponentProxyError);
+		expect(result?.message).toBe('PREFIX:\noriginal error');
+		expect(result?.hint).toBe('PREFIX:\noriginal error');
+		expect(result?.stack).toBe('stacktrace');
+		expect(result?.name).toBe('Component Proxy Error');
+	});
+
+	it('toComponentProxyError should handle errors without message property', async () => {
+		const err = {} as Error;
+
+		const result = toComponentProxyError(err, 'PFX');
+		expect(result).toBeInstanceOf(ComponentProxyError);
+		expect(result.message.startsWith('PFX')).toBe(true);
+		expect(result.hint?.startsWith('PFX')).toBe(true);
+	});
+
+	it('toComponentProxyError should handle undefined error gracefully', async () => {
+		// @ts-expect-error we are breaking this on purpose
+		const result = toComponentProxyError(undefined, 'PFX');
+		expect(result).toBeInstanceOf(ComponentProxyError);
+		expect(result.message.startsWith('PFX')).toBe(true);
+		expect(result.hint?.startsWith('PFX')).toBe(true);
+	});
+});

--- a/packages/@withstudiocms/component-registry/test/fixtures/registry-test/astro.config.mts
+++ b/packages/@withstudiocms/component-registry/test/fixtures/registry-test/astro.config.mts
@@ -1,0 +1,43 @@
+import { componentRegistryHandler } from '@withstudiocms/component-registry';
+import type { AstroIntegration } from 'astro';
+import { defineConfig } from 'astro/config';
+import { addVirtualImports, createResolver } from 'astro-integration-kit';
+
+const label = 'test-integration';
+
+const { resolve } = createResolver(import.meta.url);
+
+const testIntegration: AstroIntegration = {
+	name: label,
+	hooks: {
+		'astro:config:setup': async (params) => {
+			// Setup Component Registry
+			await componentRegistryHandler(params, {
+				config: {
+					name: label,
+					verbose: true,
+					virtualId: 'test:component-registry',
+				},
+				componentRegistry: {
+					'test-comp': resolve('./src/components/test-comp.astro'),
+				},
+			});
+
+			addVirtualImports(params, {
+				name: label,
+				imports: {
+					'virtual:test-config': `export const config = ${JSON.stringify({ test: true })};`,
+				},
+			});
+		},
+	},
+};
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [testIntegration],
+	output: 'static',
+	devToolbar: {
+		enabled: false,
+	},
+});

--- a/packages/@withstudiocms/component-registry/test/fixtures/registry-test/package.json
+++ b/packages/@withstudiocms/component-registry/test/fixtures/registry-test/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@test-component-registry/registry-test",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "@withstudiocms/component-registry": "workspace:*",
+    "astro": "catalog:astrojs",
+    "astro-integration-kit": "catalog:"
+  }
+}

--- a/packages/@withstudiocms/component-registry/test/fixtures/registry-test/src/components/test-comp.astro
+++ b/packages/@withstudiocms/component-registry/test/fixtures/registry-test/src/components/test-comp.astro
@@ -1,0 +1,31 @@
+---
+import { Debug } from 'astro:components';
+
+interface Props {
+	/**
+	 * A string property.
+	 *
+	 * @default Hello World
+	 */
+	foo: string;
+	/**
+	 * A number property.
+	 *
+	 * @default 42
+	 */
+	bar: number;
+	/**
+	 * Example Template literal
+	 *
+	 * @default foo-bar-baz.42
+	 */
+	baz: `${string}-${string}-${string}.${number}`;
+}
+---
+
+<div>
+	<h1>Test Component</h1>
+	<p>This is a test Astro component for the WYSIWYG editor.</p>
+	<Debug props={Astro.props} />
+	<slot />
+</div>

--- a/packages/@withstudiocms/component-registry/test/fixtures/registry-test/src/pages/index.ts
+++ b/packages/@withstudiocms/component-registry/test/fixtures/registry-test/src/pages/index.ts
@@ -1,0 +1,12 @@
+// @ts-expect-error: virtual module
+import { componentProps } from 'test:component-registry';
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = () => {
+	const components = componentProps;
+
+	return new Response(JSON.stringify(components), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+};

--- a/packages/@withstudiocms/component-registry/test/fixtures/registry-test/tsconfig.json
+++ b/packages/@withstudiocms/component-registry/test/fixtures/registry-test/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "files": [],
+  "exclude": ["dist"],
+  "include": ["**/*", ".astro/types.d.ts"]
+}

--- a/packages/@withstudiocms/component-registry/test/registry-test.test.ts
+++ b/packages/@withstudiocms/component-registry/test/registry-test.test.ts
@@ -38,53 +38,45 @@ describe('Component Registry Integration tests', () => {
 		it('the endpoint responds with the expected config', async () => {
 			const json = await res.json();
 
-			expect(json).toEqual([
-				{
-					name: 'test-comp',
-					props: [
-						{
-							name: 'foo',
-							type: 'string',
-							optional: false,
-							description: 'A string property.',
-							defaultValue: 'Hello World',
-							jsDocTags: [
-								{
-									tagName: 'default',
-									text: 'Hello World',
-								},
-							],
-						},
-						{
-							name: 'bar',
-							type: 'number',
-							optional: false,
-							description: 'A number property.',
-							defaultValue: '42',
-							jsDocTags: [
-								{
-									tagName: 'default',
-									text: '42',
-								},
-							],
-						},
-						{
-							name: 'baz',
-							type: '`${string}-${string}-${string}.${number}`',
-							optional: false,
-							description: 'Example Template literal',
-							defaultValue: 'foo-bar-baz.42',
-							jsDocTags: [
-								{
-									tagName: 'default',
-									text: 'foo-bar-baz.42',
-								},
-							],
-						},
-					],
-					safeName: 'test_comp',
-				},
-			]);
+			const entry = json.find((entry: { name: string }) => entry.name === 'test-comp');
+
+			expect(entry).toBeDefined();
+
+			expect(entry.name).toBe('test-comp');
+			expect(entry.safeName).toBe('test_comp');
+
+			expect(entry.props).toBeDefined();
+			expect(entry.props.length).toBe(3);
+
+			expect(entry.props[0].name).toBe('foo');
+			expect(entry.props[0].type).toBe('string');
+			expect(entry.props[0].optional).toBe(false);
+			expect(entry.props[0].description).toBe('A string property.');
+			expect(entry.props[0].defaultValue).toBe('Hello World');
+			expect(entry.props[0].jsDocTags).toBeDefined();
+			expect(entry.props[0].jsDocTags.length).toBe(1);
+			expect(entry.props[0].jsDocTags[0].tagName).toBe('default');
+			expect(entry.props[0].jsDocTags[0].text).toBe('Hello World');
+
+			expect(entry.props[1].name).toBe('bar');
+			expect(entry.props[1].type).toBe('number');
+			expect(entry.props[1].optional).toBe(false);
+			expect(entry.props[1].description).toBe('A number property.');
+			expect(entry.props[1].defaultValue).toBe('42');
+			expect(entry.props[1].jsDocTags).toBeDefined();
+			expect(entry.props[1].jsDocTags.length).toBe(1);
+			expect(entry.props[1].jsDocTags[0].tagName).toBe('default');
+			expect(entry.props[1].jsDocTags[0].text).toBe('42');
+
+			expect(entry.props[2].name).toBe('baz');
+			expect(entry.props[2].type).toBe('`${string}-${string}-${string}.${number}`');
+			expect(entry.props[2].optional).toBe(false);
+			expect(entry.props[2].description).toBe('Example Template literal');
+			expect(entry.props[2].defaultValue).toBe('foo-bar-baz.42');
+			expect(entry.props[2].jsDocTags).toBeDefined();
+			expect(entry.props[2].jsDocTags.length).toBe(1);
+			expect(entry.props[2].jsDocTags[0].tagName).toBe('default');
+			expect(entry.props[2].jsDocTags[0].text).toBe('foo-bar-baz.42');
 		});
 	});
 });

--- a/packages/@withstudiocms/component-registry/test/registry-test.test.ts
+++ b/packages/@withstudiocms/component-registry/test/registry-test.test.ts
@@ -1,0 +1,90 @@
+/** biome-ignore-all lint/suspicious/noTemplateCurlyInString: this is fine */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { type DevServer, type Fixture, loadFixture, MockFunction } from './test-utils.js';
+
+describe('Component Registry Integration tests', () => {
+	let fixture: Fixture;
+	let devServer: DevServer;
+	let consoleErrorMock: MockFunction<Console, 'error'>;
+
+	beforeAll(async () => {
+		consoleErrorMock = new MockFunction(console, 'error');
+		fixture = await loadFixture({ root: './fixtures/registry-test/' });
+		devServer = await fixture.startDevServer({});
+	});
+
+	afterAll(async () => {
+		consoleErrorMock.restore();
+		await devServer.stop();
+	});
+
+	beforeEach(() => {
+		consoleErrorMock.reset();
+	});
+
+	describe('the integration loads and serves basic config over endpoint', () => {
+		let res: Response;
+
+		beforeAll(async () => {
+			res = await fixture.fetch('/', {
+				method: 'GET',
+			});
+		});
+
+		it('the endpoint responds with 200', () => {
+			expect(res.status).toBe(200);
+		});
+
+		it('the endpoint responds with the expected config', async () => {
+			const json = await res.json();
+
+			expect(json).toEqual([
+				{
+					name: 'test-comp',
+					props: [
+						{
+							name: 'foo',
+							type: 'string',
+							optional: false,
+							description: 'A string property.',
+							defaultValue: 'Hello World',
+							jsDocTags: [
+								{
+									tagName: 'default',
+									text: 'Hello World',
+								},
+							],
+						},
+						{
+							name: 'bar',
+							type: 'number',
+							optional: false,
+							description: 'A number property.',
+							defaultValue: '42',
+							jsDocTags: [
+								{
+									tagName: 'default',
+									text: '42',
+								},
+							],
+						},
+						{
+							name: 'baz',
+							type: '`${string}-${string}-${string}.${number}`',
+							optional: false,
+							description: 'Example Template literal',
+							defaultValue: 'foo-bar-baz.42',
+							jsDocTags: [
+								{
+									tagName: 'default',
+									text: 'foo-bar-baz.42',
+								},
+							],
+						},
+					],
+					safeName: 'test_comp',
+				},
+			]);
+		});
+	});
+});

--- a/packages/@withstudiocms/component-registry/test/registry/PropsParser.test.ts
+++ b/packages/@withstudiocms/component-registry/test/registry/PropsParser.test.ts
@@ -1,0 +1,110 @@
+import { Effect, runEffect } from '@withstudiocms/effect';
+import { describe, expect, it } from 'vitest';
+import { PropsParser } from '../../src/registry/PropsParser.js';
+
+describe('PropsParser', async () => {
+	const parser = await runEffect(PropsParser.pipe(Effect.provide(PropsParser.Default)));
+
+	describe('parseComponentProps', () => {
+		it('parses interface props with JSDoc', async () => {
+			const source = `
+                /**
+                 * Props for MyComponent
+                 */
+                export interface Props {
+                    /** The title to display */
+                    title: string;
+                    /** The count (optional) */
+                    count?: number;
+                    /**
+                     * Is enabled
+                     * @default true
+                     */
+                    enabled?: boolean;
+                }
+            `;
+			const result = await runEffect(parser.parseComponentProps(source));
+			expect(result).toHaveLength(1);
+			expect(result[0].name).toBe('Props');
+			expect(result[0].props).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ name: 'title', type: 'string', optional: false }),
+					expect.objectContaining({ name: 'count', type: 'number', optional: true }),
+					expect.objectContaining({
+						name: 'enabled',
+						type: 'boolean',
+						optional: true,
+						defaultValue: 'true',
+					}),
+				])
+			);
+		});
+
+		it('parses type alias props', async () => {
+			const source = `
+                export type Props = {
+                    /** Foo string */
+                    foo: string;
+                    bar?: number;
+                }
+            `;
+			const result = await runEffect(parser.parseComponentProps(source));
+			expect(result).toHaveLength(1);
+			expect(result[0].name).toBe('Props');
+			expect(result[0].props).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ name: 'foo', type: 'string', optional: false }),
+					expect.objectContaining({ name: 'bar', type: 'number', optional: true }),
+				])
+			);
+		});
+	});
+
+	describe('extractPropsFromAstroFile', () => {
+		it('extracts Props interface from Astro frontmatter', async () => {
+			const astro = `
+---
+export interface Props {
+    /** Title */
+    title: string;
+}
+const { title } = Astro.props;
+---`;
+			const result = await runEffect(parser.extractPropsFromAstroFile(astro));
+			expect(result).toContain('interface Props');
+			expect(result).toContain('title: string');
+		});
+
+		it('extracts Props type alias from Astro frontmatter', async () => {
+			const astro = `
+---
+export type Props = {
+    foo: string;
+}
+---`;
+			const result = await runEffect(parser.extractPropsFromAstroFile(astro));
+			expect(result).toContain('type Props');
+			expect(result).toContain('foo: string');
+		});
+
+		it('returns error if no frontmatter', async () => {
+			const astro = '<h1>No frontmatter</h1>';
+			const result = await runEffect(parser.extractPropsFromAstroFile(astro).pipe(Effect.either));
+			expect(result._tag).toBe('Left');
+			// @ts-expect-error
+			expect(result.left).toBeInstanceOf(Error);
+			// @ts-expect-error
+			expect(result.left.message).toMatch(/No frontmatter/);
+		});
+
+		it('returns error if no Props found', async () => {
+			const astro = '---\nconst foo = 1;\n---\n<h1>No Props</h1>';
+			const result = await runEffect(parser.extractPropsFromAstroFile(astro).pipe(Effect.either));
+			expect(result._tag).toBe('Left');
+			// @ts-expect-error
+			expect(result.left).toBeInstanceOf(Error);
+			// @ts-expect-error
+			expect(result.left.message).toMatch(/No Props interface or type/);
+		});
+	});
+});

--- a/packages/@withstudiocms/component-registry/test/registry/consts.test.ts
+++ b/packages/@withstudiocms/component-registry/test/registry/consts.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildAliasExports,
+	buildVirtualImport,
+	InternalId,
+	RuntimeInternalId,
+} from '../../src/registry/consts.js';
+import type { ComponentRegistryEntry } from '../../src/types.js';
+
+describe('buildVirtualImport', () => {
+	it('should generate virtual import code with given keys, props, and components', () => {
+		const componentKeys = ['Button', 'Input'];
+		const componentProps: ComponentRegistryEntry[] = [
+			{
+				name: 'Button',
+				safeName: 'button',
+				props: [{ name: 'Button', type: 'string', optional: false }],
+			},
+			{
+				name: 'Input',
+				safeName: 'input',
+				props: [{ name: 'Input', type: 'string', optional: false }],
+			},
+		];
+		const components = ['export const Button = () => {};', 'export const Input = () => {};'];
+
+		const result = buildVirtualImport(componentKeys, componentProps, components);
+
+		expect(result).toContain(`export const componentKeys = ${JSON.stringify(componentKeys)};`);
+		expect(result).toContain(`export const componentProps = ${JSON.stringify(componentProps)};`);
+		expect(result).toContain('export const Button = () => {};');
+		expect(result).toContain('export const Input = () => {};');
+	});
+
+	it('should handle empty arrays', () => {
+		const result = buildVirtualImport([], [], []);
+		expect(result).toContain('export const componentKeys = [];');
+		expect(result).toContain('export const componentProps = [];');
+		// Should not throw or add extra newlines
+		expect(result.trim().endsWith('];')).toBe(true);
+	});
+
+	it('should handle undefined components array gracefully', () => {
+		// @ts-expect-error testing undefined for components
+		const result = buildVirtualImport(['A'], [{ key: 'A', props: {} }], undefined);
+		expect(result).toContain('export const componentKeys = ["A"];');
+		expect(result).toContain('export const componentProps = [{"key":"A","props":{}}];');
+	});
+});
+
+describe('buildAliasExports', () => {
+	it('should return correct export statements for a given virtualId', () => {
+		const virtualId = 'my-module';
+		const result = buildAliasExports(virtualId);
+
+		expect(result).toHaveProperty(virtualId, `export * from '${InternalId}';`);
+		expect(result).toHaveProperty(`${virtualId}/runtime`, `export * from '${RuntimeInternalId}';`);
+	});
+
+	it('should work with different virtualIds', () => {
+		const virtualId = 'another-module';
+		const result = buildAliasExports(virtualId);
+
+		expect(result[virtualId]).toBe(`export * from '${InternalId}';`);
+		expect(result[`${virtualId}/runtime`]).toBe(`export * from '${RuntimeInternalId}';`);
+	});
+
+	it('should not include extra keys', () => {
+		const virtualId = 'test-module';
+		const result = buildAliasExports(virtualId);
+
+		expect(Object.keys(result)).toEqual([virtualId, `${virtualId}/runtime`]);
+	});
+});

--- a/packages/@withstudiocms/component-registry/test/registry/handler.test.ts
+++ b/packages/@withstudiocms/component-registry/test/registry/handler.test.ts
@@ -1,0 +1,57 @@
+import { Effect } from '@withstudiocms/effect';
+import { describe, expect, it, vi } from 'vitest';
+import { resolver } from '../../src/registry/handler.js';
+
+// Mock createResolver from astro-integration-kit
+vi.mock('astro-integration-kit', async () => {
+	return {
+		createResolver: (base: string) => ({
+			resolve: (...paths: string[]) => [base, ...paths].join('/'),
+		}),
+		defineUtility: () => () => {},
+		addVirtualImports: vi.fn(),
+	};
+});
+
+describe('resolver', () => {
+	const basePath = '/base/path';
+
+	it('returns an Effect-wrapped resolver that resolves paths correctly', async () => {
+		const resolveEffect = await Effect.runPromise(resolver(basePath));
+		const result = await Effect.runPromise(resolveEffect((resolve) => resolve('component.astro')));
+		expect(result).toBe('/base/path/component.astro');
+	});
+
+	it('catches errors thrown in the callback and returns an Error', async () => {
+		const errorMsg = 'Test error';
+		const resolveEffect = await Effect.runPromise(resolver(basePath));
+		const result = await Effect.runPromise(
+			Effect.exit(
+				resolveEffect(() => {
+					throw new Error(errorMsg);
+				})
+			)
+		);
+		expect(result._tag).toBe('Failure');
+
+		// biome-ignore lint/suspicious/noExplicitAny: allow any for testing
+		const resultData = result.toJSON() as any;
+
+		console.log(resultData);
+
+		expect(resultData.cause.failure).toBeInstanceOf(Error);
+
+		expect((resultData.cause.failure as unknown as Error).message).toBe(
+			'Failed to resolve component'
+		);
+		expect((resultData.cause.failure as unknown as Error).cause).toBeInstanceOf(Error);
+		// @ts-expect-error - this is a test
+		expect((resultData.cause.failure as unknown as Error).cause?.message).toBe(errorMsg);
+	});
+
+	it('passes the correct resolve function to the callback', async () => {
+		const resolveEffect = await Effect.runPromise(resolver(basePath));
+		const result = await Effect.runPromise(resolveEffect((resolve) => resolve('foo', 'bar.astro')));
+		expect(result).toBe('/base/path/foo/bar.astro');
+	});
+});

--- a/packages/@withstudiocms/component-registry/test/test-utils.ts
+++ b/packages/@withstudiocms/component-registry/test/test-utils.ts
@@ -1,0 +1,52 @@
+import {
+	loadFixture as baseLoadFixture,
+	type DevServer,
+	type Fixture,
+} from '@inox-tools/astro-tests/astroFixture';
+
+type InlineConfig = Omit<Parameters<typeof baseLoadFixture>[0], 'root'> & {
+	root: string;
+};
+
+export type { Fixture, DevServer };
+
+export function loadFixture(inlineConfig: InlineConfig) {
+	if (!inlineConfig?.root) throw new Error("Must provide { root: './fixtures/...' }");
+
+	// resolve the relative root (i.e. "./fixtures/tailwindcss") to a full filepath
+	// without this, the main `loadFixture` helper will resolve relative to `packages/astro/test`
+	return baseLoadFixture({
+		...inlineConfig,
+		root: new URL(inlineConfig.root, import.meta.url).toString(),
+	});
+}
+
+export function startOfHourISOString() {
+	const date = new Date();
+	date.setMinutes(0, 0, 0);
+	return date.toISOString();
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: This is fine
+export class MockFunction<T extends Record<K, (...args: any[]) => void>, K extends keyof T> {
+	calls: Parameters<T[K]>[] = [];
+	object: T;
+	property: K;
+	original: T[K];
+
+	constructor(object: T, property: K) {
+		this.object = object;
+		this.property = property;
+		this.original = object[property];
+		// @ts-ignore
+		object[property] = (...args: Parameters<T[K]>) => {
+			this.calls.push(args);
+		};
+	}
+	restore() {
+		this.object[this.property] = this.original;
+	}
+	reset() {
+		this.calls = [];
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -626,6 +626,18 @@ importers:
         specifier: 'catalog:'
         version: 5.9.2
 
+  packages/@withstudiocms/component-registry/test/fixtures/registry-test:
+    dependencies:
+      '@withstudiocms/component-registry':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: catalog:astrojs
+        version: 5.13.7(@types/node@24.3.0)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0)
+      astro-integration-kit:
+        specifier: 'catalog:'
+        version: 0.19.0(astro@5.13.7(@types/node@24.3.0)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0))
+
   packages/@withstudiocms/config-utils:
     dependencies:
       astro:
@@ -727,18 +739,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.16.3
-
-  packages/@withstudiocms/internal_helpers/test/fixtures/integration-utils:
-    dependencies:
-      '@withstudiocms/internal_helpers':
-        specifier: workspace:*
-        version: link:../../..
-      astro:
-        specifier: catalog:astrojs
-        version: 5.13.7(@types/node@24.3.0)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0)
-      astro-integration-kit:
-        specifier: 'catalog:'
-        version: 0.19.0(astro@5.13.7(@types/node@24.3.0)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0))
 
   packages/studiocms:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -46,6 +46,7 @@ export default defineConfig({
 				'**/**/scratchpad/**',
 				'**/**/test/fixtures/**',
 				'**/**/test/test-utils.ts',
+				'**/**/runtime.ts',
 			],
 		},
 	},


### PR DESCRIPTION
This pull request focuses on improving test coverage and code quality for the `@withstudiocms/component-registry` package, while also enhancing configuration for workspace tools and adding code coverage instrumentation. The most significant changes include adding tests, updating ignore patterns for test fixtures, and introducing `/* v8 ignore */` comments to improve code coverage reporting. Minor enhancements include documentation updates and a small export fix.

**Testing and Coverage Improvements:**

* Added tests for `@withstudiocms/component-registry` and included a Codecov badge in the `README.md` to display code coverage status. (.changeset/whole-times-wash.md [[1]](diffhunk://#diff-9b3cc3aedfac67c9a9e0b8b494dff47237ebfa9659e261a2a6ebfe3915b41f8aR1-R5) packages/@withstudiocms/component-registry/README.md [[2]](diffhunk://#diff-e239bf29beee5488f58db648b69c526e712e4b7c6796ee2e0c9cad10ff07d242R3-R4)
* Added `/* v8 ignore start */` and `/* v8 ignore stop */` comments throughout the codebase to exclude specific code paths from v8 coverage, improving the accuracy of coverage metrics. (Multiple: [[1]](diffhunk://#diff-9d992143130fff6a2573a24bd9dd2cb4d578678879013e1687627390760b9c00R41) [[2]](diffhunk://#diff-9d992143130fff6a2573a24bd9dd2cb4d578678879013e1687627390760b9c00R54) [[3]](diffhunk://#diff-9d22ea24ec4e9344e0f1c3c8e0b84e3488baac7332e1829bb3ed76abb06d24eeR158) [[4]](diffhunk://#diff-9d22ea24ec4e9344e0f1c3c8e0b84e3488baac7332e1829bb3ed76abb06d24eeR174) [[5]](diffhunk://#diff-9d22ea24ec4e9344e0f1c3c8e0b84e3488baac7332e1829bb3ed76abb06d24eeR188-R192) [[6]](diffhunk://#diff-9d22ea24ec4e9344e0f1c3c8e0b84e3488baac7332e1829bb3ed76abb06d24eeR235-R239) [[7]](diffhunk://#diff-9d22ea24ec4e9344e0f1c3c8e0b84e3488baac7332e1829bb3ed76abb06d24eeR264-R268) [[8]](diffhunk://#diff-9d22ea24ec4e9344e0f1c3c8e0b84e3488baac7332e1829bb3ed76abb06d24eeR286-R312) [[9]](diffhunk://#diff-9d22ea24ec4e9344e0f1c3c8e0b84e3488baac7332e1829bb3ed76abb06d24eeR373-R375) [[10]](diffhunk://#diff-9d22ea24ec4e9344e0f1c3c8e0b84e3488baac7332e1829bb3ed76abb06d24eeR410-R420) [[11]](diffhunk://#diff-9d22ea24ec4e9344e0f1c3c8e0b84e3488baac7332e1829bb3ed76abb06d24eeR454) [[12]](diffhunk://#diff-5ba35b744c27f6188b7882cbe426f49eb84c6ca65e4828b9175c398a96c09918R22-R26) [[13]](diffhunk://#diff-3065d75627f053d49b33514d5d95f3df0caa65329f31327af012352e21b020e7R42) [[14]](diffhunk://#diff-3065d75627f053d49b33514d5d95f3df0caa65329f31327af012352e21b020e7R54) [[15]](diffhunk://#diff-3065d75627f053d49b33514d5d95f3df0caa65329f31327af012352e21b020e7R75) [[16]](diffhunk://#diff-3065d75627f053d49b33514d5d95f3df0caa65329f31327af012352e21b020e7R90) [[17]](diffhunk://#diff-3065d75627f053d49b33514d5d95f3df0caa65329f31327af012352e21b020e7L157-R181) [[18]](diffhunk://#diff-3065d75627f053d49b33514d5d95f3df0caa65329f31327af012352e21b020e7R222) [[19]](diffhunk://#diff-3065d75627f053d49b33514d5d95f3df0caa65329f31327af012352e21b020e7R259) [[20]](diffhunk://#diff-0417dc15ef7419f9a65247c79e3826d89069aedf86caadbc1de51e9a8050f2deR64-R69) [[21]](diffhunk://#diff-b633a8dda1f6e9c157e11061c783d370659fec05a43484895bc9f28424e6c43fR75-R76) [[22]](diffhunk://#diff-b633a8dda1f6e9c157e11061c783d370659fec05a43484895bc9f28424e6c43fR254) [[23]](diffhunk://#diff-2b9a19d1c3f7a865c9d96ef5ed4381f9bb0784ccb1711335cda1f77f30b9d62eR1-R9)

**Configuration and Tooling:**

* Updated `knip.config.ts` to include `.astro` files in entry and project globs, and added ignore patterns for test fixture directories to prevent unnecessary analysis. [[1]](diffhunk://#diff-d5963738993926b3ad1d6763702f9e7a611bb6eb9d1e2c4c184f36acf7e5959fL30-R34) [[2]](diffhunk://#diff-d5963738993926b3ad1d6763702f9e7a611bb6eb9d1e2c4c184f36acf7e5959fR151-R159)

**Code Quality and API Improvements:**

* Made the `resolver` function exportable in `handler.ts` to support external usage and testing.
* Updated `createComponentProxy` to accept test props for improved testability and coverage. [[1]](diffhunk://#diff-6248a73bb1b7feac7060a396b05379e8bcdbe1e6eef40a56859d954dbf22a54cR10-R15) [[2]](diffhunk://#diff-6248a73bb1b7feac7060a396b05379e8bcdbe1e6eef40a56859d954dbf22a54cL20-R30) [[3]](diffhunk://#diff-6248a73bb1b7feac7060a396b05379e8bcdbe1e6eef40a56859d954dbf22a54cR43) [[4]](diffhunk://#diff-6248a73bb1b7feac7060a396b05379e8bcdbe1e6eef40a56859d954dbf22a54cR52-R58)

Let me know if you have questions about any of these changes or want to dive deeper into a specific area!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better error visibility when decoding code blocks (more informative warnings).
  * Exported resolver for easier integration use.

* **Documentation**
  * Added a Codecov badge and expanded handler documentation.

* **Tests**
  * Added extensive unit and integration tests for the component registry, decoders, error utilities, proxy, and fixtures.

* **Chores**
  * Include Astro files in workspace scanning, ignore test fixtures, exclude runtime from coverage, and added a changeset for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->