### PR TITLE
ci(bundle-tests): Add bundle tests and Codecov bundle analysis

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Tools & Dependencies
         uses: withstudiocms/automations/.github/actions/install@78e87c84a960d27f3832db1e6af755abc31fb09b # main Jul 17th, 2025
 
-      - name: Run Knip Linter
+      - name: Run Knip Linter and Report
         uses: codex-/knip-reporter@398e656c485dd1649f06631a4cd2e602c6ccc4f1 # v2.6.0
 
   zizmor:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      checks: write
+      issues: write
+      pull-requests: write
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
     name: Run Knip Linter
@@ -33,7 +36,7 @@ jobs:
         uses: withstudiocms/automations/.github/actions/install@78e87c84a960d27f3832db1e6af755abc31fb09b # main Jul 17th, 2025
 
       - name: Run Knip Linter
-        run: pnpm knip
+        uses: codex-/knip-reporter@398e656c485dd1649f06631a4cd2e602c6ccc4f1 # v2.6.0
 
   zizmor:
     name: Run Zizmor Actions Security Analysis

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
-    name: Run Knip Linter
+    name: Run Knip Linter and Report
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout Repo

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -57,7 +57,6 @@ jobs:
   studiocms-plugin-typecheck:
     name: Run StudioCMS Plugin & Packages TypeCheck
     runs-on: ubuntu-latest
-    needs: studiocms-typecheck
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
@@ -75,6 +74,10 @@ jobs:
   codecov:
     name: Run Tests & Code Coverage
     runs-on: ubuntu-latest
+    needs: 
+      - withstudiocms-typecheck
+      - studiocms-typecheck
+      - studiocms-plugin-typecheck
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
@@ -111,16 +114,37 @@ jobs:
           flags: integrations,plugins,tools-utils
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  studiocms-playground-test-build:
-    name: Build Packages and Playground
+  # Disabled for now in place for new bundle tests
+  # studiocms-playground-test-build:
+  #   name: Build Packages and Playground
+  #   runs-on: ubuntu-latest
+  #   needs: 
+  #     - codecov
+  #   env:
+  #     NODE_OPTIONS: "--max_old_space_size=4096"
+  #     ASTRO_DB_REMOTE_URL: ${{ secrets.ASTRO_DB_REMOTE_URL }}
+  #     ASTRO_DB_APP_TOKEN: ${{ secrets.ASTRO_DB_APP_TOKEN }}
+  #     CMS_ENCRYPTION_KEY: ${{ secrets.CMS_ENCRYPTION_KEY }}
+  #   steps:
+  #     - name: Check out code using Git
+  #       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+  #       with:
+  #         persist-credentials: false
+
+  #     - name: Install Tools & Dependencies
+  #       uses: withstudiocms/automations/.github/actions/install@78e87c84a960d27f3832db1e6af755abc31fb09b # main
+
+  #     - name: Build packages and playground
+  #       run: pnpm build
+
+  run-bundle-tests:
+    name: Run Bundle Analysis Tests
     runs-on: ubuntu-latest
     needs: 
-      - withstudiocms-typecheck
-      - studiocms-typecheck
-      - studiocms-plugin-typecheck
       - codecov
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
+      GH_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       ASTRO_DB_REMOTE_URL: ${{ secrets.ASTRO_DB_REMOTE_URL }}
       ASTRO_DB_APP_TOKEN: ${{ secrets.ASTRO_DB_APP_TOKEN }}
       CMS_ENCRYPTION_KEY: ${{ secrets.CMS_ENCRYPTION_KEY }}
@@ -133,5 +157,8 @@ jobs:
       - name: Install Tools & Dependencies
         uses: withstudiocms/automations/.github/actions/install@78e87c84a960d27f3832db1e6af755abc31fb09b # main
 
-      - name: Build packages and playground
-        run: pnpm build
+      - name: Build packages
+        run: pnpm build:studiocms
+
+      - name: Build Astro Bundle Tests
+        run: pnpm bundle-test:all

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -114,31 +114,8 @@ jobs:
           flags: integrations,plugins,tools-utils
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  # Disabled for now in place for new bundle tests
-  # studiocms-playground-test-build:
-  #   name: Build Packages and Playground
-  #   runs-on: ubuntu-latest
-  #   needs: 
-  #     - codecov
-  #   env:
-  #     NODE_OPTIONS: "--max_old_space_size=4096"
-  #     ASTRO_DB_REMOTE_URL: ${{ secrets.ASTRO_DB_REMOTE_URL }}
-  #     ASTRO_DB_APP_TOKEN: ${{ secrets.ASTRO_DB_APP_TOKEN }}
-  #     CMS_ENCRYPTION_KEY: ${{ secrets.CMS_ENCRYPTION_KEY }}
-  #   steps:
-  #     - name: Check out code using Git
-  #       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-  #       with:
-  #         persist-credentials: false
-
-  #     - name: Install Tools & Dependencies
-  #       uses: withstudiocms/automations/.github/actions/install@78e87c84a960d27f3832db1e6af755abc31fb09b # main
-
-  #     - name: Build packages and playground
-  #       run: pnpm build
-
   run-bundle-tests:
-    name: Run Bundle Analysis Tests
+    name: Run Bundle Analysis
     runs-on: ubuntu-latest
     needs: 
       - codecov

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -145,6 +145,7 @@ jobs:
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
       GH_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       ASTRO_DB_REMOTE_URL: ${{ secrets.ASTRO_DB_REMOTE_URL }}
       ASTRO_DB_APP_TOKEN: ${{ secrets.ASTRO_DB_APP_TOKEN }}
       CMS_ENCRYPTION_KEY: ${{ secrets.CMS_ENCRYPTION_KEY }}

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -121,7 +121,6 @@ jobs:
       - codecov
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
-      GH_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       ASTRO_DB_REMOTE_URL: ${{ secrets.ASTRO_DB_REMOTE_URL }}
       ASTRO_DB_APP_TOKEN: ${{ secrets.ASTRO_DB_APP_TOKEN }}
@@ -130,6 +129,7 @@ jobs:
       - name: Check out code using Git
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          fetch-depth: 2
           persist-credentials: false
 
       - name: Install Tools & Dependencies

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -87,6 +87,7 @@
     "automations",
     "bluwy",
     "buildkit",
+    "bundletests",
     "carryforward",
     "CMSAPI",
     "CMSMD",

--- a/bundle-tests/studiocms-blog/.env.demo
+++ b/bundle-tests/studiocms-blog/.env.demo
@@ -1,0 +1,6 @@
+# libSQL URL and Token for AstroDB
+ASTRO_DB_REMOTE_URL=libsql://your-database.turso.io
+ASTRO_DB_APP_TOKEN=
+
+# Auth encryption key
+CMS_ENCRYPTION_KEY="..." # openssl rand --base64 16

--- a/bundle-tests/studiocms-blog/.gitignore
+++ b/bundle-tests/studiocms-blog/.gitignore
@@ -1,0 +1,26 @@
+# build output
+dist/
+.output/
+.vercel/
+# generated types
+.astro/
+
+# dependencies
+node_modules/
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+
+# environment variables
+.env
+.env.production
+
+# macOS-specific files
+.DS_Store
+
+# jetbrains setting folder
+.idea/

--- a/bundle-tests/studiocms-blog/README.md
+++ b/bundle-tests/studiocms-blog/README.md
@@ -1,0 +1,1 @@
+# StudioCMS - Blog Template

--- a/bundle-tests/studiocms-blog/astro.config.mts
+++ b/bundle-tests/studiocms-blog/astro.config.mts
@@ -16,7 +16,7 @@ export default defineConfig({
 		db(),
 		studioCMS(),
 		codecovAstroPlugin({
-			enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+			enableBundleAnalysis: true,
 			bundleName: 'studiocms-blog-astro-bundle',
 			uploadToken: process.env.CODECOV_TOKEN,
 			telemetry: false,

--- a/bundle-tests/studiocms-blog/astro.config.mts
+++ b/bundle-tests/studiocms-blog/astro.config.mts
@@ -1,0 +1,28 @@
+import db from '@astrojs/db';
+import node from '@astrojs/node';
+import codecovAstroPlugin from '@codecov/astro-plugin';
+import { defineConfig } from 'astro/config';
+import studioCMS from 'studiocms';
+
+// https://astro.build/config
+export default defineConfig({
+	site: 'https://change.me',
+	output: 'server',
+	adapter: node({ mode: 'standalone' }),
+	security: {
+		checkOrigin: false, // This depends on your hosting provider
+	},
+	integrations: [
+		db(),
+		studioCMS(),
+		codecovAstroPlugin({
+			enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+			bundleName: 'studiocms-blog-astro-bundle',
+			uploadToken: process.env.CODECOV_TOKEN,
+			telemetry: false,
+			uploadOverrides: {
+				sha: process.env.GH_COMMIT_SHA,
+			},
+		}),
+	],
+});

--- a/bundle-tests/studiocms-blog/astro.config.mts
+++ b/bundle-tests/studiocms-blog/astro.config.mts
@@ -20,9 +20,6 @@ export default defineConfig({
 			bundleName: 'studiocms-blog-astro-bundle',
 			uploadToken: process.env.CODECOV_TOKEN,
 			telemetry: false,
-			uploadOverrides: {
-				sha: process.env.GH_COMMIT_SHA,
-			},
 		}),
 	],
 });

--- a/bundle-tests/studiocms-blog/package.json
+++ b/bundle-tests/studiocms-blog/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "@bundletests/studiocms-blog",
 	"type": "module",
+	"private": true,
 	"version": "0.0.1",
 	"scripts": {
 		"astro": "astro",

--- a/bundle-tests/studiocms-blog/package.json
+++ b/bundle-tests/studiocms-blog/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@bundletests/studiocms-blog",
+	"type": "module",
+	"version": "0.0.1",
+	"scripts": {
+		"astro": "astro",
+		"studiocms": "studiocms",
+		"db:push": "astro db push --remote",
+		"dev": "astro dev --remote",
+		"build": "astro build --remote",
+		"preview": "astro preview --remote"
+	},
+	"devDependencies": {
+		"@types/node": "catalog:",
+		"typescript": "catalog:"
+	},
+	"dependencies": {
+		"@astrojs/db": "catalog:astrojs",
+		"@astrojs/node": "catalog:astrojs",
+		"@codecov/astro-plugin": "catalog:",
+		"@studiocms/blog": "workspace:*",
+		"@studiocms/md": "workspace:*",
+    	"astro": "catalog:astrojs",
+		"sharp": "catalog:",
+		"studiocms": "workspace:*"
+	}
+}

--- a/bundle-tests/studiocms-blog/public/favicon.svg
+++ b/bundle-tests/studiocms-blog/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg width="755" height="792" viewBox="0 0 755 792" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .studiocms-logo {
+      fill: black;
+    }
+    @media (prefers-color-scheme: dark) {
+      .studiocms-logo {
+        fill: white;
+      }
+    }
+  </style>
+  <rect class="studiocms-logo" x="295" width="460" height="466" rx="32" fill="currentColor"/>
+  <path class="studiocms-logo" d="M272 434V166H180C162.327 166 148 180.327 148 198V597C148 614.673 162.327 629 180 629H577.5C595.173 629 609.5 614.673 609.5 597V490H328C297.072 490 272 464.928 272 434Z" fill="currentColor"/>
+  <path class="studiocms-logo" d="M124 597V329H32C14.3269 329 0 343.327 0 361V760C0 777.673 14.3269 792 32 792H429.5C447.173 792 461.5 777.673 461.5 760V653H180C149.072 653 124 627.928 124 597Z" fill="currentColor"/>
+</svg>

--- a/bundle-tests/studiocms-blog/studiocms.config.mts
+++ b/bundle-tests/studiocms-blog/studiocms.config.mts
@@ -1,0 +1,8 @@
+import blog from '@studiocms/blog';
+import md from '@studiocms/md';
+import { defineStudioCMSConfig } from 'studiocms/config';
+
+export default defineStudioCMSConfig({
+	dbStartPage: false,
+	plugins: [md(), blog()],
+});

--- a/bundle-tests/studiocms-blog/tsconfig.json
+++ b/bundle-tests/studiocms-blog/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "astro/tsconfigs/base",
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"]
+}

--- a/bundle-tests/studiocms-blog/tsconfig.json
+++ b/bundle-tests/studiocms-blog/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "astro/tsconfigs/base",
+  "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
   "exclude": ["dist"]
 }

--- a/bundle-tests/studiocms-headless/.env.demo
+++ b/bundle-tests/studiocms-headless/.env.demo
@@ -1,0 +1,6 @@
+# libSQL URL and Token for AstroDB
+ASTRO_DB_REMOTE_URL=libsql://your-database.turso.io
+ASTRO_DB_APP_TOKEN=
+
+# Auth encryption key
+CMS_ENCRYPTION_KEY="..." # openssl rand --base64 16

--- a/bundle-tests/studiocms-headless/.gitignore
+++ b/bundle-tests/studiocms-headless/.gitignore
@@ -1,0 +1,26 @@
+# build output
+dist/
+.output/
+.vercel/
+# generated types
+.astro/
+
+# dependencies
+node_modules/
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+
+# environment variables
+.env
+.env.production
+
+# macOS-specific files
+.DS_Store
+
+# jetbrains setting folder
+.idea/

--- a/bundle-tests/studiocms-headless/README.md
+++ b/bundle-tests/studiocms-headless/README.md
@@ -1,0 +1,1 @@
+# StudioCMS - Headless Template

--- a/bundle-tests/studiocms-headless/astro.config.mts
+++ b/bundle-tests/studiocms-headless/astro.config.mts
@@ -20,9 +20,6 @@ export default defineConfig({
 			bundleName: 'studiocms-headless-astro-bundle',
 			uploadToken: process.env.CODECOV_TOKEN,
 			telemetry: false,
-			uploadOverrides: {
-				sha: process.env.GH_COMMIT_SHA,
-			},
 		}),
 	],
 });

--- a/bundle-tests/studiocms-headless/astro.config.mts
+++ b/bundle-tests/studiocms-headless/astro.config.mts
@@ -16,7 +16,7 @@ export default defineConfig({
 		db(),
 		studioCMS(),
 		codecovAstroPlugin({
-			enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+			enableBundleAnalysis: true,
 			bundleName: 'studiocms-headless-astro-bundle',
 			uploadToken: process.env.CODECOV_TOKEN,
 			telemetry: false,

--- a/bundle-tests/studiocms-headless/astro.config.mts
+++ b/bundle-tests/studiocms-headless/astro.config.mts
@@ -1,0 +1,28 @@
+import db from '@astrojs/db';
+import node from '@astrojs/node';
+import codecovAstroPlugin from '@codecov/astro-plugin';
+import { defineConfig } from 'astro/config';
+import studioCMS from 'studiocms';
+
+// https://astro.build/config
+export default defineConfig({
+	site: 'https://change.me',
+	output: 'server',
+	adapter: node({ mode: 'standalone' }),
+	security: {
+		checkOrigin: false, // This depends on your hosting provider
+	},
+	integrations: [
+		db(),
+		studioCMS(),
+		codecovAstroPlugin({
+			enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+			bundleName: 'studiocms-headless-astro-bundle',
+			uploadToken: process.env.CODECOV_TOKEN,
+			telemetry: false,
+			uploadOverrides: {
+				sha: process.env.GH_COMMIT_SHA,
+			},
+		}),
+	],
+});

--- a/bundle-tests/studiocms-headless/package.json
+++ b/bundle-tests/studiocms-headless/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "@bundletests/studiocms-headless",
+	"type": "module",
+	"version": "0.0.1",
+	"scripts": {
+		"astro": "astro",
+		"studiocms": "studiocms",
+		"db:push": "astro db push --remote",
+		"dev": "astro dev --remote",
+		"build": "astro build --remote",
+		"preview": "astro preview --remote"
+	},
+	"devDependencies": {
+		"@types/node": "catalog:",
+		"typescript": "catalog:"
+	},
+	"dependencies": {
+		"@astrojs/db": "catalog:astrojs",
+		"@astrojs/node": "catalog:astrojs",
+		"@codecov/astro-plugin": "catalog:",
+		"@studiocms/md": "workspace:*",
+    	"astro": "catalog:astrojs",
+		"sharp": "catalog:",
+		"studiocms": "workspace:*"
+	}
+}

--- a/bundle-tests/studiocms-headless/package.json
+++ b/bundle-tests/studiocms-headless/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "@bundletests/studiocms-headless",
 	"type": "module",
+	"private": true,
 	"version": "0.0.1",
 	"scripts": {
 		"astro": "astro",

--- a/bundle-tests/studiocms-headless/public/favicon.svg
+++ b/bundle-tests/studiocms-headless/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg width="755" height="792" viewBox="0 0 755 792" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .studiocms-logo {
+      fill: black;
+    }
+    @media (prefers-color-scheme: dark) {
+      .studiocms-logo {
+        fill: white;
+      }
+    }
+  </style>
+  <rect class="studiocms-logo" x="295" width="460" height="466" rx="32" fill="currentColor"/>
+  <path class="studiocms-logo" d="M272 434V166H180C162.327 166 148 180.327 148 198V597C148 614.673 162.327 629 180 629H577.5C595.173 629 609.5 614.673 609.5 597V490H328C297.072 490 272 464.928 272 434Z" fill="currentColor"/>
+  <path class="studiocms-logo" d="M124 597V329H32C14.3269 329 0 343.327 0 361V760C0 777.673 14.3269 792 32 792H429.5C447.173 792 461.5 777.673 461.5 760V653H180C149.072 653 124 627.928 124 597Z" fill="currentColor"/>
+</svg>

--- a/bundle-tests/studiocms-headless/studiocms.config.mts
+++ b/bundle-tests/studiocms-headless/studiocms.config.mts
@@ -1,0 +1,7 @@
+import md from '@studiocms/md';
+import { defineStudioCMSConfig } from 'studiocms/config';
+
+export default defineStudioCMSConfig({
+	dbStartPage: false,
+	plugins: [md()],
+});

--- a/bundle-tests/studiocms-headless/tsconfig.json
+++ b/bundle-tests/studiocms-headless/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "astro/tsconfigs/base",
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"]
+}

--- a/bundle-tests/studiocms-headless/tsconfig.json
+++ b/bundle-tests/studiocms-headless/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "astro/tsconfigs/base",
+  "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
   "exclude": ["dist"]
 }

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -152,7 +152,20 @@ const config: KnipConfig = {
 		...bundleTestPackages.reduce(
 			(acc, pkg) => {
 				acc[`bundle-tests/${pkg}`] = {
-					...baseAstroWorkspaceConfig,
+					ignoreDependencies: ['sharp'],
+					astro: {
+						entry: [
+							'studiocms.config.{js,cjs,mjs,ts,mts}',
+							'astro.config.{js,cjs,mjs,ts,mts}',
+							'src/content/config.ts',
+							'src/content.config.ts',
+							'src/components/**/*.{astro,js,ts}',
+							'src/pages/**/*.{astro,mdx,js,ts}',
+							'src/content/**/*.mdx',
+							'src/middleware.{js,ts}',
+							'src/actions/index.{js,ts}',
+						],
+					},
 				};
 				return acc;
 			},

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -86,6 +86,8 @@ const atWithStudioCMSPackages = [
 	'internal_helpers',
 ] as const;
 
+const bundleTestPackages = ['studiocms-blog', 'studiocms-headless'] as const;
+
 /**
  * Returns additional configuration options for a given package, such as dependencies to ignore.
  *
@@ -141,6 +143,16 @@ const config: KnipConfig = {
 				acc[`packages/@withstudiocms/${pkg}`] = {
 					...baseWithStudioCMSConfig,
 					...extras(pkg),
+				};
+				return acc;
+			},
+			// biome-ignore lint/suspicious/noExplicitAny: This is a dynamic object construction
+			{} as Record<string, any>
+		),
+		...bundleTestPackages.reduce(
+			(acc, pkg) => {
+				acc[`bundle-tests/${pkg}`] = {
+					...baseAstroWorkspaceConfig,
 				};
 				return acc;
 			},

--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
     "test:watch": "vitest",
     "ci:test": "vitest run --coverage",
 
+    "bundle-test:blog": "pnpm --filter @bundletests/studiocms-blog build",
+    "bundle-test:headless": "pnpm --filter @bundletests/studiocms-headless build",
+    "bundle-test:all": "pnpm --filter @bundletests/* build",
+
     "clean:node": "node ./scripts/clean-node-modules.mjs",
     "postinstall": "ts-patch install"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ catalogs:
       specifier: ^5.13.7
       version: 5.13.7
   default:
+    '@codecov/astro-plugin':
+      specifier: ^1.9.1
+      version: 1.9.1
     '@types/mdast':
       specifier: ^4.0.4
       version: 4.0.4
@@ -181,6 +184,71 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.3)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@15.2.1(canvas@2.11.2))(tsx@4.20.3)(yaml@2.8.0)
+
+  bundle-tests/studiocms-blog:
+    dependencies:
+      '@astrojs/db':
+        specifier: catalog:astrojs
+        version: 0.17.2(@opentelemetry/api@1.9.0)(@types/pg@8.6.1)
+      '@astrojs/node':
+        specifier: catalog:astrojs
+        version: 9.4.3(astro@5.13.7(@types/node@22.16.3)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0))
+      '@codecov/astro-plugin':
+        specifier: 'catalog:'
+        version: 1.9.1(astro@5.13.7(@types/node@22.16.3)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0))(vite@6.3.6(@types/node@22.16.3)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@studiocms/blog':
+        specifier: workspace:*
+        version: link:../../packages/@studiocms/blog
+      '@studiocms/md':
+        specifier: workspace:*
+        version: link:../../packages/@studiocms/md
+      astro:
+        specifier: catalog:astrojs
+        version: 5.13.7(@types/node@22.16.3)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0)
+      sharp:
+        specifier: 'catalog:'
+        version: 0.34.3
+      studiocms:
+        specifier: workspace:*
+        version: link:../../packages/studiocms
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.16.3
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+
+  bundle-tests/studiocms-headless:
+    dependencies:
+      '@astrojs/db':
+        specifier: catalog:astrojs
+        version: 0.17.2(@opentelemetry/api@1.9.0)(@types/pg@8.6.1)
+      '@astrojs/node':
+        specifier: catalog:astrojs
+        version: 9.4.3(astro@5.13.7(@types/node@22.16.3)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0))
+      '@codecov/astro-plugin':
+        specifier: 'catalog:'
+        version: 1.9.1(astro@5.13.7(@types/node@22.16.3)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0))(vite@6.3.6(@types/node@22.16.3)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@studiocms/md':
+        specifier: workspace:*
+        version: link:../../packages/@studiocms/md
+      astro:
+        specifier: catalog:astrojs
+        version: 5.13.7(@types/node@22.16.3)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0)
+      sharp:
+        specifier: 'catalog:'
+        version: 0.34.3
+      studiocms:
+        specifier: workspace:*
+        version: link:../../packages/studiocms
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.16.3
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
 
   packages/@studiocms/auth0:
     dependencies:
@@ -933,6 +1001,9 @@ packages:
   '@actions/exec@1.1.1':
     resolution: {integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==}
 
+  '@actions/github@6.0.1':
+    resolution: {integrity: sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==}
+
   '@actions/http-client@2.2.3':
     resolution: {integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==}
 
@@ -1329,6 +1400,22 @@ packages:
 
   '@cloudinary/url-gen@1.22.0':
     resolution: {integrity: sha512-le8RMlgyC0JN3+FlC/YAlPYfvmJdtw8QGcSKDjCsfhS2CIem0mJl6ayti8bMoZ0P5wDvBewvRB0/dUQvhCzy3g==}
+
+  '@codecov/astro-plugin@1.9.1':
+    resolution: {integrity: sha512-Ajw1a4hqTt4PPeHGcGN0WoomxVuPTwrvtEZbhCXGjLWzuQaBnQnLz5SOMxV+B6FHbgZy1Cn55J36MtO6xpzI7g==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      astro: 4.x || 5.x
+
+  '@codecov/bundler-plugin-core@1.9.1':
+    resolution: {integrity: sha512-dt3ic7gMswz4p/qdkYPVJwXlLiLsz55rBBn2I7mr0HTG8pCoLRqnANJIwo5WrqGBZgPyVSMPBqBra6VxLWfDyA==}
+    engines: {node: '>=18.0.0'}
+
+  '@codecov/vite-plugin@1.9.1':
+    resolution: {integrity: sha512-S6Yne7comVulJ1jD3T7rCfYFHPR0zUjAYoLjUDPXNJCUrdzWJdf/ak/UepE7TicqQG+yBa6eb5WusqcPgg+1AQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      vite: 4.x || 5.x || 6.x
 
   '@commander-js/extra-typings@13.1.0':
     resolution: {integrity: sha512-q5P52BYb1hwVWE6dtID7VvuJWrlfbCv4klj7BjUUOqMz4jbSZD4C9fJ9lRjL2jnBGTg+gDDlaXN51rkWcLk4fg==}
@@ -5460,6 +5547,10 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  unplugin@1.16.1:
+    resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
+    engines: {node: '>=14.0.0'}
+
   unstorage@1.17.1:
     resolution: {integrity: sha512-KKGwRTT0iVBCErKemkJCLs7JdxNVfqTPc/85ae1XES0+bsHbc/sFBfVi5kJp156cc51BHinIH2l3k0EZ24vOBQ==}
     peerDependencies:
@@ -5676,6 +5767,9 @@ packages:
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
   whatwg-encoding@1.0.5:
     resolution: {integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==}
 
@@ -5845,6 +5939,16 @@ snapshots:
   '@actions/exec@1.1.1':
     dependencies:
       '@actions/io': 1.1.3
+
+  '@actions/github@6.0.1':
+    dependencies:
+      '@actions/http-client': 2.2.3
+      '@octokit/core': 5.2.2
+      '@octokit/plugin-paginate-rest': 9.2.2(@octokit/core@5.2.2)
+      '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.2)
+      '@octokit/request': 8.4.1
+      '@octokit/request-error': 5.1.1
+      undici: 5.29.0
 
   '@actions/http-client@2.2.3':
     dependencies:
@@ -6713,6 +6817,30 @@ snapshots:
   '@cloudinary/url-gen@1.22.0':
     dependencies:
       '@cloudinary/transformation-builder-sdk': 1.17.0
+
+  '@codecov/astro-plugin@1.9.1(astro@5.13.7(@types/node@22.16.3)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0))(vite@6.3.6(@types/node@22.16.3)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@codecov/bundler-plugin-core': 1.9.1
+      '@codecov/vite-plugin': 1.9.1(vite@6.3.6(@types/node@22.16.3)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.8.0))
+      astro: 5.13.7(@types/node@22.16.3)(jiti@2.5.1)(rollup@4.45.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0)
+      unplugin: 1.16.1
+    transitivePeerDependencies:
+      - vite
+
+  '@codecov/bundler-plugin-core@1.9.1':
+    dependencies:
+      '@actions/core': 1.11.1
+      '@actions/github': 6.0.1
+      chalk: 4.1.2
+      semver: 7.7.2
+      unplugin: 1.16.1
+      zod: 3.25.76
+
+  '@codecov/vite-plugin@1.9.1(vite@6.3.6(@types/node@22.16.3)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@codecov/bundler-plugin-core': 1.9.1
+      unplugin: 1.16.1
+      vite: 6.3.6(@types/node@22.16.3)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.8.0)
 
   '@commander-js/extra-typings@13.1.0(commander@13.1.0)':
     dependencies:
@@ -11661,6 +11789,11 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  unplugin@1.16.1:
+    dependencies:
+      acorn: 8.15.0
+      webpack-virtual-modules: 0.6.2
+
   unstorage@1.17.1:
     dependencies:
       anymatch: 3.1.3
@@ -11846,6 +11979,8 @@ snapshots:
 
   webidl-conversions@4.0.2:
     optional: true
+
+  webpack-virtual-modules@0.6.2: {}
 
   whatwg-encoding@1.0.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ catalog:
   tinyglobby: ^0.2.15
   typescript: ^5.9.2
   "@types/mdast": ^4.0.4
+  "@codecov/astro-plugin": ^1.9.1
 
 catalogs:
   astrojs:
@@ -48,4 +49,5 @@ packages:
   - "packages/@withstudiocms/*"
   - "packages/@withstudiocms/*/test/fixtures/*"
   - "packages/*"
+  - "bundle-tests/*"
   - "playground"


### PR DESCRIPTION
This pull request introduces a new bundle testing system for StudioCMS by adding two example projects—one for a blog and one for a headless CMS—along with their configuration, environment, and build files. It also updates the CI workflow to build and test these bundles, integrates bundle analysis with Codecov, and updates dependency and configuration files to support these changes.

**Bundle testing infrastructure:**

* Added two bundle test projects, `studiocms-blog` and `studiocms-headless`, under `bundle-tests/` with all necessary config, environment, and ignore files for isolated testing and building. [[1]](diffhunk://#diff-f782b0642568d24ce3863b2de5ea1c135666071fedee8492f1a236d717389c06R1-R6) [[2]](diffhunk://#diff-0f63d7bd42d5cc2fa9f6c3d714ab913a53ff969868cbd2eba6c28ab73ec45958R1-R26) [[3]](diffhunk://#diff-f14622615b2068275ee4f09c37587346eabfe0da6c64e85a6fa4aa948514af52R1) [[4]](diffhunk://#diff-b6fa75f0f333640454ce849ca17f73dbf4303b11a81e3f24935b0dcad666cb15R1-R28) [[5]](diffhunk://#diff-f02132009af95b3768eb6aa44298c6887067ee20f78abe73dd167563ce11ef62R1-R28) [[6]](diffhunk://#diff-cfe7b94324eb89d90555f86cfff86ffd0ab00aa4694d5499543219d5309417c2R1-R8) [[7]](diffhunk://#diff-0e0b9c937ebdaade534efd096dfc033c6673992e31418ccd4f801dc5da5befafR1-R5) [[8]](diffhunk://#diff-e513a29c6781c8c679cab91d493d13e4f398bbcd5c129afd03eb2c0a9e96a687R1) [[9]](diffhunk://#diff-81dfab5ce2375669c1000b2158b61654bcc728bb8b3847f4a85a0d9f08167289R1-R28) [[10]](diffhunk://#diff-e505e88a3cb54c946e76f51ae11d0a10e2951fb11136d3fa8622e31f665d06bbR1-R27) [[11]](diffhunk://#diff-fd75362536bf703698c1783df5296122a997d915cf6ebe6eaf222b33a61655bcR1-R7)
* Added `bundle-test:blog`, `bundle-test:headless`, and `bundle-test:all` scripts to the root `package.json` for building the new test bundles.

**CI/CD and workflow improvements:**

* Updated `.github/workflows/ci-testing.yml` to add a `run-bundle-tests` job that builds and analyzes the new bundle test projects, and adjusted dependencies between jobs to ensure correct execution order. [[1]](diffhunk://#diff-82af06888290ef31d154541fdc86514e682a9b9c656353a226e1d3eed32fef0aL60) [[2]](diffhunk://#diff-82af06888290ef31d154541fdc86514e682a9b9c656353a226e1d3eed32fef0aR77-R80) [[3]](diffhunk://#diff-82af06888290ef31d154541fdc86514e682a9b9c656353a226e1d3eed32fef0aL114-R125) [[4]](diffhunk://#diff-82af06888290ef31d154541fdc86514e682a9b9c656353a226e1d3eed32fef0aL136-R142)
* Integrated Codecov bundle analysis for both test projects using `@codecov/astro-plugin` in their configs and updated lockfiles accordingly. [[1]](diffhunk://#diff-b6fa75f0f333640454ce849ca17f73dbf4303b11a81e3f24935b0dcad666cb15R1-R28) [[2]](diffhunk://#diff-81dfab5ce2375669c1000b2158b61654bcc728bb8b3847f4a85a0d9f08167289R1-R28) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR22-R24) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR188-R252) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1004-R1006) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1404-R1419) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5550-R5553) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5770-R5772) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5943-R5952)

**Tooling and configuration updates:**

* Updated `knip.config.ts` to recognize the new bundle test packages and ignore unnecessary dependencies for them. [[1]](diffhunk://#diff-d5963738993926b3ad1d6763702f9e7a611bb6eb9d1e2c4c184f36acf7e5959fR89-R90) [[2]](diffhunk://#diff-d5963738993926b3ad1d6763702f9e7a611bb6eb9d1e2c4c184f36acf7e5959fR152-R174)
* Added `bundletests` to the list of recognized workspace folders in `.vscode/settings.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bundle-test templates for StudioCMS Blog and Headless with Codecov bundle analysis
  * New npm scripts to build bundle-test packages (blog, headless, all)

* **Chores**
  * Updated CI to run bundle analysis and integrate bundle-test jobs
  * Added workspace entries for bundle-tests and added Codecov plugin dependency
  * Spell-check vocabulary updated

* **Documentation**
  * Added README and .env.demo templates for both bundle-test templates
  * Added .gitignore and TypeScript configs for each template
<!-- end of auto-generated comment: release notes by coderabbit.ai -->