### PR TITLE
chore(studiocms/i18n): fix missing translation

### DIFF
--- a/.changeset/old-doodles-work.md
+++ b/.changeset/old-doodles-work.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Fixes missing translation

--- a/packages/studiocms/src/virtuals/i18n/translations/en.json
+++ b/packages/studiocms/src/virtuals/i18n/translations/en.json
@@ -326,6 +326,7 @@
     "@studiocms/dashboard:profile-notifications": {
       "header-title": "Notification Events",
       "save-button": "Save",
+      "account_updated": "Account Updated",
       "page_updated": "Editor: Page Updated",
       "page_deleted": "Editor: Page Deleted",
       "new_page": "Editor: New Page",


### PR DESCRIPTION
This pull request addresses a missing translation in the StudioCMS dashboard notifications. The main change is the addition of the "Account Updated" translation key, ensuring users see the correct notification text when their account is updated.

Translation fixes:

* Added the `account_updated` translation key with the value "Account Updated" to `en.json` for dashboard notification events.
* Documented the translation fix in a new changeset file `.changeset/old-doodles-work.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored missing “Account Updated” translation in dashboard profile notifications, ensuring the message displays correctly for English users.

* **Chores**
  * Prepared patch release metadata to document the translation fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->