### PR TITLE
chore(studiocms): update feedback button to point to github

### DIFF
--- a/.changeset/major-mice-lick.md
+++ b/.changeset/major-mice-lick.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Updates feedback button to point to github for now

--- a/.changeset/major-mice-lick.md
+++ b/.changeset/major-mice-lick.md
@@ -2,4 +2,4 @@
 "studiocms": patch
 ---
 
-Updates feedback button to point to github for now
+Updates feedback button to point to GitHub (temporary measure until astro-feedback integration)

--- a/packages/studiocms/src/components/dashboard/DashboardPageHeader.astro
+++ b/packages/studiocms/src/components/dashboard/DashboardPageHeader.astro
@@ -32,16 +32,23 @@ const t = useTranslations(lang, '@studiocms/dashboard:index');
       <Fragment set:html={`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 16 16"><path fill="currentColor" d="M13.545 2.907a13.2 13.2 0 0 0-3.257-1.011a.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.2 12.2 0 0 0-3.658 0a8 8 0 0 0-.412-.833a.05.05 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.011a.04.04 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032q.003.022.021.037a13.3 13.3 0 0 0 3.995 2.02a.05.05 0 0 0 .056-.019q.463-.63.818-1.329a.05.05 0 0 0-.01-.059l-.018-.011a9 9 0 0 1-1.248-.595a.05.05 0 0 1-.02-.066l.015-.019q.127-.095.248-.195a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.05.05 0 0 1 .053.007q.121.1.248.195a.05.05 0 0 1-.004.085a8 8 0 0 1-1.249.594a.05.05 0 0 0-.03.03a.05.05 0 0 0 .003.041c.24.465.515.909.817 1.329a.05.05 0 0 0 .056.019a13.2 13.2 0 0 0 4.001-2.02a.05.05 0 0 0 .021-.037c.334-3.451-.559-6.449-2.366-9.106a.03.03 0 0 0-.02-.019m-8.198 7.307c-.789 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.45.73 1.438 1.613c0 .888-.637 1.612-1.438 1.612m5.316 0c-.788 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.451.73 1.438 1.613c0 .888-.631 1.612-1.438 1.612"/></svg>`} slot='start-content' />
       <t-dashboard-header key="title-button:discord">{t("title-button:discord")}</t-dashboard-header>
     </Button>
+    {/*
     <Button color='success' variant='flat' id="feedback-button">
+      <Icon name='heroicons:chat-bubble-oval-left-ellipsis' width={24} height={24} />
+      <t-dashboard-header key="title-button:feedback">{t("title-button:feedback")}</t-dashboard-header>
+    </Button>
+    */}
+    <Button color='success' variant='flat' id="feedback-button" as="a" href={studioCMSSocials.github} target="_blank" rel='noopener noreferrer'>
       <Icon name='heroicons:chat-bubble-oval-left-ellipsis' width={24} height={24} />
       <t-dashboard-header key="title-button:feedback">{t("title-button:feedback")}</t-dashboard-header>
     </Button>
   </div>
 </header>
 
-<Modal 
-  id='feedback-modal' 
-  size='lg' 
+{/*
+<Modal
+  id='feedback-modal'
+  size='lg'
   isForm
   cancelButton={{ label: 'Cancel', color: 'default' }}
   actionButton={{ label: 'Confirm', color: 'primary' }}
@@ -88,7 +95,7 @@ const t = useTranslations(lang, '@studiocms/dashboard:index');
       })
       return;
     }
-    
+
     let response;
     try {
       response = await sendFeelback(
@@ -120,9 +127,10 @@ const t = useTranslations(lang, '@studiocms/dashboard:index');
     }
   });
 </script>
+*/}
 
 <script>
-    import { 
+    import {
         $i18n,
         baseTranslation,
         makeTranslation,
@@ -147,20 +155,20 @@ const t = useTranslations(lang, '@studiocms/dashboard:index');
     flex-wrap: wrap;
     gap: 1rem;
   }
-  
+
   .page-title-container {
     display: flex;
     flex-direction: row;
     gap: 1rem;
     width: fit-content;
   }
-  
+
   .page-title {
     display: block;
     width: fit-content;
     margin: 0;
   }
-  
+
   .page-actions-container {
     display: flex;
     flex-direction: row;

--- a/packages/studiocms/src/components/dashboard/DashboardPageHeader.astro
+++ b/packages/studiocms/src/components/dashboard/DashboardPageHeader.astro
@@ -3,8 +3,6 @@ import type { UserSessionData } from 'studiocms:auth/lib/types';
 import { type UiLanguageKeys, useTranslations } from 'studiocms:i18n';
 import { Button } from 'studiocms:ui/components/button';
 import { Icon } from 'studiocms:ui/components/icon';
-import { Modal } from 'studiocms:ui/components/modal';
-import { Textarea } from 'studiocms:ui/components/textarea';
 import { studioCMSSocials } from '../../consts.js';
 import UserName from './UserName.astro';
 
@@ -32,102 +30,13 @@ const t = useTranslations(lang, '@studiocms/dashboard:index');
       <Fragment set:html={`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 16 16"><path fill="currentColor" d="M13.545 2.907a13.2 13.2 0 0 0-3.257-1.011a.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.2 12.2 0 0 0-3.658 0a8 8 0 0 0-.412-.833a.05.05 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.011a.04.04 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032q.003.022.021.037a13.3 13.3 0 0 0 3.995 2.02a.05.05 0 0 0 .056-.019q.463-.63.818-1.329a.05.05 0 0 0-.01-.059l-.018-.011a9 9 0 0 1-1.248-.595a.05.05 0 0 1-.02-.066l.015-.019q.127-.095.248-.195a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.05.05 0 0 1 .053.007q.121.1.248.195a.05.05 0 0 1-.004.085a8 8 0 0 1-1.249.594a.05.05 0 0 0-.03.03a.05.05 0 0 0 .003.041c.24.465.515.909.817 1.329a.05.05 0 0 0 .056.019a13.2 13.2 0 0 0 4.001-2.02a.05.05 0 0 0 .021-.037c.334-3.451-.559-6.449-2.366-9.106a.03.03 0 0 0-.02-.019m-8.198 7.307c-.789 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.45.73 1.438 1.613c0 .888-.637 1.612-1.438 1.612m5.316 0c-.788 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.451.73 1.438 1.613c0 .888-.631 1.612-1.438 1.612"/></svg>`} slot='start-content' />
       <t-dashboard-header key="title-button:discord">{t("title-button:discord")}</t-dashboard-header>
     </Button>
-    {/*
-    <Button color='success' variant='flat' id="feedback-button">
-      <Icon name='heroicons:chat-bubble-oval-left-ellipsis' width={24} height={24} />
-      <t-dashboard-header key="title-button:feedback">{t("title-button:feedback")}</t-dashboard-header>
-    </Button>
-    */}
+    {/* TODO: Replace with astro-feedback integration when available */}
     <Button color='success' variant='flat' id="feedback-button" as="a" href={studioCMSSocials.github} target="_blank" rel='noopener noreferrer'>
       <Icon name='heroicons:chat-bubble-oval-left-ellipsis' width={24} height={24} />
       <t-dashboard-header key="title-button:feedback">{t("title-button:feedback")}</t-dashboard-header>
     </Button>
   </div>
 </header>
-
-{/*
-<Modal
-  id='feedback-modal'
-  size='lg'
-  isForm
-  cancelButton={{ label: 'Cancel', color: 'default' }}
-  actionButton={{ label: 'Confirm', color: 'primary' }}
-  >
-  <h2 slot='header'>Give Feedback</h2>
-  <div>
-    <Textarea id="feedback-text" name="feedback-text" label="What's on your mind?" placeholder="Type your feedback here..." rows={5} required />
-  </div>
-</Modal>
-
-<script>
-  import { toast } from 'studiocms:ui/components/toaster';
-  import { ModalHelper } from 'studiocms:ui/components/modal';
-
-  const ENDPOINT = "https://api.feelback.dev/v0";
-
-  async function sendFeelback(contentSetId: string, key: string, value: string) {
-      const response = await fetch(ENDPOINT + "/feelbacks/create", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-              contentSetId,
-              key,
-              value
-          })
-      });
-
-      // returns the feelbackId and, if enabled, a revocable token
-      return await response.json() as Promise<{ feelbackId: string; } | { error: string; }>;
-  }
-
-  const modal = new ModalHelper('feedback-modal', 'feedback-button');
-  modal.registerCancelCallback(() => {
-    modal.hide();
-  });
-
-  modal.registerConfirmCallback(async (data) => {
-    const feedbackText = data?.get('feedback-text')?.toString();
-    if (!feedbackText) {
-      toast({
-        title: 'Error',
-        description: 'Please provide feedback before submitting.',
-        type: 'danger',
-      })
-      return;
-    }
-
-    let response;
-    try {
-      response = await sendFeelback(
-        '0ed28bbd-7aac-4ced-ae8d-56b8086c44d7',
-        'general-feedback-dashboard',
-        feedbackText
-      );
-    } catch (error) {
-      toast({
-        title: 'Error',
-        description: 'Network error. Please check your connection and try again.',
-        type: 'danger',
-      });
-      return;
-    }
-
-    if (response && 'feelbackId' in response) {
-      toast({
-        title: 'Success',
-        description: 'Your feedback has been sent successfully.',
-        type: 'success',
-      });
-    } else {
-      toast({
-        title: 'Error',
-        description: 'There was an error sending your feedback. Please try again later.',
-        type: 'danger',
-      });
-    }
-  });
-</script>
-*/}
 
 <script>
     import {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Feelback isn't working anymore at all, for now we are going to point people to use github instead until a new system (astro-feedback) can be implemented.

## Testing

No testing affected

## Docs

N/A

<!-- Could this affect a user’s behavior? We probably need to update docs! -->

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feedback button now opens GitHub in a new tab for submitting feedback, replacing the in-app modal; Discord feedback option remains available.
* **Chores**
  * Added a changeset entry to publish a patch release for studiocms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->