### PR TITLE
fix(ci): correct condition for PR snapshot preview job to exclude specific users

### DIFF
--- a/.github/workflows/ci-pkg-pr-new.yml
+++ b/.github/workflows/ci-pkg-pr-new.yml
@@ -106,7 +106,7 @@ jobs:
           fi
 
   preview-pr:
-    if: github.event_name == 'pull_request' && (github.event.pull_request.user.login != 'studiocms-no-reply' || github.event.pull_request.user.login != 'apollo-git-bot[bot]')
+    if: github.event_name == 'pull_request' && (github.event.pull_request.user.login != 'studiocms-no-reply' && github.event.pull_request.user.login != 'apollo-git-bot[bot]')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci-pkg-pr-new.yml
+++ b/.github/workflows/ci-pkg-pr-new.yml
@@ -106,7 +106,7 @@ jobs:
           fi
 
   preview-pr:
-    if: github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'studiocms-no-reply' || github.event.pull_request.user.login == 'apollo-git-bot[bot]')
+    if: github.event_name == 'pull_request' && (github.event.pull_request.user.login != 'studiocms-no-reply' || github.event.pull_request.user.login != 'apollo-git-bot[bot]')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes # <!-- If applicable add an issue number to this PR so it can be closed otherwise feel free to remove this. -->
- What does this PR change? Give us a brief description.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI rules for preview environments on pull requests: preview builds now run for PRs opened by non-bot contributors and are skipped for specific bot accounts, improving preview predictability and reducing unnecessary runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->