### PR TITLE
feat(mdx): add tests for MDX editor and renderer components

### DIFF
--- a/packages/@studiocms/mdx/package.json
+++ b/packages/@studiocms/mdx/package.json
@@ -42,6 +42,7 @@
   "scripts": {
     "build": "buildkit build 'src/**/*.{ts,astro,css,json,png,d.ts}'",
     "dev": "buildkit dev 'src/**/*.{ts,astro,css,json,png,d.ts}'",
+    "test": "vitest",
     "typecheck": "tspc -p tsconfig.tspc.json"
   },
   "exports": {

--- a/packages/@studiocms/mdx/test/components/editor.test.ts
+++ b/packages/@studiocms/mdx/test/components/editor.test.ts
@@ -1,0 +1,128 @@
+/// <reference types="astro/client" />
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, expect, test } from 'vitest';
+import Editor from '../../src/components/editor.astro';
+
+interface TestEditorProps {
+	content?: string | null;
+	[key: string]: unknown;
+}
+
+describe('MDX Editor component', () => {
+	test('Editor with props', async () => {
+		const container = await AstroContainer.create();
+		const props: TestEditorProps = {
+			content: '# Hello MDX\n\nThis is **bold** text with a [link](https://example.com).',
+		};
+		const result = await container.renderToString(Editor, { props });
+
+		expect(result).toContain('<div class="editor-container"');
+		expect(result).toMatch(
+			/<textarea[^>]*id="page-content"[^>]*name="page-content"[^>]*>[\s\S]*Hello MDX[\s\S]*<\/textarea>/
+		);
+		expect(result).toMatch(/<script\s+type="module"\s+src=.*?><\/script>/);
+	});
+
+	test('Editor with empty content', async () => {
+		const container = await AstroContainer.create();
+		const props: TestEditorProps = {
+			content: '',
+		};
+		const result = await container.renderToString(Editor, { props });
+
+		expect(result).toContain('<div class="editor-container"');
+		expect(result).toMatch(
+			/<textarea[^>]*id="page-content"[^>]*name="page-content"[^>]*>[\s\S]*<\/textarea>/
+		);
+	});
+
+	test('Editor with MDX content including JSX', async () => {
+		const container = await AstroContainer.create();
+		const mdxContent = `# MDX Content
+
+import { Button } from './components/Button';
+
+This is MDX content with a component:
+
+<Button>Click me!</Button>
+
+And some **bold** text.`;
+
+		const props: TestEditorProps = {
+			content: mdxContent,
+		};
+		const result = await container.renderToString(Editor, { props });
+
+		expect(result).toContain('<div class="editor-container"');
+		expect(result).toMatch(
+			/<textarea[^>]*id="page-content"[^>]*name="page-content"[^>]*>[\s\S]*MDX Content[\s\S]*<\/textarea>/
+		);
+		expect(result).toContain('Button');
+	});
+
+	test('Editor with undefined content', async () => {
+		const container = await AstroContainer.create();
+		const props: TestEditorProps = {
+			content: undefined,
+		};
+		const result = await container.renderToString(Editor, { props });
+
+		expect(result).toContain('<div class="editor-container"');
+		expect(result).toMatch(
+			/<textarea[^>]*id="page-content"[^>]*name="page-content"[^>]*>[\s\S]*<\/textarea>/
+		);
+	});
+
+	describe('Edge cases', () => {
+		test('Editor with null content', async () => {
+			const container = await AstroContainer.create();
+			const props: TestEditorProps = {
+				content: null,
+			};
+			const result = await container.renderToString(Editor, { props });
+
+			expect(result).toContain('<div class="editor-container"');
+			expect(result).toMatch(
+				/<textarea[^>]*id="page-content"[^>]*name="page-content"[^>]*>[\s\S]*<\/textarea>/
+			);
+		});
+
+		test('Editor with whitespace-only content', async () => {
+			const container = await AstroContainer.create();
+			const props: TestEditorProps = {
+				content: '   \n\t   ',
+			};
+			const result = await container.renderToString(Editor, { props });
+
+			expect(result).toContain('<div class="editor-container"');
+			expect(result).toMatch(
+				/<textarea[^>]*id="page-content"[^>]*name="page-content"[^>]*>[\s\S]*<\/textarea>/
+			);
+		});
+
+		test('Editor with very long content', async () => {
+			const container = await AstroContainer.create();
+			const longContent = '# Title\n\n' + 'A'.repeat(10000);
+			const props: TestEditorProps = {
+				content: longContent,
+			};
+			const result = await container.renderToString(Editor, { props });
+
+			expect(result).toContain('<div class="editor-container"');
+			expect(result).toMatch(
+				/<textarea[^>]*id="page-content"[^>]*name="page-content"[^>]*>[\s\S]*Title[\s\S]*<\/textarea>/
+			);
+		});
+
+		test('Editor with no props', async () => {
+			const container = await AstroContainer.create();
+			const props: TestEditorProps = {};
+			const result = await container.renderToString(Editor, { props });
+
+			expect(result).toContain('<div class="editor-container"');
+			expect(result).toMatch(
+				/<textarea[^>]*id="page-content"[^>]*name="page-content"[^>]*>[\s\S]*<\/textarea>/
+			);
+		});
+	});
+});

--- a/packages/@studiocms/mdx/test/components/editor.test.ts
+++ b/packages/@studiocms/mdx/test/components/editor.test.ts
@@ -102,7 +102,7 @@ And some **bold** text.`;
 
 		test('Editor with very long content', async () => {
 			const container = await AstroContainer.create();
-			const longContent = '# Title\n\n' + 'A'.repeat(10000);
+			const longContent = `# Title\n\n${'A'.repeat(10000)}`;
 			const props: TestEditorProps = {
 				content: longContent,
 			};

--- a/packages/@studiocms/mdx/test/components/renderer.test.ts
+++ b/packages/@studiocms/mdx/test/components/renderer.test.ts
@@ -1,0 +1,204 @@
+/// <reference types="astro/client" />
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, expect, test, vi } from 'vitest';
+import MDXRenderer from '../../src/components/MDXRenderer.astro';
+
+interface MDXRendererProps {
+	data: {
+		defaultContent?: {
+			content?: string | null;
+		};
+	};
+	[key: string]: unknown;
+}
+
+// Mock the MDX renderer
+vi.mock('studiocms:mdx/renderer', () => ({
+	default: vi.fn((content: string) => {
+		// Simple mock that converts markdown-like content to HTML
+		return Promise.resolve(
+			content
+				.replace(/^# (.*$)/gm, '<h1>$1</h1>')
+				.replace(/^## (.*$)/gm, '<h2>$1</h2>')
+				.replace(/^### (.*$)/gm, '<h3>$1</h3>')
+				.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+				.replace(/\*(.*?)\*/g, '<em>$1</em>')
+				.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
+				.replace(/\n/g, '<br>')
+		);
+	}),
+}));
+
+describe('MDX Renderer component', () => {
+	test('Renderer with valid content', async () => {
+		const container = await AstroContainer.create();
+		const props: MDXRendererProps = {
+			data: {
+				defaultContent: {
+					content: '# Hello World\n\nThis is **bold** text with a [link](https://example.com).',
+				},
+			},
+		};
+		const result = await container.renderToString(MDXRenderer, { props });
+
+		expect(result).toContain('<h1>Hello World</h1>');
+		expect(result).toContain('<strong>bold</strong>');
+		expect(result).toContain('<a href="https://example.com">link</a>');
+	});
+
+	test('Renderer with empty content', async () => {
+		const container = await AstroContainer.create();
+		const props: MDXRendererProps = {
+			data: {
+				defaultContent: {
+					content: '',
+				},
+			},
+		};
+		const result = await container.renderToString(MDXRenderer, { props });
+
+		expect(result).toContain('<h1>Error: No content found</h1>');
+	});
+
+	test('Renderer with undefined defaultContent', async () => {
+		const container = await AstroContainer.create();
+		const props: MDXRendererProps = {
+			data: {
+				defaultContent: undefined,
+			},
+		};
+		const result = await container.renderToString(MDXRenderer, { props });
+
+		expect(result).toContain('<h1>Error: No content found</h1>');
+	});
+
+	test('Renderer with MDX content including JSX-like syntax', async () => {
+		const container = await AstroContainer.create();
+		const mdxContent = `# MDX Content
+
+import { Button } from './components/Button';
+
+This is MDX content with a component:
+
+<Button>Click me!</Button>
+
+And some **bold** text.`;
+
+		const props: MDXRendererProps = {
+			data: {
+				defaultContent: {
+					content: mdxContent,
+				},
+			},
+		};
+		const result = await container.renderToString(MDXRenderer, { props });
+
+		expect(result).toContain('<h1>MDX Content</h1>');
+		expect(result).toContain('<strong>bold</strong>');
+		expect(result).toContain('Button');
+	});
+
+	test('Renderer with complex markdown content', async () => {
+		const container = await AstroContainer.create();
+		const complexContent = `# Main Title
+
+## Subtitle
+
+This is a paragraph with **bold** and *italic* text.
+
+- List item 1
+- List item 2
+- List item 3
+
+[External link](https://example.com)
+
+\`\`\`javascript
+const code = 'example';
+console.log(code);
+\`\`\``;
+
+		const props: MDXRendererProps = {
+			data: {
+				defaultContent: {
+					content: complexContent,
+				},
+			},
+		};
+		const result = await container.renderToString(MDXRenderer, { props });
+
+		expect(result).toContain('<h1>Main Title</h1>');
+		expect(result).toContain('<h2>Subtitle</h2>');
+		expect(result).toContain('<strong>bold</strong>');
+		expect(result).toContain('<em>italic</em>');
+		expect(result).toContain('<a href="https://example.com">External link</a>');
+	});
+
+	test('Renderer handles missing data prop gracefully', async () => {
+		const container = await AstroContainer.create();
+		const props: MDXRendererProps = {
+			data: {},
+		};
+		const result = await container.renderToString(MDXRenderer, { props });
+
+		expect(result).toContain('<h1>Error: No content found</h1>');
+	});
+
+	describe('Edge cases', () => {
+		test('Renderer handles null content', async () => {
+			const container = await AstroContainer.create();
+			const props: MDXRendererProps = {
+				data: {
+					defaultContent: {
+						content: null,
+					},
+				},
+			};
+			const result = await container.renderToString(MDXRenderer, { props });
+
+			expect(result).toContain('<h1>Error: No content found</h1>');
+		});
+
+		test('Renderer handles undefined content', async () => {
+			const container = await AstroContainer.create();
+			const props: MDXRendererProps = {
+				data: {
+					defaultContent: {
+						content: undefined,
+					},
+				},
+			};
+			const result = await container.renderToString(MDXRenderer, { props });
+
+			expect(result).toContain('<h1>Error: No content found</h1>');
+		});
+
+		test('Renderer handles whitespace-only content', async () => {
+			const container = await AstroContainer.create();
+			const props: MDXRendererProps = {
+				data: {
+					defaultContent: {
+						content: '   \n\t   ',
+					},
+				},
+			};
+			const result = await container.renderToString(MDXRenderer, { props });
+
+			expect(result).toContain('<br>');
+		});
+
+		test('Renderer handles very long content', async () => {
+			const container = await AstroContainer.create();
+			const longContent = `# Title\n\n${'A'.repeat(10000)}`;
+			const props: MDXRendererProps = {
+				data: {
+					defaultContent: {
+						content: longContent,
+					},
+				},
+			};
+			const result = await container.renderToString(MDXRenderer, { props });
+
+			expect(result).toContain('<h1>Title</h1>');
+		});
+	});
+});

--- a/packages/@studiocms/mdx/test/index.test.ts
+++ b/packages/@studiocms/mdx/test/index.test.ts
@@ -1,10 +1,7 @@
 import type { StudioCMSPlugin } from 'studiocms/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { studiocmsMDX } from '../src/index.js';
-import {
-	cleanupGlobalState,
-	createMockMDXOptions,
-} from './test-utils.js';
+import { createMockMDXOptions } from './test-utils.js';
 
 interface MockAddIntegrationsParams {
 	addIntegrations: (integration: any) => void;
@@ -34,7 +31,6 @@ vi.mock('studiocms/plugins', () => ({
 describe('studiocmsMDX', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		cleanupGlobalState();
 	});
 
 	afterEach(() => {

--- a/packages/@studiocms/mdx/test/index.test.ts
+++ b/packages/@studiocms/mdx/test/index.test.ts
@@ -1,19 +1,14 @@
-import type { StudioCMSPlugin } from 'studiocms/types';
+import type { PluggableList } from 'unified';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { studiocmsMDX } from '../src/index.js';
 import { createMockMDXOptions } from './test-utils.js';
 
 interface MockAddIntegrationsParams {
-	addIntegrations: (integration: any) => void;
+	addIntegrations: (integration: unknown) => void;
 }
 
 interface MockSetRenderingParams {
-	setRendering: (rendering: any) => void;
-}
-
-interface MockAstroConfigSetupParams {
-	addVirtualImports: (params: any, imports: any) => void;
-	injectScript?: (target: string, script: string) => void;
+	setRendering: (rendering: unknown) => void;
 }
 
 // Mock the dependencies
@@ -50,8 +45,8 @@ describe('studiocmsMDX', () => {
 
 		it('should create a plugin with custom options', () => {
 			const options = createMockMDXOptions({
-				remarkPlugins: [['remark-gfm', {}] as any],
-				rehypePlugins: [['rehype-highlight', {}] as any],
+				remarkPlugins: [[vi.fn(), {}]],
+				rehypePlugins: [[vi.fn(), {}]],
 				recmaPlugins: [],
 				remarkRehypeOptions: { allowDangerousHtml: true },
 			});
@@ -96,7 +91,7 @@ describe('studiocmsMDX', () => {
 		});
 
 		it('should call studiocms:astro:config hook with addIntegrations', async () => {
-			const plugin: StudioCMSPlugin = studiocmsMDX();
+			const plugin: ReturnType<typeof studiocmsMDX> = studiocmsMDX();
 			const mockAddIntegrations = vi.fn();
 
 			const hook = plugin.hooks['studiocms:astro:config'];
@@ -114,7 +109,7 @@ describe('studiocmsMDX', () => {
 		});
 
 		it('should call studiocms:config:setup hook with setRendering', () => {
-			const plugin: StudioCMSPlugin = studiocmsMDX();
+			const plugin: ReturnType<typeof studiocmsMDX> = studiocmsMDX();
 			const mockSetRendering = vi.fn();
 
 			const hook = plugin.hooks['studiocms:config:setup'];
@@ -230,9 +225,9 @@ describe('studiocmsMDX', () => {
 	describe('Edge cases', () => {
 		it('should handle plugin options with mixed types', () => {
 			const mixedOptions = createMockMDXOptions({
-				remarkPlugins: [['plugin1', {}] as any, ['plugin2', { option: 'value' }] as any],
-				rehypePlugins: [['rehype1', {}] as any],
-				recmaPlugins: [['recma1', {}] as any],
+				remarkPlugins: [[vi.fn(), {}], [vi.fn(), { option: 'value' }]],
+				rehypePlugins: [[vi.fn(), {}]],
+				recmaPlugins: [[vi.fn(), {}]],
 				remarkRehypeOptions: { allowDangerousHtml: true, footnoteLabel: 'Notes' },
 			});
 
@@ -258,7 +253,7 @@ describe('studiocmsMDX', () => {
 				remarkRehypeOptions: {
 					allowDangerousHtml: true,
 					handlers: {
-						custom: () => {}
+						paragraph: () => undefined
 					}
 				},
 			});
@@ -271,19 +266,16 @@ describe('studiocmsMDX', () => {
 
 		it('should handle plugin with maximum configuration', () => {
 			const maxOptions = createMockMDXOptions({
-				remarkPlugins: Array(10).fill(['plugin', {}] as any),
-				rehypePlugins: Array(10).fill(['rehype', {}] as any),
-				recmaPlugins: Array(10).fill(['recma', {}] as any),
+				remarkPlugins: Array(10).fill([vi.fn(), {}]),
+				rehypePlugins: Array(10).fill([vi.fn(), {}]),
+				recmaPlugins: Array(10).fill([vi.fn(), {}]),
 				remarkRehypeOptions: {
 					allowDangerousHtml: true,
 					footnoteLabel: 'Notes',
 					footnoteLabelTagName: 'h2',
-					footnoteLabelId: 'footnote-label',
 					footnoteBackLabel: 'Back to content',
-					footnoteBackLabelId: 'footnote-back-label',
 					clobberPrefix: 'user-content-',
 					handlers: {},
-					transform: () => {},
 				},
 			});
 
@@ -309,10 +301,10 @@ describe('studiocmsMDX', () => {
 
 		it('should handle plugin creation with undefined nested properties', () => {
 			const optionsWithUndefined = createMockMDXOptions({
-				remarkPlugins: undefined as any,
-				rehypePlugins: undefined as any,
-				recmaPlugins: undefined as any,
-				remarkRehypeOptions: undefined as any,
+				remarkPlugins: undefined as unknown as PluggableList,
+				rehypePlugins: undefined as unknown as PluggableList,
+				recmaPlugins: undefined as unknown as PluggableList,
+				remarkRehypeOptions: undefined as unknown as Record<string, unknown>,
 			});
 
 			const plugin = studiocmsMDX(optionsWithUndefined);
@@ -323,10 +315,10 @@ describe('studiocmsMDX', () => {
 
 		it('should handle plugin creation with null nested properties', () => {
 			const optionsWithNull = createMockMDXOptions({
-				remarkPlugins: null as any,
-				rehypePlugins: null as any,
-				recmaPlugins: null as any,
-				remarkRehypeOptions: null as any,
+				remarkPlugins: null as unknown as PluggableList,
+				rehypePlugins: null as unknown as PluggableList,
+				recmaPlugins: null as unknown as PluggableList,
+				remarkRehypeOptions: null as unknown as Record<string, unknown>,
 			});
 
 			const plugin = studiocmsMDX(optionsWithNull);

--- a/packages/@studiocms/mdx/test/index.test.ts
+++ b/packages/@studiocms/mdx/test/index.test.ts
@@ -1,0 +1,342 @@
+import type { StudioCMSPlugin } from 'studiocms/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { studiocmsMDX } from '../src/index.js';
+import {
+	cleanupGlobalState,
+	createMockMDXOptions,
+} from './test-utils.js';
+
+interface MockAddIntegrationsParams {
+	addIntegrations: (integration: any) => void;
+}
+
+interface MockSetRenderingParams {
+	setRendering: (rendering: any) => void;
+}
+
+interface MockAstroConfigSetupParams {
+	addVirtualImports: (params: any, imports: any) => void;
+	injectScript?: (target: string, script: string) => void;
+}
+
+// Mock the dependencies
+vi.mock('astro-integration-kit', () => ({
+	createResolver: vi.fn(() => ({
+		resolve: vi.fn((path: string) => `/mocked/path/${path}`),
+	})),
+	addVirtualImports: vi.fn(),
+}));
+
+vi.mock('studiocms/plugins', () => ({
+	definePlugin: vi.fn((config) => config),
+}));
+
+describe('studiocmsMDX', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		cleanupGlobalState();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('plugin creation', () => {
+		it('should create a plugin with default options', () => {
+			const plugin = studiocmsMDX();
+
+			expect(plugin).toBeDefined();
+			expect(plugin.identifier).toBe('@studiocms/mdx');
+			expect(plugin.name).toBe('StudioCMS MDX');
+			expect(plugin.studiocmsMinimumVersion).toBe('0.1.0-beta.21');
+			expect(plugin.hooks).toBeDefined();
+		});
+
+		it('should create a plugin with custom options', () => {
+			const options = createMockMDXOptions({
+				remarkPlugins: [['remark-gfm', {}] as any],
+				rehypePlugins: [['rehype-highlight', {}] as any],
+				recmaPlugins: [],
+				remarkRehypeOptions: { allowDangerousHtml: true },
+			});
+
+			const plugin = studiocmsMDX(options);
+
+			expect(plugin).toBeDefined();
+			expect(plugin.identifier).toBe('@studiocms/mdx');
+			expect(plugin.name).toBe('StudioCMS MDX');
+		});
+
+		it('should handle empty options gracefully', () => {
+			const plugin = studiocmsMDX({});
+
+			expect(plugin).toBeDefined();
+			expect(plugin.identifier).toBe('@studiocms/mdx');
+			expect(plugin.name).toBe('StudioCMS MDX');
+		});
+
+		it('should handle undefined options', () => {
+			const plugin = studiocmsMDX(undefined);
+
+			expect(plugin).toBeDefined();
+			expect(plugin.identifier).toBe('@studiocms/mdx');
+			expect(plugin.name).toBe('StudioCMS MDX');
+		});
+	});
+
+	describe('plugin hooks', () => {
+		it('should have studiocms:astro:config hook', () => {
+			const plugin = studiocmsMDX();
+
+			expect(plugin.hooks['studiocms:astro:config']).toBeDefined();
+			expect(typeof plugin.hooks['studiocms:astro:config']).toBe('function');
+		});
+
+		it('should have studiocms:config:setup hook', () => {
+			const plugin = studiocmsMDX();
+
+			expect(plugin.hooks['studiocms:config:setup']).toBeDefined();
+			expect(typeof plugin.hooks['studiocms:config:setup']).toBe('function');
+		});
+
+		it('should call studiocms:astro:config hook with addIntegrations', async () => {
+			const plugin: StudioCMSPlugin = studiocmsMDX();
+			const mockAddIntegrations = vi.fn();
+
+			const hook = plugin.hooks['studiocms:astro:config'];
+			if (!hook) throw new Error('Hook not found');
+			const params: MockAddIntegrationsParams = { addIntegrations: mockAddIntegrations };
+			hook(params as any);
+
+			expect(mockAddIntegrations).toHaveBeenCalledWith({
+				name: '@studiocms/mdx',
+				hooks: {
+					'astro:config:setup': expect.any(Function),
+					'astro:config:done': expect.any(Function),
+				},
+			});
+		});
+
+		it('should call studiocms:config:setup hook with setRendering', () => {
+			const plugin: StudioCMSPlugin = studiocmsMDX();
+			const mockSetRendering = vi.fn();
+
+			const hook = plugin.hooks['studiocms:config:setup'];
+			if (!hook) throw new Error('Hook not found');
+			const params: MockSetRenderingParams = { setRendering: mockSetRendering };
+			hook(params as any);
+
+			expect(mockSetRendering).toHaveBeenCalledWith({
+				pageTypes: [
+					{
+						identifier: 'studiocms/mdx',
+						label: 'MDX',
+						pageContentComponent: '/mocked/path/./components/editor.astro',
+						rendererComponent: '/mocked/path/./components/MDXRenderer.astro',
+					},
+				],
+			});
+		});
+
+		it('should set up virtual imports correctly', async () => {
+			const { addVirtualImports } = await import('astro-integration-kit');
+			const mockAddVirtualImports = vi.mocked(addVirtualImports);
+			const mockAddIntegrations = vi.fn();
+
+			const plugin: ReturnType<typeof studiocmsMDX> = studiocmsMDX();
+
+			const hook = plugin.hooks['studiocms:astro:config'];
+			if (!hook) throw new Error('Hook not found');
+			hook({ addIntegrations: mockAddIntegrations } as any);
+
+			// Get the integration that was added
+			const integrationArg = mockAddIntegrations.mock.calls[0]?.[0];
+			if (!integrationArg) throw new Error('Integration not found');
+
+			// Call the astro:config:setup hook
+			const setupHook = integrationArg.hooks['astro:config:setup'];
+			setupHook({
+				addVirtualImports: mockAddVirtualImports,
+			} as any);
+
+			expect(mockAddVirtualImports).toHaveBeenCalledWith(expect.any(Object), {
+				name: '@studiocms/mdx',
+				imports: {
+					'studiocms:mdx/renderer': expect.stringContaining('renderMDX'),
+				},
+			});
+		});
+
+		it('should store resolved options in shared context on astro:config:done', async () => {
+			const customOptions = createMockMDXOptions({
+				remarkPlugins: [['remark-gfm', {}] as any],
+				rehypePlugins: [['rehype-highlight', {}] as any],
+				recmaPlugins: [],
+				remarkRehypeOptions: { allowDangerousHtml: true },
+			});
+
+			const plugin: ReturnType<typeof studiocmsMDX> = studiocmsMDX(customOptions);
+			const mockAddIntegrations = vi.fn();
+
+			const hook = plugin.hooks['studiocms:astro:config'];
+			if (!hook) throw new Error('Hook not found');
+			hook({ addIntegrations: mockAddIntegrations } as any);
+
+			// Get the integration that was added
+			const integrationArg = mockAddIntegrations.mock.calls[0]?.[0];
+			if (!integrationArg) throw new Error('Integration not found');
+
+			// Call the astro:config:done hook
+			const doneHook = integrationArg.hooks['astro:config:done'];
+			doneHook({} as any);
+
+			// Verify the shared context was updated
+			const { shared } = await import('../src/lib/shared.js');
+			expect(shared.mdxConfig).toEqual(customOptions);
+		});
+	});
+
+	describe('default export', () => {
+		it('should export the same function as named export', async () => {
+			const { default: defaultExport } = await import('../src/index.js');
+			expect(defaultExport).toBe(studiocmsMDX);
+		});
+	});
+
+	describe('plugin requirements', () => {
+		it('should require @studiocms/md plugin', () => {
+			const plugin = studiocmsMDX();
+
+			expect(plugin.requires).toContain('@studiocms/md');
+		});
+	});
+
+	describe('plugin configuration', () => {
+		it('should have correct package identifier', () => {
+			const plugin = studiocmsMDX();
+
+			expect(plugin.identifier).toBe('@studiocms/mdx');
+		});
+
+		it('should have correct plugin name', () => {
+			const plugin = studiocmsMDX();
+
+			expect(plugin.name).toBe('StudioCMS MDX');
+		});
+
+		it('should have correct minimum StudioCMS version', () => {
+			const plugin = studiocmsMDX();
+
+			expect(plugin.studiocmsMinimumVersion).toBe('0.1.0-beta.21');
+		});
+	});
+
+	describe('Edge cases', () => {
+		it('should handle plugin options with mixed types', () => {
+			const mixedOptions = createMockMDXOptions({
+				remarkPlugins: [['plugin1', {}] as any, ['plugin2', { option: 'value' }] as any],
+				rehypePlugins: [['rehype1', {}] as any],
+				recmaPlugins: [['recma1', {}] as any],
+				remarkRehypeOptions: { allowDangerousHtml: true, footnoteLabel: 'Notes' },
+			});
+
+			const plugin = studiocmsMDX(mixedOptions);
+
+			expect(plugin).toBeDefined();
+			expect(plugin.identifier).toBe('@studiocms/mdx');
+		});
+
+		it('should handle deeply nested plugin configurations', () => {
+			const nestedOptions = createMockMDXOptions({
+				remarkPlugins: [
+					['remark-plugin', {
+						options: {
+							nested: {
+								deep: {
+									value: 'test'
+								}
+							}
+						}
+					}] as any
+				],
+				remarkRehypeOptions: {
+					allowDangerousHtml: true,
+					handlers: {
+						custom: () => {}
+					}
+				},
+			});
+
+			const plugin = studiocmsMDX(nestedOptions);
+
+			expect(plugin).toBeDefined();
+			expect(plugin.identifier).toBe('@studiocms/mdx');
+		});
+
+		it('should handle plugin with maximum configuration', () => {
+			const maxOptions = createMockMDXOptions({
+				remarkPlugins: Array(10).fill(['plugin', {}] as any),
+				rehypePlugins: Array(10).fill(['rehype', {}] as any),
+				recmaPlugins: Array(10).fill(['recma', {}] as any),
+				remarkRehypeOptions: {
+					allowDangerousHtml: true,
+					footnoteLabel: 'Notes',
+					footnoteLabelTagName: 'h2',
+					footnoteLabelId: 'footnote-label',
+					footnoteBackLabel: 'Back to content',
+					footnoteBackLabelId: 'footnote-back-label',
+					clobberPrefix: 'user-content-',
+					handlers: {},
+					transform: () => {},
+				},
+			});
+
+			const plugin = studiocmsMDX(maxOptions);
+
+			expect(plugin).toBeDefined();
+			expect(plugin.identifier).toBe('@studiocms/mdx');
+		});
+
+		it('should handle plugin with minimal configuration', () => {
+			const minOptions = createMockMDXOptions({
+				remarkPlugins: [],
+				rehypePlugins: [],
+				recmaPlugins: [],
+				remarkRehypeOptions: {},
+			});
+
+			const plugin = studiocmsMDX(minOptions);
+
+			expect(plugin).toBeDefined();
+			expect(plugin.identifier).toBe('@studiocms/mdx');
+		});
+
+		it('should handle plugin creation with undefined nested properties', () => {
+			const optionsWithUndefined = createMockMDXOptions({
+				remarkPlugins: undefined as any,
+				rehypePlugins: undefined as any,
+				recmaPlugins: undefined as any,
+				remarkRehypeOptions: undefined as any,
+			});
+
+			const plugin = studiocmsMDX(optionsWithUndefined);
+
+			expect(plugin).toBeDefined();
+			expect(plugin.identifier).toBe('@studiocms/mdx');
+		});
+
+		it('should handle plugin creation with null nested properties', () => {
+			const optionsWithNull = createMockMDXOptions({
+				remarkPlugins: null as any,
+				rehypePlugins: null as any,
+				recmaPlugins: null as any,
+				remarkRehypeOptions: null as any,
+			});
+
+			const plugin = studiocmsMDX(optionsWithNull);
+
+			expect(plugin).toBeDefined();
+			expect(plugin.identifier).toBe('@studiocms/mdx');
+		});
+	});
+});

--- a/packages/@studiocms/mdx/test/lib/render.test.ts
+++ b/packages/@studiocms/mdx/test/lib/render.test.ts
@@ -1,0 +1,516 @@
+import type { PluggableList } from 'unified';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderMDX } from '../../src/lib/render.js';
+import { createMockMDXContent } from '../test-utils.js';
+
+interface MockReactElement {
+	type: any;
+	props: Record<string, any>;
+	key: string | null;
+}
+
+interface MockEvaluateOptions {
+	remarkPlugins: PluggableList;
+	rehypePlugins: PluggableList;
+	recmaPlugins: PluggableList;
+	remarkRehypeOptions: Record<string, any>;
+}
+
+// Mock the dependencies
+vi.mock('@mdx-js/mdx', () => ({
+	evaluate: vi.fn(),
+}));
+
+vi.mock('react', () => ({
+	createElement: vi.fn((component: any, props: Record<string, any> = {}, ...children: any[]): MockReactElement => ({
+		type: component,
+		props: { ...props, children },
+		key: null,
+	})),
+}));
+
+vi.mock('react-dom/server', () => ({
+	renderToString: vi.fn((element: MockReactElement | string): string => {
+		// Simple mock renderer
+		if (typeof element === 'string') return element;
+		if (element?.type) {
+			const props = element.props || {};
+			const children = props.children || '';
+			return `<${element.type}${Object.entries(props)
+				.filter(([key]) => key !== 'children')
+				.map(([key, value]) => ` ${key}="${value}"`)
+				.join('')}>${children}</${element.type}>`;
+		}
+		return '';
+	}),
+}));
+
+vi.mock('rehype-highlight', () => ({
+	default: vi.fn(),
+}));
+
+vi.mock('remark-gfm', () => ({
+	default: vi.fn(),
+}));
+
+vi.mock('../../src/lib/shared.js', () => ({
+	shared: {
+		mdxConfig: {
+			remarkPlugins: [],
+			rehypePlugins: [],
+			recmaPlugins: [],
+			remarkRehypeOptions: {},
+		},
+	},
+}));
+
+describe('renderMDX', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('should render simple MDX content', async () => {
+		const { evaluate } = await import('@mdx-js/mdx');
+		const { renderToString } = await import('react-dom/server');
+		const { createElement } = await import('react');
+
+		const mockContent = createMockMDXContent('# Hello World');
+		const mockComponent = vi.fn(() => 'Hello World');
+
+		vi.mocked(evaluate).mockResolvedValue({
+			default: mockComponent,
+		});
+
+		vi.mocked(createElement).mockReturnValue({
+			type: mockComponent,
+			props: {},
+			key: null,
+		} as MockReactElement);
+
+		vi.mocked(renderToString).mockReturnValue('<h1>Hello World</h1>');
+
+		const result = await renderMDX(mockContent);
+
+		expect(evaluate).toHaveBeenCalledWith(mockContent, expect.objectContaining({
+			remarkPlugins: expect.any(Array),
+			rehypePlugins: expect.any(Array),
+			recmaPlugins: expect.any(Array),
+			remarkRehypeOptions: expect.any(Object),
+		}));
+
+		expect(createElement).toHaveBeenCalledWith(mockComponent);
+		expect(renderToString).toHaveBeenCalled();
+		expect(result).toBe('<h1>Hello World</h1>');
+	});
+
+	it('should render MDX content with JSX components', async () => {
+		const { evaluate } = await import('@mdx-js/mdx');
+		const { renderToString } = await import('react-dom/server');
+		const { createElement } = await import('react');
+
+		const mdxContent = `import { Button } from './Button';
+
+# Hello World
+
+<Button>Click me!</Button>`;
+
+		const mockComponent = vi.fn(() => 'Hello World with Button');
+
+		vi.mocked(evaluate).mockResolvedValue({
+			default: mockComponent,
+		});
+
+		vi.mocked(createElement).mockReturnValue({
+			type: mockComponent,
+			props: {},
+			key: null,
+		} as MockReactElement);
+
+		vi.mocked(renderToString).mockReturnValue('<div><h1>Hello World</h1><button>Click me!</button></div>');
+
+		const result = await renderMDX(mdxContent);
+
+		expect(evaluate).toHaveBeenCalledWith(mdxContent, expect.objectContaining({
+			remarkPlugins: expect.any(Array),
+			rehypePlugins: expect.any(Array),
+			recmaPlugins: expect.any(Array),
+			remarkRehypeOptions: expect.any(Object),
+		}));
+
+		expect(result).toBe('<div><h1>Hello World</h1><button>Click me!</button></div>');
+	});
+
+	it('should handle empty content', async () => {
+		const { evaluate } = await import('@mdx-js/mdx');
+		const { renderToString } = await import('react-dom/server');
+		const { createElement } = await import('react');
+
+		const mockComponent = vi.fn(() => '');
+
+		vi.mocked(evaluate).mockResolvedValue({
+			default: mockComponent,
+		});
+
+		vi.mocked(createElement).mockReturnValue({
+			type: mockComponent,
+			props: {},
+			key: null,
+		} as MockReactElement);
+
+		vi.mocked(renderToString).mockReturnValue('');
+
+		const result = await renderMDX('');
+
+		expect(evaluate).toHaveBeenCalledWith('', expect.any(Object));
+		expect(result).toBe('');
+	});
+
+	it('should include base remark and rehype plugins', async () => {
+		const { evaluate } = await import('@mdx-js/mdx');
+		const { renderToString } = await import('react-dom/server');
+		const { createElement } = await import('react');
+
+		const mockComponent = vi.fn(() => 'test');
+
+		vi.mocked(evaluate).mockResolvedValue({
+			default: mockComponent,
+		});
+
+		vi.mocked(createElement).mockReturnValue({
+			type: mockComponent,
+			props: {},
+			key: null,
+		} as MockReactElement);
+
+		vi.mocked(renderToString).mockReturnValue('test');
+
+		await renderMDX('test');
+
+		const evaluateCall = vi.mocked(evaluate).mock.calls[0];
+		const options = evaluateCall[1];
+
+		expect(options.remarkPlugins).toHaveLength(1); // remark-gfm
+		expect(options.rehypePlugins).toHaveLength(1); // rehype-highlight
+	});
+
+	it('should use default shared config', async () => {
+		const { evaluate } = await import('@mdx-js/mdx');
+		const { renderToString } = await import('react-dom/server');
+		const { createElement } = await import('react');
+
+		const mockComponent = vi.fn(() => 'test');
+
+		vi.mocked(evaluate).mockResolvedValue({
+			default: mockComponent,
+		});
+
+		vi.mocked(createElement).mockReturnValue({
+			type: mockComponent,
+			props: {},
+			key: null,
+		} as MockReactElement);
+
+		vi.mocked(renderToString).mockReturnValue('test');
+
+		await renderMDX('test');
+
+		const evaluateCall = vi.mocked(evaluate).mock.calls[0];
+		const options = evaluateCall[1];
+
+		expect(options.remarkPlugins).toHaveLength(1); // remark-gfm
+		expect(options.rehypePlugins).toHaveLength(1); // rehype-highlight
+		expect(options.recmaPlugins).toHaveLength(0); // no custom recma plugins
+		expect(options.remarkRehypeOptions).toEqual({});
+	});
+
+	it('should handle evaluation errors gracefully', async () => {
+		const { evaluate } = await import('@mdx-js/mdx');
+
+		vi.mocked(evaluate).mockRejectedValue(new Error('MDX evaluation failed'));
+
+		await expect(renderMDX('invalid mdx')).rejects.toThrow('MDX evaluation failed');
+	});
+
+	it('should handle render errors gracefully', async () => {
+		const { evaluate } = await import('@mdx-js/mdx');
+		const { renderToString } = await import('react-dom/server');
+		const { createElement } = await import('react');
+
+		const mockComponent = vi.fn(() => 'test');
+
+		vi.mocked(evaluate).mockResolvedValue({
+			default: mockComponent,
+		});
+
+		vi.mocked(createElement).mockReturnValue({
+			type: mockComponent,
+			props: {},
+			key: null,
+		} as MockReactElement);
+
+		vi.mocked(renderToString).mockImplementation(() => {
+			throw new Error('Render failed');
+		});
+
+		await expect(renderMDX('test')).rejects.toThrow('Render failed');
+	});
+
+	describe('Edge cases', () => {
+		it('should handle empty plugin arrays', async () => {
+			const { evaluate } = await import('@mdx-js/mdx');
+			const { renderToString } = await import('react-dom/server');
+			const { createElement } = await import('react');
+
+			// Mock shared config with empty plugin arrays
+			const { shared } = await import('../../src/lib/shared.js');
+			shared.mdxConfig = {
+				remarkPlugins: [],
+				rehypePlugins: [],
+				recmaPlugins: [],
+				remarkRehypeOptions: {},
+			};
+
+			const mockComponent = vi.fn(() => 'test');
+
+			vi.mocked(evaluate).mockResolvedValue({
+				default: mockComponent,
+			});
+
+			vi.mocked(createElement).mockReturnValue({
+				type: mockComponent,
+				props: {},
+				key: null,
+			} as any);
+
+			vi.mocked(renderToString).mockReturnValue('test');
+
+			await renderMDX('test');
+
+			const evaluateCall = vi.mocked(evaluate).mock.calls[0];
+			const options = evaluateCall[1];
+
+			expect(options.remarkPlugins).toHaveLength(1); // base remark-gfm
+			expect(options.rehypePlugins).toHaveLength(1); // base rehype-highlight
+			expect(options.recmaPlugins).toHaveLength(0); // empty array
+		});
+
+		it('should handle null/undefined plugin configurations', async () => {
+			const { evaluate } = await import('@mdx-js/mdx');
+			const { renderToString } = await import('react-dom/server');
+			const { createElement } = await import('react');
+
+			const mockComponent = vi.fn(() => 'test');
+
+			vi.mocked(evaluate).mockResolvedValue({
+				default: mockComponent,
+			});
+
+			vi.mocked(createElement).mockReturnValue({
+				type: mockComponent,
+				props: {},
+				key: null,
+			} as any);
+
+			vi.mocked(renderToString).mockReturnValue('test');
+
+			// Test with null content
+			await renderMDX('');
+
+			// Test with whitespace-only content
+			await renderMDX('   \n\t   ');
+
+			// Test with very long content
+			const longContent = '# Title\n\n' + 'A'.repeat(10000);
+			await renderMDX(longContent);
+
+			expect(evaluate).toHaveBeenCalledTimes(3);
+		});
+
+		it('should handle malformed MDX content', async () => {
+			const { evaluate } = await import('@mdx-js/mdx');
+			const { renderToString } = await import('react-dom/server');
+			const { createElement } = await import('react');
+
+			const malformedContent = `
+# Broken MDX
+
+<UnclosedTag>
+This is broken JSX
+
+import { Component } from 'react';
+<Component prop="unclosed quote>
+`;
+
+			const mockComponent = vi.fn(() => 'test');
+
+			vi.mocked(evaluate).mockResolvedValue({
+				default: mockComponent,
+			});
+
+			vi.mocked(createElement).mockReturnValue({
+				type: mockComponent,
+				props: {},
+				key: null,
+			} as any);
+
+			vi.mocked(renderToString).mockReturnValue('test');
+
+			await renderMDX(malformedContent);
+
+			expect(evaluate).toHaveBeenCalledWith(malformedContent, expect.any(Object));
+		});
+
+		it('should handle special characters and unicode content', async () => {
+			const { evaluate } = await import('@mdx-js/mdx');
+			const { renderToString } = await import('react-dom/server');
+			const { createElement } = await import('react');
+
+			const unicodeContent = `# Hello World
+
+This is **bold** with emojis
+
+Math symbols and unicode text
+
+Special chars: <>&"'`;
+
+			const mockComponent = vi.fn(() => 'test');
+
+			vi.mocked(evaluate).mockResolvedValue({
+				default: mockComponent,
+			});
+
+			vi.mocked(createElement).mockReturnValue({
+				type: mockComponent,
+				props: {},
+				key: null,
+			} as any);
+
+			vi.mocked(renderToString).mockReturnValue('test');
+
+			await renderMDX(unicodeContent);
+
+			expect(evaluate).toHaveBeenCalledWith(unicodeContent, expect.any(Object));
+		});
+
+		it('should handle complex JSX with nested components', async () => {
+			const { evaluate } = await import('@mdx-js/mdx');
+			const { renderToString } = await import('react-dom/server');
+			const { createElement } = await import('react');
+
+			const complexJSX = `import { Button, Card, Modal } from './components';
+
+# Complex Component Test
+
+<Card title="Test Card">
+  <p>This is a complex component test.</p>
+  <Button onClick={() => alert('clicked')}>
+    Click me
+  </Button>
+  <Modal isOpen={true}>
+    <h2>Modal Content</h2>
+    <p>This is inside a modal.</p>
+  </Modal>
+</Card>`;
+
+			const mockComponent = vi.fn(() => 'test');
+
+			vi.mocked(evaluate).mockResolvedValue({
+				default: mockComponent,
+			});
+
+			vi.mocked(createElement).mockReturnValue({
+				type: mockComponent,
+				props: {},
+				key: null,
+			} as any);
+
+			vi.mocked(renderToString).mockReturnValue('test');
+
+			await renderMDX(complexJSX);
+
+			expect(evaluate).toHaveBeenCalledWith(complexJSX, expect.any(Object));
+		});
+
+		it('should handle makeList function with empty userDefinedPlugins', async () => {
+			const { evaluate } = await import('@mdx-js/mdx');
+			const { renderToString } = await import('react-dom/server');
+			const { createElement } = await import('react');
+
+			// Mock shared config with empty arrays to test makeList edge case
+			const { shared } = await import('../../src/lib/shared.js');
+			shared.mdxConfig = {
+				remarkPlugins: [],
+				rehypePlugins: [],
+				recmaPlugins: [],
+				remarkRehypeOptions: {},
+			};
+
+			const mockComponent = vi.fn(() => 'test');
+
+			vi.mocked(evaluate).mockResolvedValue({
+				default: mockComponent,
+			});
+
+			vi.mocked(createElement).mockReturnValue({
+				type: mockComponent,
+				props: {},
+				key: null,
+			} as any);
+
+			vi.mocked(renderToString).mockReturnValue('test');
+
+			await renderMDX('test');
+
+			const evaluateCall = vi.mocked(evaluate).mock.calls[0];
+			const options = evaluateCall[1];
+
+			// Should still include base plugins even with empty user arrays
+			expect(options.remarkPlugins).toHaveLength(1); // remark-gfm
+			expect(options.rehypePlugins).toHaveLength(1); // rehype-highlight
+		});
+
+		it('should handle runtime errors in MDX evaluation', async () => {
+			const { evaluate } = await import('@mdx-js/mdx');
+
+			// Test different types of evaluation errors
+			vi.mocked(evaluate).mockRejectedValue(new SyntaxError('Invalid MDX syntax'));
+			await expect(renderMDX('invalid syntax')).rejects.toThrow('Invalid MDX syntax');
+
+			vi.mocked(evaluate).mockRejectedValue(new TypeError('Type error in MDX'));
+			await expect(renderMDX('type error')).rejects.toThrow('Type error in MDX');
+
+			vi.mocked(evaluate).mockRejectedValue(new ReferenceError('Undefined variable'));
+			await expect(renderMDX('undefined var')).rejects.toThrow('Undefined variable');
+		});
+
+		it('should handle React rendering edge cases', async () => {
+			const { evaluate } = await import('@mdx-js/mdx');
+			const { renderToString } = await import('react-dom/server');
+			const { createElement } = await import('react');
+
+			const mockComponent = vi.fn(() => 'test');
+
+			vi.mocked(evaluate).mockResolvedValue({
+				default: mockComponent,
+			});
+
+			// Test with different React element structures
+			vi.mocked(createElement).mockReturnValue({
+				type: mockComponent,
+				props: { className: 'test-class', id: 'test-id' },
+				key: 'test-key',
+			} as any);
+
+			vi.mocked(renderToString).mockReturnValue('<div class="test-class" id="test-id">test</div>');
+
+			const result = await renderMDX('test');
+
+			expect(result).toBe('<div class="test-class" id="test-id">test</div>');
+			expect(createElement).toHaveBeenCalledWith(mockComponent);
+		});
+	});
+});

--- a/packages/@studiocms/mdx/test/lib/render.test.ts
+++ b/packages/@studiocms/mdx/test/lib/render.test.ts
@@ -1,19 +1,13 @@
+import type { JSXElementConstructor, ReactElement } from 'react';
 import type { PluggableList } from 'unified';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderMDX } from '../../src/lib/render.js';
 import { createMockMDXContent } from '../test-utils.js';
 
 interface MockReactElement {
-	type: any;
-	props: Record<string, any>;
+	type: unknown;
+	props: Record<string, unknown>;
 	key: string | null;
-}
-
-interface MockEvaluateOptions {
-	remarkPlugins: PluggableList;
-	rehypePlugins: PluggableList;
-	recmaPlugins: PluggableList;
-	remarkRehypeOptions: Record<string, any>;
 }
 
 // Mock the dependencies
@@ -22,7 +16,7 @@ vi.mock('@mdx-js/mdx', () => ({
 }));
 
 vi.mock('react', () => ({
-	createElement: vi.fn((component: any, props: Record<string, any> = {}, ...children: any[]): MockReactElement => ({
+	createElement: vi.fn((component: unknown, props: Record<string, unknown> = {}, ...children: unknown[]): MockReactElement => ({
 		type: component,
 		props: { ...props, children },
 		key: null,
@@ -89,7 +83,7 @@ describe('renderMDX', () => {
 			type: mockComponent,
 			props: {},
 			key: null,
-		} as MockReactElement);
+		} as unknown as ReactElement<Record<string, never>, string | JSXElementConstructor<unknown>>);
 
 		vi.mocked(renderToString).mockReturnValue('<h1>Hello World</h1>');
 
@@ -128,7 +122,7 @@ describe('renderMDX', () => {
 			type: mockComponent,
 			props: {},
 			key: null,
-		} as MockReactElement);
+		} as unknown as ReactElement<Record<string, never>, string | JSXElementConstructor<unknown>>);
 
 		vi.mocked(renderToString).mockReturnValue('<div><h1>Hello World</h1><button>Click me!</button></div>');
 
@@ -159,7 +153,7 @@ describe('renderMDX', () => {
 			type: mockComponent,
 			props: {},
 			key: null,
-		} as MockReactElement);
+		} as unknown as ReactElement<Record<string, never>, string | JSXElementConstructor<unknown>>);
 
 		vi.mocked(renderToString).mockReturnValue('');
 
@@ -184,7 +178,7 @@ describe('renderMDX', () => {
 			type: mockComponent,
 			props: {},
 			key: null,
-		} as MockReactElement);
+		} as unknown as ReactElement<Record<string, never>, string | JSXElementConstructor<unknown>>);
 
 		vi.mocked(renderToString).mockReturnValue('test');
 
@@ -212,7 +206,7 @@ describe('renderMDX', () => {
 			type: mockComponent,
 			props: {},
 			key: null,
-		} as MockReactElement);
+		} as unknown as ReactElement<Record<string, never>, string | JSXElementConstructor<unknown>>);
 
 		vi.mocked(renderToString).mockReturnValue('test');
 
@@ -250,7 +244,7 @@ describe('renderMDX', () => {
 			type: mockComponent,
 			props: {},
 			key: null,
-		} as MockReactElement);
+		} as unknown as ReactElement<Record<string, never>, string | JSXElementConstructor<unknown>>);
 
 		vi.mocked(renderToString).mockImplementation(() => {
 			throw new Error('Render failed');
@@ -284,7 +278,7 @@ describe('renderMDX', () => {
 				type: mockComponent,
 				props: {},
 				key: null,
-			} as any);
+			} as unknown as ReactElement<Record<string, never>, string | JSXElementConstructor<unknown>>);
 
 			vi.mocked(renderToString).mockReturnValue('test');
 
@@ -313,7 +307,7 @@ describe('renderMDX', () => {
 				type: mockComponent,
 				props: {},
 				key: null,
-			} as any);
+			} as unknown as ReactElement<Record<string, never>, string | JSXElementConstructor<unknown>>);
 
 			vi.mocked(renderToString).mockReturnValue('test');
 
@@ -355,7 +349,7 @@ import { Component } from 'react';
 				type: mockComponent,
 				props: {},
 				key: null,
-			} as any);
+			} as unknown as ReactElement<Record<string, never>, string | JSXElementConstructor<unknown>>);
 
 			vi.mocked(renderToString).mockReturnValue('test');
 
@@ -387,7 +381,7 @@ Special chars: <>&"'`;
 				type: mockComponent,
 				props: {},
 				key: null,
-			} as any);
+			} as unknown as ReactElement<Record<string, never>, string | JSXElementConstructor<unknown>>);
 
 			vi.mocked(renderToString).mockReturnValue('test');
 
@@ -426,7 +420,7 @@ Special chars: <>&"'`;
 				type: mockComponent,
 				props: {},
 				key: null,
-			} as any);
+			} as unknown as ReactElement<Record<string, never>, string | JSXElementConstructor<unknown>>);
 
 			vi.mocked(renderToString).mockReturnValue('test');
 
@@ -459,7 +453,7 @@ Special chars: <>&"'`;
 				type: mockComponent,
 				props: {},
 				key: null,
-			} as any);
+			} as unknown as ReactElement<Record<string, never>, string | JSXElementConstructor<unknown>>);
 
 			vi.mocked(renderToString).mockReturnValue('test');
 
@@ -503,7 +497,7 @@ Special chars: <>&"'`;
 				type: mockComponent,
 				props: { className: 'test-class', id: 'test-id' },
 				key: 'test-key',
-			} as any);
+			} as unknown as ReactElement<Record<string, never>, string | JSXElementConstructor<unknown>>);
 
 			vi.mocked(renderToString).mockReturnValue('<div class="test-class" id="test-id">test</div>');
 

--- a/packages/@studiocms/mdx/test/test-utils.ts
+++ b/packages/@studiocms/mdx/test/test-utils.ts
@@ -1,0 +1,50 @@
+import type { MDXPluginOptions } from '../src/types.js';
+
+/**
+ * Mock MDX plugin options for testing
+ */
+export const createMockMDXOptions = (
+	overrides: Partial<MDXPluginOptions> = {}
+): MDXPluginOptions => ({
+	remarkPlugins: [],
+	rehypePlugins: [],
+	recmaPlugins: [],
+	remarkRehypeOptions: {},
+	...overrides,
+});
+
+/**
+ * Mock MDX content for testing
+ */
+export const createMockMDXContent = (content = '# Hello World\n\nThis is a test MDX content.') => content;
+
+/**
+ * Mock React component for testing MDX rendering
+ */
+export const createMockReactComponent = (name = 'TestComponent') => {
+	return `import React from 'react';
+
+export const ${name} = ({ children }: { children: React.ReactNode }) => {
+	return <div className="test-component">{children}</div>;
+};`;
+};
+
+/**
+ * Clean up global state after tests
+ */
+export const cleanupGlobalState = () => {
+	// Clean up any global state if needed
+	// This can be extended based on what the MDX plugin stores globally
+};
+
+/**
+ * Mock MDX evaluation result
+ */
+export const createMockMDXEvaluationResult = (content: string) => ({
+	default: () => content,
+});
+
+/**
+ * Mock React render result
+ */
+export const createMockReactRenderResult = (html: string) => html;

--- a/packages/@studiocms/mdx/test/test-utils.ts
+++ b/packages/@studiocms/mdx/test/test-utils.ts
@@ -17,34 +17,3 @@ export const createMockMDXOptions = (
  * Mock MDX content for testing
  */
 export const createMockMDXContent = (content = '# Hello World\n\nThis is a test MDX content.') => content;
-
-/**
- * Mock React component for testing MDX rendering
- */
-export const createMockReactComponent = (name = 'TestComponent') => {
-	return `import React from 'react';
-
-export const ${name} = ({ children }: { children: React.ReactNode }) => {
-	return <div className="test-component">{children}</div>;
-};`;
-};
-
-/**
- * Clean up global state after tests
- */
-export const cleanupGlobalState = () => {
-	// Clean up any global state if needed
-	// This can be extended based on what the MDX plugin stores globally
-};
-
-/**
- * Mock MDX evaluation result
- */
-export const createMockMDXEvaluationResult = (content: string) => ({
-	default: () => content,
-});
-
-/**
- * Mock React render result
- */
-export const createMockReactRenderResult = (html: string) => html;

--- a/packages/@studiocms/mdx/vitest.config.ts
+++ b/packages/@studiocms/mdx/vitest.config.ts
@@ -2,7 +2,7 @@ import type { AstroIntegration } from 'astro';
 import { getViteConfig } from 'astro/config';
 import { addVirtualImports } from 'astro-integration-kit';
 import { defineProject } from 'vitest/config';
-import { studiocmsMDX } from './src/index.js';
+import { internalMDXIntegration } from './src/index.js';
 
 const testIntegration: AstroIntegration = {
 	name: 'test-integration',
@@ -29,7 +29,7 @@ export default defineProject(
 			},
 		},
 		{
-			integrations: [testIntegration, studiocmsMDX()],
+			integrations: [testIntegration, internalMDXIntegration('@studiocms/mdx')],
 		}
 	)
 );

--- a/packages/@studiocms/mdx/vitest.config.ts
+++ b/packages/@studiocms/mdx/vitest.config.ts
@@ -1,0 +1,35 @@
+import type { AstroIntegration } from 'astro';
+import { getViteConfig } from 'astro/config';
+import { addVirtualImports } from 'astro-integration-kit';
+import { defineProject } from 'vitest/config';
+import { studiocmsMDX } from './src/index.js';
+
+const testIntegration: AstroIntegration = {
+	name: 'test-integration',
+	hooks: {
+		'astro:config:setup': (params) => {
+			addVirtualImports(params, {
+				name: 'test-integration',
+				imports: {
+					'studiocms:component-registry/runtime':
+						// Test-only identity renderer: mirrors API shape but skips sanitization on purpose.
+						'export const createRenderer = (result, sanitize, preRenderer) => (content) => content;',
+				},
+			});
+		},
+	},
+};
+
+export default defineProject(
+	getViteConfig(
+		{
+			test: {
+				environment: 'node',
+				include: ['**/*.test.ts'],
+			},
+		},
+		{
+			integrations: [testIntegration, studiocmsMDX()],
+		}
+	)
+);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,7 @@ const projectsWithTests: { scope?: string; names: string[] }[] = [
 	},
 	{
 		scope: 'studiocms',
-		names: ['devapps', 'html', 'cloudinary-image-service', 'md'],
+		names: ['devapps', 'html', 'cloudinary-image-service', 'md', 'mdx'],
 	},
 ];
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes # <!-- If applicable add an issue number to this PR so it can be closed otherwise feel free to remove this. -->
- What does this PR change? Give us a brief description.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added comprehensive automated tests for the MDX editor, renderer, plugin setup, and render pipeline covering typical and edge cases.
  - Added test utilities and a package-level Vitest configuration to enable consistent MDX package testing.

- Chores
  - Added a test script to the MDX package and included the MDX package in workspace test runs.

- Public API
  - Added a new exported integration helper to simplify MDX integration configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->