### PR TITLE
feat(tests): add tests for Discord, GitHub, and Google OAuth plugins

### DIFF
--- a/packages/@studiocms/discord/package.json
+++ b/packages/@studiocms/discord/package.json
@@ -42,7 +42,8 @@
   "scripts": {
     "build": "buildkit build 'src/**/*.{ts,astro,css,json,png}'",
     "dev": "buildkit dev 'src/**/*.{ts,astro,css,json,png}'",
-    "typecheck": "tspc -p tsconfig.tspc.json"
+    "typecheck": "tspc -p tsconfig.tspc.json",
+    "test": "vitest"
   },
   "exports": {
     ".": {

--- a/packages/@studiocms/discord/test/index.test.ts
+++ b/packages/@studiocms/discord/test/index.test.ts
@@ -1,0 +1,156 @@
+import { StudioCMSPluginTester } from 'studiocms/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { studiocmsDiscord } from '../src/index.js';
+
+describe('@studiocms/discord', () => {
+	let tester: StudioCMSPluginTester;
+	let plugin: ReturnType<typeof studiocmsDiscord>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = studiocmsDiscord();
+		tester = new StudioCMSPluginTester(plugin);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('plugin creation', () => {
+		it('should create a plugin with correct metadata', () => {
+			const pluginInfo = tester.getPluginInfo();
+			expect(pluginInfo).toBeDefined();
+			expect(pluginInfo.identifier).toBe('@studiocms/discord');
+			expect(pluginInfo.name).toBe('StudioCMS Discord Provider Plugin');
+			expect(pluginInfo.studiocmsMinimumVersion).toBe('0.1.0-beta.22');
+			expect(pluginInfo.requires).toBeUndefined();
+		});
+
+		it('should export default function', () => {
+			expect(typeof studiocmsDiscord).toBe('function');
+			expect(studiocmsDiscord.name).toBe('studiocmsDiscord');
+		});
+
+		it('should return a valid StudioCMSPlugin object', () => {
+			expect(plugin).toBeDefined();
+			expect(plugin.identifier).toBe('@studiocms/discord');
+			expect(plugin.name).toBe('StudioCMS Discord Provider Plugin');
+			expect(plugin.hooks).toBeDefined();
+		});
+	});
+
+	describe('hooks', () => {
+		it('should have the correct hooks defined', async () => {
+			const hookResults = await tester.getHookResults();
+
+			expect(hookResults.studiocmsConfig).toBeDefined();
+			expect(hookResults.studiocmsConfig.hasHook).toBe(true);
+		});
+
+		it('should configure Discord OAuth provider in studiocms config hook', async () => {
+			const hookResults = await tester.getHookResults();
+
+			expect(hookResults.studiocmsConfig.hookResults.authService).toBeDefined();
+			expect(hookResults.studiocmsConfig.hookResults.authService.oAuthProvider).toBeDefined();
+
+			const oAuthProvider = hookResults.studiocmsConfig.hookResults.authService.oAuthProvider;
+			expect(oAuthProvider).toBeDefined();
+			expect(oAuthProvider?.name).toBe('discord');
+			expect(oAuthProvider?.formattedName).toBe('Discord');
+			expect(oAuthProvider?.endpointPath).toContain('endpoint.js');
+		});
+
+		it('should define required environment variables', async () => {
+			const hookResults = await tester.getHookResults();
+			const oAuthProvider = hookResults.studiocmsConfig.hookResults.authService.oAuthProvider;
+
+			expect(oAuthProvider?.requiredEnvVariables).toEqual([
+				'CMS_DISCORD_CLIENT_ID',
+				'CMS_DISCORD_CLIENT_SECRET',
+				'CMS_DISCORD_REDIRECT_URI',
+			]);
+		});
+
+		it('should include Discord SVG logo', async () => {
+			const hookResults = await tester.getHookResults();
+			const oAuthProvider = hookResults.studiocmsConfig.hookResults.authService.oAuthProvider;
+
+			expect(oAuthProvider?.svg).toBeDefined();
+			expect(oAuthProvider?.svg).toContain('<svg');
+			expect(oAuthProvider?.svg).toContain('oauth-logo');
+			expect(oAuthProvider?.svg).toContain('viewBox="0 0 256 199"');
+		});
+
+		it('should not have astro config hook', async () => {
+			const hookResults = await tester.getHookResults();
+
+			expect(hookResults.astroConfig.hasHook).toBe(false);
+			expect(hookResults.astroConfig.hookResults.integrations).toEqual([]);
+		});
+	});
+
+	describe('plugin structure', () => {
+		it('should have correct plugin identifier', () => {
+			expect(plugin.identifier).toBe('@studiocms/discord');
+		});
+
+		it('should have correct plugin name', () => {
+			expect(plugin.name).toBe('StudioCMS Discord Provider Plugin');
+		});
+
+		it('should have correct minimum version requirement', () => {
+			expect(plugin.studiocmsMinimumVersion).toBe('0.1.0-beta.22');
+		});
+
+		it('should have no required dependencies', () => {
+			expect(plugin.requires).toBeUndefined();
+		});
+
+		it('should have hooks object', () => {
+			expect(plugin.hooks).toBeDefined();
+			expect(typeof plugin.hooks).toBe('object');
+		});
+	});
+
+	describe('hook implementation', () => {
+		it('should have studiocms:config:setup hook', () => {
+			expect(plugin.hooks['studiocms:config:setup']).toBeDefined();
+			expect(typeof plugin.hooks['studiocms:config:setup']).toBe('function');
+		});
+
+		it('should not have other hooks', () => {
+			const hookKeys = Object.keys(plugin.hooks);
+			expect(hookKeys).toEqual(['studiocms:config:setup']);
+		});
+	});
+
+	describe('OAuth provider configuration', () => {
+		it('should configure Discord as OAuth provider', async () => {
+			const hookResults = await tester.getHookResults();
+			const authService = hookResults.studiocmsConfig.hookResults.authService;
+
+			expect(authService.oAuthProvider).toBeDefined();
+			expect(authService.oAuthProvider?.name).toBe('discord');
+			expect(authService.oAuthProvider?.formattedName).toBe('Discord');
+		});
+
+		it('should set correct endpoint path', async () => {
+			const hookResults = await tester.getHookResults();
+			const oAuthProvider = hookResults.studiocmsConfig.hookResults.authService.oAuthProvider;
+
+			expect(oAuthProvider?.endpointPath).toContain('endpoint.js');
+			expect(oAuthProvider?.endpointPath).not.toContain('endpoint.ts');
+		});
+
+		it('should include all required Discord environment variables', async () => {
+			const hookResults = await tester.getHookResults();
+			const requiredEnvVars =
+				hookResults.studiocmsConfig.hookResults.authService.oAuthProvider?.requiredEnvVariables;
+
+			expect(requiredEnvVars).toContain('CMS_DISCORD_CLIENT_ID');
+			expect(requiredEnvVars).toContain('CMS_DISCORD_CLIENT_SECRET');
+			expect(requiredEnvVars).toContain('CMS_DISCORD_REDIRECT_URI');
+			expect(requiredEnvVars).toHaveLength(3);
+		});
+	});
+});

--- a/packages/@studiocms/discord/vitest.config.ts
+++ b/packages/@studiocms/discord/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineProject } from 'vitest/config';
+
+export default defineProject({
+	test: {
+		environment: 'node',
+		include: ['**/*.test.ts'],
+	},
+});

--- a/packages/@studiocms/github/package.json
+++ b/packages/@studiocms/github/package.json
@@ -42,7 +42,8 @@
   "scripts": {
     "build": "buildkit build 'src/**/*.{ts,astro,css,json,png}'",
     "dev": "buildkit dev 'src/**/*.{ts,astro,css,json,png}'",
-    "typecheck": "tspc -p tsconfig.tspc.json"
+    "typecheck": "tspc -p tsconfig.tspc.json",
+    "test": "vitest"
   },
   "exports": {
     ".": {

--- a/packages/@studiocms/github/test/index.test.ts
+++ b/packages/@studiocms/github/test/index.test.ts
@@ -1,0 +1,156 @@
+import { StudioCMSPluginTester } from 'studiocms/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { studiocmsGithub } from '../src/index.js';
+
+describe('@studiocms/github', () => {
+	let tester: StudioCMSPluginTester;
+	let plugin: ReturnType<typeof studiocmsGithub>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = studiocmsGithub();
+		tester = new StudioCMSPluginTester(plugin);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('plugin creation', () => {
+		it('should create a plugin with correct metadata', () => {
+			const pluginInfo = tester.getPluginInfo();
+			expect(pluginInfo).toBeDefined();
+			expect(pluginInfo.identifier).toBe('@studiocms/github');
+			expect(pluginInfo.name).toBe('StudioCMS GitHub Plugin');
+			expect(pluginInfo.studiocmsMinimumVersion).toBe('0.1.0-beta.22');
+			expect(pluginInfo.requires).toBeUndefined();
+		});
+
+		it('should export default function', () => {
+			expect(typeof studiocmsGithub).toBe('function');
+			expect(studiocmsGithub.name).toBe('studiocmsGithub');
+		});
+
+		it('should return a valid StudioCMSPlugin object', () => {
+			expect(plugin).toBeDefined();
+			expect(plugin.identifier).toBe('@studiocms/github');
+			expect(plugin.name).toBe('StudioCMS GitHub Plugin');
+			expect(plugin.hooks).toBeDefined();
+		});
+	});
+
+	describe('hooks', () => {
+		it('should have the correct hooks defined', async () => {
+			const hookResults = await tester.getHookResults();
+
+			expect(hookResults.studiocmsConfig).toBeDefined();
+			expect(hookResults.studiocmsConfig.hasHook).toBe(true);
+		});
+
+		it('should configure GitHub OAuth provider in studiocms config hook', async () => {
+			const hookResults = await tester.getHookResults();
+
+			expect(hookResults.studiocmsConfig.hookResults.authService).toBeDefined();
+			expect(hookResults.studiocmsConfig.hookResults.authService.oAuthProvider).toBeDefined();
+
+			const oAuthProvider = hookResults.studiocmsConfig.hookResults.authService.oAuthProvider;
+			expect(oAuthProvider).toBeDefined();
+			expect(oAuthProvider?.name).toBe('github');
+			expect(oAuthProvider?.formattedName).toBe('GitHub');
+			expect(oAuthProvider?.endpointPath).toContain('endpoint.js');
+		});
+
+		it('should define required environment variables', async () => {
+			const hookResults = await tester.getHookResults();
+			const oAuthProvider = hookResults.studiocmsConfig.hookResults.authService.oAuthProvider;
+
+			expect(oAuthProvider?.requiredEnvVariables).toEqual([
+				'CMS_GITHUB_CLIENT_ID',
+				'CMS_GITHUB_CLIENT_SECRET',
+				'CMS_GITHUB_REDIRECT_URI',
+			]);
+		});
+
+		it('should include GitHub SVG logo', async () => {
+			const hookResults = await tester.getHookResults();
+			const oAuthProvider = hookResults.studiocmsConfig.hookResults.authService.oAuthProvider;
+
+			expect(oAuthProvider?.svg).toBeDefined();
+			expect(oAuthProvider?.svg).toContain('<svg');
+			expect(oAuthProvider?.svg).toContain('oauth-logo');
+			expect(oAuthProvider?.svg).toContain('viewBox="0 0 98 96"');
+		});
+
+		it('should not have astro config hook', async () => {
+			const hookResults = await tester.getHookResults();
+
+			expect(hookResults.astroConfig.hasHook).toBe(false);
+			expect(hookResults.astroConfig.hookResults.integrations).toEqual([]);
+		});
+	});
+
+	describe('plugin structure', () => {
+		it('should have correct plugin identifier', () => {
+			expect(plugin.identifier).toBe('@studiocms/github');
+		});
+
+		it('should have correct plugin name', () => {
+			expect(plugin.name).toBe('StudioCMS GitHub Plugin');
+		});
+
+		it('should have correct minimum version requirement', () => {
+			expect(plugin.studiocmsMinimumVersion).toBe('0.1.0-beta.22');
+		});
+
+		it('should have no required dependencies', () => {
+			expect(plugin.requires).toBeUndefined();
+		});
+
+		it('should have hooks object', () => {
+			expect(plugin.hooks).toBeDefined();
+			expect(typeof plugin.hooks).toBe('object');
+		});
+	});
+
+	describe('hook implementation', () => {
+		it('should have studiocms:config:setup hook', () => {
+			expect(plugin.hooks['studiocms:config:setup']).toBeDefined();
+			expect(typeof plugin.hooks['studiocms:config:setup']).toBe('function');
+		});
+
+		it('should not have other hooks', () => {
+			const hookKeys = Object.keys(plugin.hooks);
+			expect(hookKeys).toEqual(['studiocms:config:setup']);
+		});
+	});
+
+	describe('OAuth provider configuration', () => {
+		it('should configure GitHub as OAuth provider', async () => {
+			const hookResults = await tester.getHookResults();
+			const authService = hookResults.studiocmsConfig.hookResults.authService;
+
+			expect(authService.oAuthProvider).toBeDefined();
+			expect(authService.oAuthProvider?.name).toBe('github');
+			expect(authService.oAuthProvider?.formattedName).toBe('GitHub');
+		});
+
+		it('should set correct endpoint path', async () => {
+			const hookResults = await tester.getHookResults();
+			const oAuthProvider = hookResults.studiocmsConfig.hookResults.authService.oAuthProvider;
+
+			expect(oAuthProvider?.endpointPath).toContain('endpoint.js');
+			expect(oAuthProvider?.endpointPath).not.toContain('endpoint.ts');
+		});
+
+		it('should include all required GitHub environment variables', async () => {
+			const hookResults = await tester.getHookResults();
+			const requiredEnvVars =
+				hookResults.studiocmsConfig.hookResults.authService.oAuthProvider?.requiredEnvVariables;
+
+			expect(requiredEnvVars).toContain('CMS_GITHUB_CLIENT_ID');
+			expect(requiredEnvVars).toContain('CMS_GITHUB_CLIENT_SECRET');
+			expect(requiredEnvVars).toContain('CMS_GITHUB_REDIRECT_URI');
+			expect(requiredEnvVars).toHaveLength(3);
+		});
+	});
+});

--- a/packages/@studiocms/github/vitest.config.ts
+++ b/packages/@studiocms/github/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineProject } from 'vitest/config';
+
+export default defineProject({
+	test: {
+		environment: 'node',
+		include: ['**/*.test.ts'],
+	},
+});

--- a/packages/@studiocms/google/package.json
+++ b/packages/@studiocms/google/package.json
@@ -42,7 +42,8 @@
   "scripts": {
     "build": "buildkit build 'src/**/*.{ts,astro,css,json,png}'",
     "dev": "buildkit dev 'src/**/*.{ts,astro,css,json,png}'",
-    "typecheck": "tspc -p tsconfig.tspc.json"
+    "typecheck": "tspc -p tsconfig.tspc.json",
+    "test": "vitest"
   },
   "exports": {
     ".": {

--- a/packages/@studiocms/google/test/index.test.ts
+++ b/packages/@studiocms/google/test/index.test.ts
@@ -1,0 +1,156 @@
+import { StudioCMSPluginTester } from 'studiocms/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { studiocmsGoogle } from '../src/index.js';
+
+describe('@studiocms/google', () => {
+	let tester: StudioCMSPluginTester;
+	let plugin: ReturnType<typeof studiocmsGoogle>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		plugin = studiocmsGoogle();
+		tester = new StudioCMSPluginTester(plugin);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('plugin creation', () => {
+		it('should create a plugin with correct metadata', () => {
+			const pluginInfo = tester.getPluginInfo();
+			expect(pluginInfo).toBeDefined();
+			expect(pluginInfo.identifier).toBe('@studiocms/google');
+			expect(pluginInfo.name).toBe('StudioCMS Google Plugin');
+			expect(pluginInfo.studiocmsMinimumVersion).toBe('0.1.0-beta.22');
+			expect(pluginInfo.requires).toBeUndefined();
+		});
+
+		it('should export default function', () => {
+			expect(typeof studiocmsGoogle).toBe('function');
+			expect(studiocmsGoogle.name).toBe('studiocmsGoogle');
+		});
+
+		it('should return a valid StudioCMSPlugin object', () => {
+			expect(plugin).toBeDefined();
+			expect(plugin.identifier).toBe('@studiocms/google');
+			expect(plugin.name).toBe('StudioCMS Google Plugin');
+			expect(plugin.hooks).toBeDefined();
+		});
+	});
+
+	describe('hooks', () => {
+		it('should have the correct hooks defined', async () => {
+			const hookResults = await tester.getHookResults();
+
+			expect(hookResults.studiocmsConfig).toBeDefined();
+			expect(hookResults.studiocmsConfig.hasHook).toBe(true);
+		});
+
+		it('should configure Google OAuth provider in studiocms config hook', async () => {
+			const hookResults = await tester.getHookResults();
+
+			expect(hookResults.studiocmsConfig.hookResults.authService).toBeDefined();
+			expect(hookResults.studiocmsConfig.hookResults.authService.oAuthProvider).toBeDefined();
+
+			const oAuthProvider = hookResults.studiocmsConfig.hookResults.authService.oAuthProvider;
+			expect(oAuthProvider).toBeDefined();
+			expect(oAuthProvider?.name).toBe('google');
+			expect(oAuthProvider?.formattedName).toBe('Google');
+			expect(oAuthProvider?.endpointPath).toContain('endpoint.js');
+		});
+
+		it('should define required environment variables', async () => {
+			const hookResults = await tester.getHookResults();
+			const oAuthProvider = hookResults.studiocmsConfig.hookResults.authService.oAuthProvider;
+
+			expect(oAuthProvider?.requiredEnvVariables).toEqual([
+				'CMS_GOOGLE_CLIENT_ID',
+				'CMS_GOOGLE_CLIENT_SECRET',
+				'CMS_GOOGLE_REDIRECT_URI',
+			]);
+		});
+
+		it('should include Google SVG logo', async () => {
+			const hookResults = await tester.getHookResults();
+			const oAuthProvider = hookResults.studiocmsConfig.hookResults.authService.oAuthProvider;
+
+			expect(oAuthProvider?.svg).toBeDefined();
+			expect(oAuthProvider?.svg).toContain('<svg');
+			expect(oAuthProvider?.svg).toContain('oauth-logo');
+			expect(oAuthProvider?.svg).toContain('viewBox="0 0 256 262"');
+		});
+
+		it('should not have astro config hook', async () => {
+			const hookResults = await tester.getHookResults();
+
+			expect(hookResults.astroConfig.hasHook).toBe(false);
+			expect(hookResults.astroConfig.hookResults.integrations).toEqual([]);
+		});
+	});
+
+	describe('plugin structure', () => {
+		it('should have correct plugin identifier', () => {
+			expect(plugin.identifier).toBe('@studiocms/google');
+		});
+
+		it('should have correct plugin name', () => {
+			expect(plugin.name).toBe('StudioCMS Google Plugin');
+		});
+
+		it('should have correct minimum version requirement', () => {
+			expect(plugin.studiocmsMinimumVersion).toBe('0.1.0-beta.22');
+		});
+
+		it('should have no required dependencies', () => {
+			expect(plugin.requires).toBeUndefined();
+		});
+
+		it('should have hooks object', () => {
+			expect(plugin.hooks).toBeDefined();
+			expect(typeof plugin.hooks).toBe('object');
+		});
+	});
+
+	describe('hook implementation', () => {
+		it('should have studiocms:config:setup hook', () => {
+			expect(plugin.hooks['studiocms:config:setup']).toBeDefined();
+			expect(typeof plugin.hooks['studiocms:config:setup']).toBe('function');
+		});
+
+		it('should not have other hooks', () => {
+			const hookKeys = Object.keys(plugin.hooks);
+			expect(hookKeys).toEqual(['studiocms:config:setup']);
+		});
+	});
+
+	describe('OAuth provider configuration', () => {
+		it('should configure Google as OAuth provider', async () => {
+			const hookResults = await tester.getHookResults();
+			const authService = hookResults.studiocmsConfig.hookResults.authService;
+
+			expect(authService.oAuthProvider).toBeDefined();
+			expect(authService.oAuthProvider?.name).toBe('google');
+			expect(authService.oAuthProvider?.formattedName).toBe('Google');
+		});
+
+		it('should set correct endpoint path', async () => {
+			const hookResults = await tester.getHookResults();
+			const oAuthProvider = hookResults.studiocmsConfig.hookResults.authService.oAuthProvider;
+
+			expect(oAuthProvider?.endpointPath).toContain('endpoint.js');
+			expect(oAuthProvider?.endpointPath).not.toContain('endpoint.ts');
+		});
+
+		it('should include all required Google environment variables', async () => {
+			const hookResults = await tester.getHookResults();
+			const requiredEnvVars =
+				hookResults.studiocmsConfig.hookResults.authService.oAuthProvider?.requiredEnvVariables;
+
+			expect(requiredEnvVars).toContain('CMS_GOOGLE_CLIENT_ID');
+			expect(requiredEnvVars).toContain('CMS_GOOGLE_CLIENT_SECRET');
+			expect(requiredEnvVars).toContain('CMS_GOOGLE_REDIRECT_URI');
+			expect(requiredEnvVars).toHaveLength(3);
+		});
+	});
+});

--- a/packages/@studiocms/google/vitest.config.ts
+++ b/packages/@studiocms/google/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineProject } from 'vitest/config';
+
+export default defineProject({
+	test: {
+		environment: 'node',
+		include: ['**/*.test.ts'],
+	},
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,9 @@ const projectsWithTests: { scope?: string; names: string[] }[] = [
 		scope: 'studiocms',
 		names: [
 			'auth0',
+			'discord',
+			'github',
+			'google',
 			'devapps',
 			'html',
 			'cloudinary-image-service',


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes # <!-- If applicable add an issue number to this PR so it can be closed otherwise feel free to remove this. -->
- What does this PR change? Give us a brief description.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added comprehensive test suites for the Discord, GitHub, and Google provider plugins.
  - Configured project-level test settings for these packages to run in a Node environment and include TypeScript tests.

- Chores
  - Added a test script to the Discord, GitHub, and Google packages.
  - Updated the typecheck script formatting in GitHub and Google packages.
  - Expanded the root test configuration to include the Discord, GitHub, and Google packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->