### PR TITLE
update StudioCMS UI and cleanup styles

### DIFF
--- a/.changeset/icy-tables-stand.md
+++ b/.changeset/icy-tables-stand.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Update `@studiocms/ui` to 1.0.0-beta.3 and cleanup now unneeded styles

--- a/packages/studiocms/src/components/dashboard/sidebar/VersionCheck.astro
+++ b/packages/studiocms/src/components/dashboard/sidebar/VersionCheck.astro
@@ -93,18 +93,6 @@ const status: false | 'outdated' | 'latest' | 'future' = (() => {
   setupVersionChecker();
 </script>
 
-<style is:global>
-  [data-theme="light"] {
-    .version-container {
-      background-color: var(--background-step-3);
-    }
-
-    .version-container:hover {
-      background-color: var(--background-step-2);
-    }
-  }
-</style>
-
 <style>
   .version-container {
     width: 100%;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ catalogs:
       specifier: ^1.2.0
       version: 1.2.0
     '@studiocms/ui':
-      specifier: ^1.0.0-beta.2
-      version: 1.0.0-beta.2
+      specifier: ^1.0.0-beta.3
+      version: 1.0.0-beta.3
     '@studiocms/web-vitals':
       specifier: ^4.5.3
       version: 4.5.3
@@ -613,7 +613,7 @@ importers:
     dependencies:
       '@studiocms/ui':
         specifier: catalog:studiocms
-        version: 1.0.0-beta.2(astro@5.14.1(@types/node@22.18.6)(jiti@2.6.0)(rollup@4.52.3)(typescript@5.9.3)(yaml@2.8.1))(vite@6.3.6(@types/node@22.18.6)(jiti@2.6.0)(yaml@2.8.1))
+        version: 1.0.0-beta.3(astro@5.14.1(@types/node@22.18.6)(jiti@2.6.0)(rollup@4.52.3)(typescript@5.9.3)(yaml@2.8.1))(vite@6.3.6(@types/node@22.18.6)(jiti@2.6.0)(yaml@2.8.1))
       '@withstudiocms/component-registry':
         specifier: workspace:*
         version: link:../../@withstudiocms/component-registry
@@ -857,7 +857,7 @@ importers:
         version: 1.1.0(nanostores@1.0.1)
       '@studiocms/ui':
         specifier: catalog:studiocms
-        version: 1.0.0-beta.2(astro@5.14.1(@types/node@22.18.6)(jiti@2.6.0)(rollup@4.52.3)(typescript@5.9.3)(yaml@2.8.1))(vite@6.3.6(@types/node@22.18.6)(jiti@2.6.0)(yaml@2.8.1))
+        version: 1.0.0-beta.3(astro@5.14.1(@types/node@22.18.6)(jiti@2.6.0)(rollup@4.52.3)(typescript@5.9.3)(yaml@2.8.1))(vite@6.3.6(@types/node@22.18.6)(jiti@2.6.0)(yaml@2.8.1))
       '@studiocms/web-vitals':
         specifier: catalog:min
         version: 4.5.3(@astrojs/db@0.18.0)
@@ -2739,8 +2739,8 @@ packages:
   '@studiocms/markdown-remark-processor@1.2.0':
     resolution: {integrity: sha512-3qOupRze2HKO2VdcrN0c5j9ZYoM8hlhFjrs4m5pg4w5Do5I1MTuDDTXmfRnZ+CwDrXyUaYr+DK1Csb7zMYjzyA==}
 
-  '@studiocms/ui@1.0.0-beta.2':
-    resolution: {integrity: sha512-/2jFbOPhYe1dVn3ISrM3oM4A1mZn9CEwA+pTg9XXEMPqSm92GVhX2wwmbp0djsJc0gJBunOdXZxgST8b0/Dcag==}
+  '@studiocms/ui@1.0.0-beta.3':
+    resolution: {integrity: sha512-rEvkU09I4cZvD/uKbx1U1OCFjWFIyL93PMsQz4NY6re+hOzlvUepE67FcmnyiM9454hmnOQ4gFBbrV3E/2gImQ==}
     peerDependencies:
       astro: ^4.5 || ^5.0.0-beta.0
       vite: ^5.0.0 || ^6.0.0
@@ -8247,7 +8247,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@studiocms/ui@1.0.0-beta.2(astro@5.14.1(@types/node@22.18.6)(jiti@2.6.0)(rollup@4.52.3)(typescript@5.9.3)(yaml@2.8.1))(vite@6.3.6(@types/node@22.18.6)(jiti@2.6.0)(yaml@2.8.1))':
+  '@studiocms/ui@1.0.0-beta.3(astro@5.14.1(@types/node@22.18.6)(jiti@2.6.0)(rollup@4.52.3)(typescript@5.9.3)(yaml@2.8.1))(vite@6.3.6(@types/node@22.18.6)(jiti@2.6.0)(yaml@2.8.1))':
     dependencies:
       '@iconify-json/heroicons': 1.2.3
       '@iconify/types': 2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,7 +39,7 @@ catalogs:
     "react-dom": ^19.2.0
   studiocms:
     "@studiocms/markdown-remark-processor": ^1.2.0
-    "@studiocms/ui": ^1.0.0-beta.2
+    "@studiocms/ui": ^1.0.0-beta.3
     "@studiocms/web-vitals": ^4.5.3
     "@withstudiocms/cli-kit": ^0.1.0
 


### PR DESCRIPTION
This pull request updates the `@studiocms/ui` package to version `1.0.0-beta.3` and removes styles that are no longer needed due to this update. The changes ensure that all references to the previous version are replaced and the codebase is cleaned up accordingly.

**Dependency update:**

* Updated all references to `@studiocms/ui` from `1.0.0-beta.2` to `1.0.0-beta.3` in `pnpm-lock.yaml` and `pnpm-workspace.yaml`, ensuring consistency across the workspace. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL111-R112) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL616-R616) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL860-R860) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2742-R2743) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8250-R8250) [[6]](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL42-R42)

**Code cleanup:**

* Removed obsolete global styles from `VersionCheck.astro` that are no longer needed after the UI package update.

**Documentation and metadata:**

* Added a changeset describing the update and the style cleanup for tracking and release notes. (.changeset/icy-tables-stand.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sidebar version indicator styling by removing global light-theme overrides to keep styles scoped. Visuals remain consistent with no functional changes.
* **Chores**
  * Bumped UI dependency to @studiocms/ui 1.0.0-beta.3 for improved compatibility.
  * Prepared a patch release via changeset to align dependencies and remove now-unneeded styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->