### PR TITLE
docs: update contributing guide and playground config path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Steps to get a running playground should be the following:
 
 - Clone the GitHub repository
 - Run `pnpm i --frozen-lockfile`
-- Change `dbStartPage` in the Node playground's [StudioCMS config](./playground/studiocms.config.mjs) to `true`.
+- Change `dbStartPage` in the Node playground's [StudioCMS config](./playground/studiocms.config.mts) to `true`.
 - Ensure `.env` variables are configured (see [`.env.demo`](./playground/.env.demo) for an example of available environment variables)
 - Run the following in this order:
   - `pnpm build:studiocms` - Build the StudioCMS packages (required to get the current table schema for the StudioCMS integration)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Updates the README to fix:
* the link in the Contributing section
* the `studiocms.config.mts` path in the playground instructions

## Testing

N/A

## Docs

I'm not sure about the policy regarding changesets in StudioCMS. This was a tiny fix so I've done that via Github UI without any changeset, but I can push another commit if needed!

<!-- Could this affect a user’s behavior? We probably need to update docs! -->

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Node playground configuration reference to use the new module extension.
  * Updated Contributing Guide links to point to the English "Getting Started" guide for contributors.
  * Clarifies onboarding and navigation for contributors; editorial only with no behavior, API, build, or dependency changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->