### PR TITLE
fix: update file inclusion patterns in biome configuration

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,9 @@
       "!**/*.min.js",
       "!**/*.min.css",
       "!**/dashboard-code.css",
-      "!**/i18n/translations/**/*.json"
+      "!**/i18n/translations/**/*.json",
+      "!**/handlers/plugin-i18n/*.ts",
+      "!**/integrations/webVitals/i18n/*.ts"
     ]
   },
   "formatter": {


### PR DESCRIPTION
This pull request makes a small update to the `biome.json` configuration file, expanding the list of files that are excluded from certain operations. The change adds TypeScript files related to i18n handlers and web vitals integrations to the exclusion list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project tooling configuration to refine which files are included in automated checks, excluding certain i18n-related files from linting/formatting.
  * Improves signal-to-noise in developer workflows and reduces unnecessary diffs in CI.
  * No impact on app functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->