### PR TITLE
feat(withstudiocms/effect): Add drizzle effect wrapper

### DIFF
--- a/.changeset/deep-dolls-attack.md
+++ b/.changeset/deep-dolls-attack.md
@@ -1,0 +1,5 @@
+---
+"@withstudiocms/effect": patch
+---
+
+Add new Drizzle helper for AstroDB and Drizzle libsql connections

--- a/packages/@withstudiocms/effect/package.json
+++ b/packages/@withstudiocms/effect/package.json
@@ -70,6 +70,10 @@
 		"./clack": {
 			"types": "./dist/clack.d.ts",
 			"default": "./dist/clack.js"
+		},
+		"./drizzle": {
+			"types": "./dist/drizzle.d.ts",
+			"default": "./dist/drizzle.js"
 		}
 	},
 	"type": "module",
@@ -87,10 +91,24 @@
 		"typescript": "catalog:"
 	},
 	"peerDependencies": {
+		"@astrojs/db": "catalog:min",
 		"@effect/cli": "catalog:effect",
 		"@effect/platform": "catalog:effect",
 		"@effect/platform-node": "catalog:effect",
+		"@libsql/client": "catalog:min",
 		"astro": "catalog:min",
+		"drizzle-orm": "catalog:min",
 		"effect": "catalog:effect"
+	},
+	"peerDependenciesMeta": {
+		"@astrojs/db": {
+			"optional": true
+		},
+		"@libsql/client": {
+			"optional": true
+		},
+		"drizzle-orm": {
+			"optional": true
+		}
 	}
 }

--- a/packages/@withstudiocms/effect/src/drizzle.ts
+++ b/packages/@withstudiocms/effect/src/drizzle.ts
@@ -43,12 +43,8 @@ const useWithErrorPromise = <A>(_try: () => Promise<A>) =>
  * @typeParam Record<string, never> - The schema type for the transaction (empty object in this case).
  * @typeParam ExtractTablesWithRelations<Record<string, never>> - Extracted table relations from the schema.
  */
-export type TransactionClient = SQLiteTransaction<
-	'async',
-	ResultSet,
-	Record<string, never>,
-	ExtractTablesWithRelations<Record<string, never>>
->;
+export type TransactionClient<Schema extends Record<string, unknown> = Record<string, never>> =
+	SQLiteTransaction<'async', ResultSet, Schema, ExtractTablesWithRelations<Schema>>;
 
 /**
  * Represents a function that executes a provided asynchronous operation using a database client.
@@ -60,7 +56,7 @@ export type TransactionClient = SQLiteTransaction<
  * @returns An `Effect` that resolves to the result of type `T` or fails with a `LibSQLClientError`.
  */
 export type ExecuteFn<Schema extends Record<string, unknown> = Record<string, never>> = <T>(
-	fn: (client: LibSQLDatabase<Schema> | TransactionClient) => Promise<T>
+	fn: (client: LibSQLDatabase<Schema> | TransactionClient<Schema>) => Promise<T>
 ) => Effect.Effect<T, LibSQLClientError>;
 
 /**
@@ -70,8 +66,10 @@ export type ExecuteFn<Schema extends Record<string, unknown> = Record<string, ne
  * @param fn - A function that receives a `TransactionClient` and returns a `Promise` of type `U`.
  * @returns An `Effect` that resolves to the result of type `U` or fails with a `LibSQLClientError`.
  */
-export type TransactionContextShape = <U>(
-	fn: (client: TransactionClient) => Promise<U>
+export type TransactionContextShape<
+	Schema extends Record<string, unknown> = Record<string, never>,
+> = <U>(
+	fn: (client: TransactionClient<Schema>) => Promise<U>
 ) => Effect.Effect<U, LibSQLClientError>;
 
 /**

--- a/packages/@withstudiocms/effect/src/drizzle.ts
+++ b/packages/@withstudiocms/effect/src/drizzle.ts
@@ -1,0 +1,211 @@
+import type { Database } from '@astrojs/db/runtime';
+import type { ResultSet } from '@libsql/client';
+import type { ExtractTablesWithRelations } from 'drizzle-orm';
+import type { LibSQLDatabase } from 'drizzle-orm/libsql';
+import type { SQLiteTransaction } from 'drizzle-orm/sqlite-core';
+import { Context, Data, Effect, Option } from './effect.js';
+
+/**
+ * Represents an error specific to the LibSQL client.
+ *
+ * This error extends from `Data.TaggedError` with the tag `'LibSQLClientError'`
+ * and includes a `cause` property to provide additional context about the underlying issue.
+ *
+ * @example
+ * ```typescript
+ * throw new LibSQLClientError({ cause: originalError });
+ * ```
+ *
+ * @property cause - The underlying cause of the error, can be any value.
+ */
+export class LibSQLClientError extends Data.TaggedError('LibSQLClientError')<{ cause: unknown }> {}
+
+/**
+ * Wraps an asynchronous function returning a Promise in an Effect,
+ * converting any thrown errors into a `LibSQLClientError`.
+ *
+ * @template A The type of the resolved value from the Promise.
+ * @param _try A function that returns a Promise of type `A`.
+ * @returns An Effect that resolves with the value of the Promise,
+ *          or fails with a `LibSQLClientError` if the Promise is rejected.
+ */
+const useWithErrorPromise = <A>(_try: () => Promise<A>) =>
+	Effect.tryPromise({
+		try: _try,
+		catch: (cause) => new LibSQLClientError({ cause }),
+	});
+
+/**
+ * Represents a SQLite transaction client with asynchronous operations.
+ *
+ * @typeParam 'async' - Specifies that the transaction is asynchronous.
+ * @typeParam ResultSet - The result set type returned by queries.
+ * @typeParam Record<string, never> - The schema type for the transaction (empty object in this case).
+ * @typeParam ExtractTablesWithRelations<Record<string, never>> - Extracted table relations from the schema.
+ */
+export type TransactionClient = SQLiteTransaction<
+	'async',
+	ResultSet,
+	Record<string, never>,
+	ExtractTablesWithRelations<Record<string, never>>
+>;
+
+/**
+ * Represents a function that executes a provided asynchronous operation using a database client.
+ *
+ * @template Schema - The database schema type, defaults to an empty record.
+ * @template T - The result type of the asynchronous operation.
+ * @param fn - An asynchronous function that receives either a `LibSQLDatabase` or `TransactionClient`
+ *             and returns a promise of type `T`.
+ * @returns An `Effect` that resolves to the result of type `T` or fails with a `LibSQLClientError`.
+ */
+export type ExecuteFn<Schema extends Record<string, unknown> = Record<string, never>> = <T>(
+	fn: (client: LibSQLDatabase<Schema> | TransactionClient) => Promise<T>
+) => Effect.Effect<T, LibSQLClientError>;
+
+/**
+ * Represents a function that executes a given asynchronous operation within a transaction context.
+ *
+ * @template U The type of the value returned by the provided function.
+ * @param fn - A function that receives a `TransactionClient` and returns a `Promise` of type `U`.
+ * @returns An `Effect` that resolves to the result of type `U` or fails with a `LibSQLClientError`.
+ */
+export type TransactionContextShape = <U>(
+	fn: (client: TransactionClient) => Promise<U>
+) => Effect.Effect<U, LibSQLClientError>;
+
+/**
+ * Represents a context tag for managing transaction context within the Studiocms SDK effect system.
+ *
+ * This class extends a generic `Context.Tag` to provide a strongly-typed context for database transactions.
+ *
+ * @template TransactionContext - The type of the transaction context.
+ * @template TransactionContextShape - The shape of the transaction context.
+ *
+ * @example
+ * ```typescript
+ * const transactionContext = { /* ... *\/ };
+ * const effectWithTransaction = TransactionContext.provide(transactionContext)(someEffect);
+ * ```
+ */
+export class TransactionContext extends Context.Tag('TransactionContext')<
+	TransactionContext,
+	TransactionContextShape
+>() {
+	public static readonly provide = (
+		transaction: TransactionContextShape
+	): (<A, E, R>(
+		self: Effect.Effect<A, E, R>
+	) => Effect.Effect<A, E, Exclude<R, TransactionContext>>) =>
+		Effect.provideService(this, transaction);
+}
+
+/**
+ * Represents a DrizzleClient context tag for dependency injection.
+ *
+ * @template DrizzleClient - The type of the DrizzleClient.
+ * @template T - The context value, containing:
+ *   - `drizzle`: An instance of either `LibSQLDatabase` or `Database`.
+ *   - `schema`: A record representing the database schema.
+ *
+ * This class is used to provide and consume a Drizzle database client and its schema
+ * within a context-aware application, leveraging the Context.Tag utility for type safety.
+ */
+export class DrizzleClient extends Context.Tag('DrizzleClient')<
+	DrizzleClient,
+	{
+		drizzle: LibSQLDatabase | Database;
+		schema?: Record<string, unknown>;
+	}
+>() {}
+
+/**
+ * DrizzleDBClient is a service class that provides an interface for executing queries
+ * and commands against a Drizzle ORM database instance within an Effect system.
+ *
+ * @remarks
+ * This class extends `Effect.Service` and is registered under the service key `'DrizzleDBClient'`.
+ * It exposes two main utilities:
+ * - `execute`: A function to safely execute asynchronous operations on the Drizzle client,
+ *   handling errors using `useWithErrorPromise`.
+ * - `makeQuery`: A higher-order function to create effectful queries that can optionally
+ *   participate in a transaction context if available.
+ *
+ * @example
+ * ```typescript
+ * const { makeQuery, execute } = yield* DrizzleDBClient;
+ * const result = yield* makeQuery((exec, input) => exec( ... ));
+ * ```
+ */
+export class DrizzleDBClientService extends Effect.Service<DrizzleDBClientService>()(
+	'DrizzleDBClientService',
+	{
+		effect: Effect.gen(function* () {
+			const { drizzle, schema = {} } = yield* DrizzleClient;
+
+			/**
+			 * Executes a provided asynchronous function with the `drizzle` client,
+			 * wrapping the execution in `useWithErrorPromise` for error handling.
+			 *
+			 * @typeParam T - The return type of the asynchronous function.
+			 * @param fn - An asynchronous function that receives the `drizzle` client and returns a Promise of type `T`.
+			 * @returns An Effect that, when run, executes the provided function with the `drizzle` client and handles errors.
+			 */
+			const execute = Effect.fn(<T>(fn: (client: typeof drizzle) => Promise<T>) =>
+				useWithErrorPromise(() => fn(drizzle))
+			);
+
+			/**
+			 * Creates a query function that executes within an optional transaction context.
+			 *
+			 * @typeParam A - The type of the successful result of the effect.
+			 * @typeParam E - The type of the error that the effect may produce.
+			 * @typeParam R - The type of the required environment for the effect.
+			 * @typeParam Input - The type of the input parameter for the query function.
+			 *
+			 * @param queryFn - A function that receives an `execute` function (or transaction context) and an input,
+			 *                  returning an `Effect` representing the query operation.
+			 *
+			 * @returns A function that takes an input (if required) and returns an `Effect` that will execute the query,
+			 *          using the current transaction context if available, or the default `execute` function otherwise.
+			 *
+			 * @example
+			 * const getUserById = makeQuery((execute, id: number) =>
+			 *   Effect.tryPromise(() => execute.users.findById(id))
+			 * );
+			 * const effect = getUserById(123);
+			 */
+			const makeQuery =
+				<A, E, R, Input = never>(
+					queryFn: (execute: ExecuteFn<typeof schema>, input: Input) => Effect.Effect<A, E, R>
+				) =>
+				(...args: [Input] extends [never] ? [] : [input: Input]): Effect.Effect<A, E, R> => {
+					const input = args[0] as Input;
+					return Effect.serviceOption(TransactionContext).pipe(
+						Effect.map(Option.getOrNull),
+						Effect.flatMap((txOrNull) => queryFn(txOrNull ?? execute, input))
+					);
+				};
+
+			return { makeQuery, execute } as const;
+		}),
+	}
+) {}
+
+/**
+ * Creates a live Drizzle database client effect with the provided configuration.
+ *
+ * @template Schema - The type of the schema object, extending a record of string keys to unknown values.
+ * @param config - The configuration object for the Drizzle client.
+ * @param config.drizzle - An instance of either `LibSQLDatabase` or `Database` to be used by the client.
+ * @param [config.schema] - Optional schema definition for the database.
+ * @returns An Effect that provides a Drizzle database client service, configured with the given parameters.
+ */
+export const drizzleDBClientLive = <Schema extends Record<string, unknown>>(config: {
+	drizzle: LibSQLDatabase | Database;
+	schema?: Schema;
+}) =>
+	DrizzleDBClientService.pipe(
+		Effect.provide(DrizzleDBClientService.Default),
+		Effect.provideService(DrizzleClient, DrizzleClient.of(config))
+	);

--- a/packages/@withstudiocms/effect/test/drizzle.test.ts
+++ b/packages/@withstudiocms/effect/test/drizzle.test.ts
@@ -1,0 +1,141 @@
+import type { Database } from '@astrojs/db/runtime';
+import type { LibSQLDatabase } from 'drizzle-orm/libsql';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	DrizzleClient,
+	type DrizzleDBClientService,
+	drizzleDBClientLive,
+	type ExecuteFn,
+	LibSQLClientError,
+	type TransactionClient,
+	TransactionContext,
+} from '../src/drizzle.js';
+import { Effect, Exit } from '../src/effect.js';
+
+describe('LibSQLClientError', () => {
+	it('should set the tag and cause', () => {
+		const cause = new Error('fail');
+		const err = new LibSQLClientError({ cause });
+		expect(err._tag).toBe('LibSQLClientError');
+		expect(err.cause).toBe(cause);
+	});
+});
+
+describe('drizzleDBClientLive', () => {
+	let drizzle: LibSQLDatabase | Database;
+	let schema: Record<string, unknown>;
+
+	beforeEach(() => {
+		drizzle = {} as LibSQLDatabase;
+		schema = { users: {} };
+	});
+
+	it('should provide DrizzleDBClientService with config', async () => {
+		const effect = drizzleDBClientLive({ drizzle, schema });
+		const result = await Effect.runPromise(effect);
+		expect(result.makeQuery).toBeTypeOf('function');
+		expect(result.execute).toBeTypeOf('function');
+	});
+});
+
+describe('DrizzleDBClientService', () => {
+	let drizzle: LibSQLDatabase;
+	let schema: Record<string, unknown>;
+	let service: typeof DrizzleDBClientService.Service;
+
+	beforeEach(async () => {
+		drizzle = {
+			select: vi.fn(),
+		} as unknown as LibSQLDatabase;
+		schema = { users: {} };
+		service = await Effect.runPromise(drizzleDBClientLive({ drizzle, schema }));
+	});
+
+	describe('execute', () => {
+		it('should resolve with the result of the function', async () => {
+			const fn = vi.fn().mockResolvedValue('ok');
+			const effect = service.execute(fn);
+			const result = await Effect.runPromise(effect);
+			expect(result).toBe('ok');
+			expect(fn).toHaveBeenCalledWith(drizzle);
+		});
+
+		it('should fail with LibSQLClientError on error', async () => {
+			const error = new Error('fail');
+			const fn = vi.fn().mockRejectedValue(error);
+			const effect = service.execute(fn);
+			await expect(Effect.runPromiseExit(effect)).resolves.toEqual(
+				Exit.fail(new LibSQLClientError({ cause: error }))
+			);
+		});
+	});
+
+	describe('makeQuery', () => {
+		it('should call queryFn with execute and input', async () => {
+			const queryFn = vi
+				.fn()
+				.mockImplementation((exec: ExecuteFn, input: number) =>
+					exec((client) => Promise.resolve(client === drizzle ? input * 2 : 0))
+				);
+			const getDouble = service.makeQuery(queryFn);
+			// @ts-expect-error input is number
+			// @effect-diagnostics-next-line missingEffectContext:off
+			const result = await Effect.runPromise(getDouble(21));
+			expect(result).toBe(42);
+			expect(queryFn).toHaveBeenCalled();
+		});
+
+		it('should use TransactionContext if available', async () => {
+			const txClient = {} as TransactionClient;
+			const txFn = vi.fn().mockImplementation((fn) => Effect.tryPromise(() => fn(txClient)));
+			const queryFn = vi
+				.fn()
+				.mockImplementation((exec: ExecuteFn, input: string) =>
+					exec((client) => Promise.resolve(client === txClient ? input + '-tx' : input))
+				);
+			const getTx = service.makeQuery(queryFn);
+
+			const effect = Effect.provideService(TransactionContext, txFn)(getTx('foo'));
+			// @ts-expect-error input is number
+			// @effect-diagnostics-next-line missingEffectContext:off
+			const result = await Effect.runPromise(effect);
+			expect(result).toBe('foo-tx');
+			expect(queryFn).toHaveBeenCalled();
+		});
+
+		it('should work with no input', async () => {
+			const queryFn = vi
+				.fn()
+				.mockImplementation((exec: ExecuteFn, _input: never) =>
+					exec((_client) => Promise.resolve('no-input'))
+				);
+			const getNoInput = service.makeQuery(queryFn);
+			// @ts-expect-error input is number
+			// @effect-diagnostics-next-line missingEffectContext:off
+			const result = await Effect.runPromise(getNoInput());
+			expect(result).toBe('no-input');
+			expect(queryFn).toHaveBeenCalled();
+		});
+	});
+});
+
+describe('DrizzleClient', () => {
+	it('should create a context tag', () => {
+		const config = { drizzle: {} as LibSQLDatabase, schema: {} };
+		const tag = DrizzleClient.of(config);
+		expect(tag.drizzle).toBe(config.drizzle);
+		expect(tag.schema).toBe(config.schema);
+	});
+});
+
+describe('TransactionContext', () => {
+	it('should provide a transaction context', async () => {
+		const txFn = vi
+			.fn()
+			.mockImplementation((fn) => Effect.tryPromise(() => fn({} as TransactionClient)));
+		const effect = Effect.succeed('ok');
+		const provided = TransactionContext.provide(txFn)(effect);
+		const result = await Effect.runPromise(provided);
+		expect(result).toBe('ok');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -659,6 +659,9 @@ importers:
 
   packages/@withstudiocms/effect:
     dependencies:
+      '@astrojs/db':
+        specifier: catalog:min
+        version: 0.17.2(@opentelemetry/api@1.9.0)(@types/pg@8.6.1)
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
@@ -671,12 +674,18 @@ importers:
       '@effect/platform-node':
         specifier: catalog:effect
         version: 0.96.1(@effect/cluster@0.48.2(@effect/platform@0.90.8(effect@3.17.13))(@effect/rpc@0.69.1(@effect/platform@0.90.8(effect@3.17.13))(effect@3.17.13))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.8(effect@3.17.13))(effect@3.17.13))(@effect/platform@0.90.8(effect@3.17.13))(effect@3.17.13))(@effect/workflow@0.9.2(@effect/platform@0.90.8(effect@3.17.13))(@effect/rpc@0.69.1(@effect/platform@0.90.8(effect@3.17.13))(effect@3.17.13))(effect@3.17.13))(effect@3.17.13))(@effect/platform@0.90.8(effect@3.17.13))(@effect/rpc@0.69.1(@effect/platform@0.90.8(effect@3.17.13))(effect@3.17.13))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.8(effect@3.17.13))(effect@3.17.13))(@effect/platform@0.90.8(effect@3.17.13))(effect@3.17.13))(effect@3.17.13)
+      '@libsql/client':
+        specifier: catalog:min
+        version: 0.15.15
       astro:
         specifier: catalog:min
         version: 5.13.7(@types/node@22.16.3)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0)
       deepmerge-ts:
         specifier: 'catalog:'
         version: 7.1.5
+      drizzle-orm:
+        specifier: catalog:min
+        version: 0.42.0(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@types/pg@8.6.1)
       effect:
         specifier: catalog:effect
         version: 3.17.13
@@ -727,18 +736,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.16.3
-
-  packages/@withstudiocms/internal_helpers/test/fixtures/integration-utils:
-    dependencies:
-      '@withstudiocms/internal_helpers':
-        specifier: workspace:*
-        version: link:../../..
-      astro:
-        specifier: catalog:astrojs
-        version: 5.13.7(@types/node@24.3.0)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0)
-      astro-integration-kit:
-        specifier: 'catalog:'
-        version: 0.19.0(astro@5.13.7(@types/node@24.3.0)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0))
 
   packages/studiocms:
     dependencies:


### PR DESCRIPTION
This pull request introduces a new Drizzle helper for AstroDB and Drizzle libsql connections in the `@withstudiocms/effect` package. The update provides a robust, effect-based abstraction for working with Drizzle ORM and AstroDB, including error handling, transaction context management, and dependency injection. It also adds comprehensive tests and updates dependencies accordingly.

**New Drizzle Helper and Effect Integration:**

- Added a new module `drizzle.ts` that provides:
  - Strongly-typed context tags for Drizzle and transaction clients.
  - An effect-based service (`DrizzleDBClientService`) for executing queries and commands with error handling (`LibSQLClientError`).
  - Utilities for running queries within or outside a transaction context, and for dependency injection of Drizzle clients.
- Added comprehensive tests for all new helpers and abstractions in `drizzle.test.ts`, ensuring correct context, error handling, and transaction support.

**Package and Dependency Updates:**

- Updated `package.json` to export the new `drizzle` entry point, and declared new peer dependencies on `@astrojs/db`, `@libsql/client`, and `drizzle-orm`, marking them as optional. [[1]](diffhunk://#diff-a75faa87ef4116df6f7609ddd8564015b951244e21260ec9a1b951facea17a0dR73-R76) [[2]](diffhunk://#diff-a75faa87ef4116df6f7609ddd8564015b951244e21260ec9a1b951facea17a0dR94-R112)
- Updated `pnpm-lock.yaml` to include the new dependencies and their versions. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR662-R664) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR677-R688)
- Added a changeset describing the new helper and its purpose.

These changes provide a standardized, effectful approach to integrating Drizzle ORM and AstroDB in StudioCMS, improving type safety, error handling, and testability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Drizzle helper for AstroDB/LibSQL with typed transaction context, safe execution helpers, and a client service for queries; new subpath export exposes it.
* **Tests**
  * Added tests for error mapping, service utilities, transaction context behavior, and client configuration.
* **Chores**
  * Bumped package via changeset and declared optional peer dependencies for Astro DB, LibSQL client, and Drizzle ORM.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->