### PR TITLE
chore(studiocms): deprecate legacy tables

### DIFF
--- a/.changeset/six-readers-work.md
+++ b/.changeset/six-readers-work.md
@@ -1,0 +1,7 @@
+---
+"studiocms": patch
+---
+
+Deprecates the legacy StudioCMSSiteConfig, StudioCMSMailerConfig, and StudioCMSNotificationSettings tables to be fully removed in a future release.
+
+Note: Users will need to run `astro db push --remote` to ensure their DB schemas are up-to-date.

--- a/packages/studiocms/src/db/config.ts
+++ b/packages/studiocms/src/db/config.ts
@@ -149,62 +149,6 @@ const StudioCMSPageContent = defineTable({
 	},
 });
 
-// TODO: Deprecate this table in a future release
-/**
- * StudioCMS - Site Config Table for Astro DB
- *
- * To be deprecated in favor of StudioCMSDynamicConfigSettings
- */
-const StudioCMSSiteConfig = defineTable({
-	columns: {
-		id: column.number({ primaryKey: true }),
-		title: column.text(),
-		description: column.text(),
-		defaultOgImage: column.text({ optional: true }),
-		siteIcon: column.text({ optional: true }),
-		loginPageBackground: column.text({ default: 'studiocms-curves' }),
-		loginPageCustomImage: column.text({ optional: true }),
-		enableDiffs: column.boolean({ default: false }),
-		diffPerPage: column.number({ default: 10 }),
-		gridItems: column.json({ default: [] }),
-		enableMailer: column.boolean({ default: false }),
-		hideDefaultIndex: column.boolean({ default: false }),
-	},
-});
-
-// TODO: Deprecate this table in a future release
-/**
- * To be deprecated in favor of StudioCMSDynamicConfigSettings
- */
-const StudioCMSMailerConfig = defineTable({
-	columns: {
-		id: column.text({ primaryKey: true }),
-		host: column.text(),
-		port: column.number(),
-		secure: column.boolean(),
-		proxy: column.text({ optional: true }),
-		auth_user: column.text({ optional: true }),
-		auth_pass: column.text({ optional: true }),
-		tls_rejectUnauthorized: column.boolean({ optional: true }),
-		tls_servername: column.text({ optional: true }),
-		default_sender: column.text(),
-	},
-});
-
-// TODO: Deprecate this table in a future release
-/**
- * To be deprecated in favor of StudioCMSDynamicConfigSettings
- */
-const StudioCMSNotificationSettings = defineTable({
-	columns: {
-		id: column.text({ primaryKey: true }),
-		emailVerification: column.boolean({ default: false }),
-		requireAdminVerification: column.boolean({ default: false }),
-		requireEditorVerification: column.boolean({ default: false }),
-		oAuthBypassVerification: column.boolean({ default: false }),
-	},
-});
-
 const StudioCMSEmailVerificationTokens = defineTable({
 	columns: {
 		id: column.text({ primaryKey: true }),
@@ -241,6 +185,62 @@ const StudioCMSDynamicConfigSettings = defineTable({
 	},
 });
 
+// TODO: Remove deprecated tables in future release
+
+/**
+ * @deprecated
+ */
+const StudioCMSSiteConfig = defineTable({
+	deprecated: true,
+	columns: {
+		id: column.number({ primaryKey: true }),
+		title: column.text(),
+		description: column.text(),
+		defaultOgImage: column.text({ optional: true }),
+		siteIcon: column.text({ optional: true }),
+		loginPageBackground: column.text({ default: 'studiocms-curves' }),
+		loginPageCustomImage: column.text({ optional: true }),
+		enableDiffs: column.boolean({ default: false }),
+		diffPerPage: column.number({ default: 10 }),
+		gridItems: column.json({ default: [] }),
+		enableMailer: column.boolean({ default: false }),
+		hideDefaultIndex: column.boolean({ default: false }),
+	},
+});
+
+/**
+ * @deprecated
+ */
+const StudioCMSMailerConfig = defineTable({
+	deprecated: true,
+	columns: {
+		id: column.text({ primaryKey: true }),
+		host: column.text(),
+		port: column.number(),
+		secure: column.boolean(),
+		proxy: column.text({ optional: true }),
+		auth_user: column.text({ optional: true }),
+		auth_pass: column.text({ optional: true }),
+		tls_rejectUnauthorized: column.boolean({ optional: true }),
+		tls_servername: column.text({ optional: true }),
+		default_sender: column.text(),
+	},
+});
+
+/**
+ * @deprecated
+ */
+const StudioCMSNotificationSettings = defineTable({
+	deprecated: true,
+	columns: {
+		id: column.text({ primaryKey: true }),
+		emailVerification: column.boolean({ default: false }),
+		requireAdminVerification: column.boolean({ default: false }),
+		requireEditorVerification: column.boolean({ default: false }),
+		oAuthBypassVerification: column.boolean({ default: false }),
+	},
+});
+
 // Export the Database Configuration for StudioCMS
 export default defineDb({
 	tables: {
@@ -250,18 +250,19 @@ export default defineDb({
 		StudioCMSPageDataTags,
 		StudioCMSPermissions,
 		StudioCMSSessionTable,
-		StudioCMSSiteConfig,
 		StudioCMSUsers,
 		StudioCMSOAuthAccounts,
 		StudioCMSDiffTracking,
 		StudioCMSPageFolderStructure,
 		StudioCMSUserResetTokens,
 		StudioCMSAPIKeys,
-		StudioCMSMailerConfig,
-		StudioCMSNotificationSettings,
 		StudioCMSEmailVerificationTokens,
 		StudioCMSPluginData,
 		StudioCMSDynamicConfigSettings,
+		// Deprecated Tables
+		StudioCMSSiteConfig,
+		StudioCMSMailerConfig,
+		StudioCMSNotificationSettings,
 	},
 });
 
@@ -288,15 +289,6 @@ export const tsPageDataCategories = asDrizzleTable(
 	StudioCMSPageDataCategories
 );
 export const tsPageContent = asDrizzleTable('StudioCMSPageContent', StudioCMSPageContent);
-// TODO: Deprecate this table in a future release
-export const tsSiteConfig = asDrizzleTable('StudioCMSSiteConfig', StudioCMSSiteConfig);
-// TODO: Deprecate this table in a future release
-export const tsMailerConfig = asDrizzleTable('StudioCMSMailerConfig', StudioCMSMailerConfig);
-// TODO: Deprecate this table in a future release
-export const tsNotificationSettings = asDrizzleTable(
-	'StudioCMSNotificationSettings',
-	StudioCMSNotificationSettings
-);
 export const tsEmailVerificationTokens = asDrizzleTable(
 	'StudioCMSEmailVerificationTokens',
 	StudioCMSEmailVerificationTokens
@@ -305,4 +297,22 @@ export const tsPluginData = asDrizzleTable('StudioCMSPluginData', StudioCMSPlugi
 export const tsDynamicConfigSettings = asDrizzleTable(
 	'StudioCMSDynamicConfigSettings',
 	StudioCMSDynamicConfigSettings
+);
+
+// TODO: Remove deprecated tables in future release
+
+/**
+ * @deprecated
+ */
+export const tsSiteConfig = asDrizzleTable('StudioCMSSiteConfig', StudioCMSSiteConfig);
+/**
+ * @deprecated
+ */
+export const tsMailerConfig = asDrizzleTable('StudioCMSMailerConfig', StudioCMSMailerConfig);
+/**
+ * @deprecated
+ */
+export const tsNotificationSettings = asDrizzleTable(
+	'StudioCMSNotificationSettings',
+	StudioCMSNotificationSettings
 );

--- a/packages/studiocms/src/db/config.ts
+++ b/packages/studiocms/src/db/config.ts
@@ -186,6 +186,7 @@ const StudioCMSDynamicConfigSettings = defineTable({
 });
 
 // TODO: Remove deprecated tables in future release
+// StudioCMSSiteConfig, StudioCMSMailerConfig, StudioCMSNotificationSettings
 
 /**
  * @deprecated
@@ -300,6 +301,7 @@ export const tsDynamicConfigSettings = asDrizzleTable(
 );
 
 // TODO: Remove deprecated tables in future release
+// StudioCMSSiteConfig, StudioCMSMailerConfig, StudioCMSNotificationSettings
 
 /**
  * @deprecated


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #757  <!-- If applicable add an issue number to this PR so it can be closed otherwise feel free to remove this. -->
- Deprecates the following tables
  - `StudioCMSSiteConfig`
  - `StudioCMSMailerConfig`
  - `StudioCMSNotificationSettings`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

N/A

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->

Added changeset, will make a note in the update guide to push schema changes. (this is official deprecation of legacy no longer used tables)

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dynamic configuration system for StudioCMS to enable more flexible config management.
* **Documentation**
  * Added a changeset notice deprecating legacy configuration tables and advising users to run “astro db push --remote” to update schemas.
* **Chores**
  * Marked three legacy configuration tables as deprecated; compatibility is maintained for now with removal planned in a future release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->