### PR TITLE
feat: add Codecov badges to README files for improved test coverage visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,24 +24,24 @@ To see how to get started with StudioCMS, check out the [StudioCMS Docs](https:/
 
 | Package | Test Coverage |
 | ------- | ------------- |
-| [studiocms](./packages/studiocms/) | Not Yet Available |
-| [@studiocms/devapps](./packages/@studiocms/devapps/) | Not Yet Available |
+| [studiocms](./packages/studiocms/) | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@studiocms/devapps](./packages/@studiocms/devapps/) | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_devapps)](https://codecov.io/github/withstudiocms/studiocms) |
 
 ### StudioCMS Plugins
 
 | Package | Category | Test Coverage |
 | ------- | -------- | ------------- |
-| [@studiocms/auth0](./packages/@studiocms/auth0/) | Authentication | Not Yet Available |
-| [@studiocms/discord](./packages/@studiocms/discord/) | Authentication | Not Yet Available |
-| [@studiocms/github](./packages/@studiocms/github/) | Authentication | Not Yet Available |
-| [@studiocms/google](./packages/@studiocms/google/) | Authentication | Not Yet Available |
-| [@studiocms/html](./packages/@studiocms/html/) | Renderer | Not Yet Available |
-| [@studiocms/markdoc](./packages/@studiocms/markdoc/) | Renderer | Not Yet Available |
-| [@studiocms/md](./packages/@studiocms/md/) | Renderer | Not Yet Available |
-| [@studiocms/mdx](./packages/@studiocms/mdx/) | Renderer | Not Yet Available |
-| [@studiocms/wysiwyg](./packages/@studiocms/wysiwyg/) | Renderer | Not Yet Available |
-| [@studiocms/cloudinary-image-service](./packages/@studiocms/cloudinary-image-service/) | Image Service | Not Yet Available |
-| [@studiocms/blog](./packages/@studiocms/blog/) | Front-End | Not Yet Available |
+| [@studiocms/auth0](./packages/@studiocms/auth0/) | Authentication | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_auth0)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@studiocms/discord](./packages/@studiocms/discord/) | Authentication | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_discord)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@studiocms/github](./packages/@studiocms/github/) | Authentication | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_github)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@studiocms/google](./packages/@studiocms/google/) | Authentication | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_google)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@studiocms/html](./packages/@studiocms/html/) | Renderer | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_html)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@studiocms/markdoc](./packages/@studiocms/markdoc/) | Renderer | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_markdoc)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@studiocms/md](./packages/@studiocms/md/) | Renderer | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_md)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@studiocms/mdx](./packages/@studiocms/mdx/) | Renderer | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_mdx)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@studiocms/wysiwyg](./packages/@studiocms/wysiwyg/) | Renderer | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_wysiwyg)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@studiocms/cloudinary-image-service](./packages/@studiocms/cloudinary-image-service/) | Image Service | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_cloudinary-image-service)](https://codecov.io/github/withstudiocms/studiocms) |
+| [@studiocms/blog](./packages/@studiocms/blog/) | Front-End | [![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_blog)](https://codecov.io/github/withstudiocms/studiocms) |
 
 ### Tools and Utilities
 

--- a/packages/@studiocms/auth0/README.md
+++ b/packages/@studiocms/auth0/README.md
@@ -1,5 +1,7 @@
 # @studiocms/auth0 Plugin
 
+[![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_auth0)](https://codecov.io/github/withstudiocms/studiocms)
+
 This plugin integrates Auth0 as an OAuth provider for StudioCMS, enabling authentication via Auth0. It sets up the necessary configuration, including required environment variables and endpoint paths.
 
 ## Usage

--- a/packages/@studiocms/blog/README.md
+++ b/packages/@studiocms/blog/README.md
@@ -1,5 +1,7 @@
 # StudioCMS - Blog Provider
 
+[![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_blog)](https://codecov.io/github/withstudiocms/studiocms)
+
 For information and docs related to this package see [The StudioCMS Docs](https://docs.studiocms.dev/package-catalog/studiocms-plugins/studiocms-blog/)
 
 ## License

--- a/packages/@studiocms/cloudinary-image-service/README.md
+++ b/packages/@studiocms/cloudinary-image-service/README.md
@@ -1,6 +1,8 @@
-# StudioCMS - Blog Provider
+# @studiocms/cloudinary-image-service
 
-For information and docs related to this package see [The StudioCMS Docs](https://docs.studiocms.dev/package-catalog/studiocms-plugins/studiocms-blog/)
+[![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_cloudinary-image-service)](https://codecov.io/github/withstudiocms/studiocms)
+
+For information and docs related to this package see [The StudioCMS Docs](https://docs.studiocms.dev/en/package-catalog/studiocms-plugins/studiocms-cloudinary-js/)
 
 ## License
 

--- a/packages/@studiocms/devapps/README.md
+++ b/packages/@studiocms/devapps/README.md
@@ -1,5 +1,7 @@
 # StudioCMS - Development Apps
 
+[![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_devapps)](https://codecov.io/github/withstudiocms/studiocms)
+
 Collection* of useful tools available during dev mode in Astro
 
 ## Installation

--- a/packages/@studiocms/discord/README.md
+++ b/packages/@studiocms/discord/README.md
@@ -1,5 +1,7 @@
 # @studiocms/discord Plugin
 
+[![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_discord)](https://codecov.io/github/withstudiocms/studiocms)
+
 This plugin integrates Discord as an OAuth authentication provider for StudioCMS. It sets up the necessary configuration, including the required environment variables and OAuth endpoints.
 
 ## Usage

--- a/packages/@studiocms/github/README.md
+++ b/packages/@studiocms/github/README.md
@@ -1,5 +1,7 @@
 # @studiocms/github Plugin
 
+[![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_github)](https://codecov.io/github/withstudiocms/studiocms) 
+
 This plugin integrates GitHub as an OAuth authentication provider for StudioCMS. It sets up the necessary authentication service, including the provider's name, endpoint paths and required environment variables.
 
 ## Usage

--- a/packages/@studiocms/google/README.md
+++ b/packages/@studiocms/google/README.md
@@ -1,5 +1,7 @@
 # @studiocms/google Plugin
 
+[![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_google)](https://codecov.io/github/withstudiocms/studiocms)
+
 This plugin integrates Google OAuth authentication into StudioCMS. It defines the necessary configuration, including the required environment variables, OAuth provider details, and the endpoint paths for authentication.
 
 ## Usage

--- a/packages/@studiocms/html/README.md
+++ b/packages/@studiocms/html/README.md
@@ -1,5 +1,7 @@
 # @studiocms/html Plugin
 
+[![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_html)](https://codecov.io/github/withstudiocms/studiocms)
+
 Add HTML support to StudioCMS
 
 ## Usage

--- a/packages/@studiocms/markdoc/README.md
+++ b/packages/@studiocms/markdoc/README.md
@@ -1,5 +1,7 @@
 # @StudioCMS/MarkDoc Plugin
 
+[![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_markdoc)](https://codecov.io/github/withstudiocms/studiocms)
+
 Add MarkDoc support to StudioCMS
 
 ## Usage

--- a/packages/@studiocms/md/README.md
+++ b/packages/@studiocms/md/README.md
@@ -1,5 +1,7 @@
 # @studiocms/md Plugin
 
+[![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_md)](https://codecov.io/github/withstudiocms/studiocms)
+
 Add Markdown support to StudioCMS
 
 ## Usage

--- a/packages/@studiocms/mdx/README.md
+++ b/packages/@studiocms/mdx/README.md
@@ -1,5 +1,7 @@
 # @StudioCMS/MDX Plugin
 
+[![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_mdx)](https://codecov.io/github/withstudiocms/studiocms)
+
 Add MDX support to StudioCMS
 
 ## Usage

--- a/packages/@studiocms/wysiwyg/README.md
+++ b/packages/@studiocms/wysiwyg/README.md
@@ -1,5 +1,7 @@
 # @studiocms/wysiwyg
 
+[![codecov](https://codecov.io/github/withstudiocms/studiocms/graph/badge.svg?token=RN8LT1O5E2&component=studiocms_wysiwyg)](https://codecov.io/github/withstudiocms/studiocms)
+
 Add a WYSIWYG editor to your StudioCMS dashboard.
 
 ## Overview


### PR DESCRIPTION
This pull request updates the documentation for the main repository and all plugin packages to display live code coverage badges using Codecov. These badges provide immediate visibility into the test coverage status for each package, helping developers and users assess the reliability of the code at a glance.

Documentation improvements:

* Added Codecov coverage badges to the main `README.md` for all core packages and plugins, replacing the previous "Not Yet Available" placeholders.
* Updated each plugin and package `README.md` (including `@studiocms/auth0`, `@studiocms/blog`, `@studiocms/cloudinary-image-service`, `@studiocms/devapps`, `@studiocms/discord`, `@studiocms/github`, `@studiocms/google`, `@studiocms/html`, `@studiocms/markdoc`, `@studiocms/md`, `@studiocms/mdx`, `@studiocms/wysiwyg`) to include a Codecov badge relevant to that package. [[1]](diffhunk://#diff-8dff83a6f69bc0f94d79af9370d4c11e09fe35be5accba512d9a1212fd3ca68eR3-R4) [[2]](diffhunk://#diff-0c0a8643a7202ab7a7b71db108e23fe49e4dc6e27d94ceb8188921f1ab049f90R3-R4) [[3]](diffhunk://#diff-10b7f5153ee9d1b8eabbac6346041c5e9708eeb6035d7fa80fa106b29ffd7646L1-R5) [[4]](diffhunk://#diff-f60c5384d51e2d5c74742a23d3f5dc3a66a3bc64282d225ee5f839b594518f62R3-R4) [[5]](diffhunk://#diff-f866cc3f2883459183b23ffc7700b528820640d8a7317736b968133c24b80a98R3-R4) [[6]](diffhunk://#diff-70800c7b41a06d018930bc2c4d66868476de1263dfba6daf43e8f62ec1d31849R3-R4) [[7]](diffhunk://#diff-b36ad9ac79abcddf185c1813827cbc765098283c18fe41cef38788612250f8e8R3-R4) [[8]](diffhunk://#diff-9165d103102d33f8dcf95778d0615919cd1de9fff6b83018deec321a0ecfbae2R3-R4) [[9]](diffhunk://#diff-20f886754c08e27a45b92102760573be136be94fcf1520bfa6a78350fc1779e9R3-R4) [[10]](diffhunk://#diff-827ca2750e263e4c01031fd09fabff822dccf6024681704dbc666ead43866443R3-R4) [[11]](diffhunk://#diff-56e2424a6a3e5b7351570da2e1469520ad5ed5f3560f18b528c7e3ce8eaa3f3bR3-R4) [[12]](diffhunk://#diff-6ce51e3ae660d95d92143fcce9b8307c629a705e8ec7192523ee0366b7f5e975R3-R4)

Other documentation corrections:

* Fixed the title and documentation link in the `@studiocms/cloudinary-image-service/README.md` to accurately reflect the package and its docs location.

These changes improve transparency and make it easier for contributors to monitor and maintain code quality across the StudioCMS ecosystem.