### PR TITLE
fix: Prevent CI from running from forks... again

### DIFF
--- a/.github/workflows/ci-labeler.yml
+++ b/.github/workflows/ci-labeler.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   add-labels:
     name: Label PRs
-    if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.repository_owner == 'withstudiocms'
+    if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Setup Apollo Git Bot
@@ -31,7 +31,7 @@ jobs:
 
   remove-merged-pr-labels:
     name: Remove merged pull request labels
-    if: github.event.pull_request.merged && github.repository_owner == 'withstudiocms'
+    if: github.event.pull_request.merged && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Setup Apollo Git Bot
@@ -52,7 +52,7 @@ jobs:
 
   remove-closed-pr-labels:
     name: Remove closed pull request labels
-    if: github.event_name == 'pull_request' && (! github.event.pull_request.merged) && github.repository_owner == 'withstudiocms'
+    if: github.event_name == 'pull_request' && (! github.event.pull_request.merged) && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Setup Apollo Git Bot

--- a/.github/workflows/ci-pkg-pr-new.yml
+++ b/.github/workflows/ci-pkg-pr-new.yml
@@ -51,7 +51,7 @@ jobs:
 
   preview-pr:
     name: PR Snapshot Preview
-    if: github.event_name == 'pull_request' && (github.event.pull_request.user.login != 'studiocms-no-reply' && github.event.pull_request.user.login != 'apollo-git-bot[bot]') && github.repository_owner == 'withstudiocms'
+    if: github.event_name == 'pull_request' && (github.event.pull_request.user.login != 'studiocms-no-reply' && github.event.pull_request.user.login != 'apollo-git-bot[bot]') && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -66,7 +66,7 @@ jobs:
         run: pnpm ci:test
 
       - name: Upload coverage results to Codecov
-        if: github.repository_owner == 'withstudiocms'
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
         with:
           slug: withstudiocms/studiocms
@@ -76,7 +76,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
-        if: ${{ always() && github.repository_owner == 'withstudiocms'}}
+        if: github.event.pull_request.head.repo.full_name == github.repository 
         uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f
         with:
           slug: withstudiocms/studiocms
@@ -87,7 +87,7 @@ jobs:
   run-bundle-tests:
     name: Run Bundle Analysis
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'withstudiocms'
+    if: github.event.pull_request.head.repo.full_name == github.repository
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to improve how workflows determine if they should run for a particular pull request. The main change replaces checks for the repository owner with a more precise check that ensures workflows only run for pull requests originating from the same repository (not from forks). This helps prevent workflows from running on external contributions where sensitive actions or secrets should not be exposed.

Workflow condition improvements:

* Updated all relevant workflow jobs in `.github/workflows/ci-labeler.yml`, `.github/workflows/ci-pkg-pr-new.yml`, and `.github/workflows/ci-testing.yml` to use `github.event.pull_request.head.repo.full_name == github.repository` instead of checking `github.repository_owner`. This ensures jobs only run for pull requests from the same repository, enhancing security and correctness. [[1]](diffhunk://#diff-b975e51b577ceb04e8bc145ad53bfa920842c06dcbb1c6a48368fb8eb0b5d619L15-R15) [[2]](diffhunk://#diff-b975e51b577ceb04e8bc145ad53bfa920842c06dcbb1c6a48368fb8eb0b5d619L34-R34) [[3]](diffhunk://#diff-b975e51b577ceb04e8bc145ad53bfa920842c06dcbb1c6a48368fb8eb0b5d619L55-R55) [[4]](diffhunk://#diff-c591da680c4a06c48bd2f2d932085bf3b91ce1cd8913d4fbddb1831f5640c03dL54-R54) [[5]](diffhunk://#diff-82af06888290ef31d154541fdc86514e682a9b9c656353a226e1d3eed32fef0aL69-R69) [[6]](diffhunk://#diff-82af06888290ef31d154541fdc86514e682a9b9c656353a226e1d3eed32fef0aL79-R79) [[7]](diffhunk://#diff-82af06888290ef31d154541fdc86514e682a9b9c656353a226e1d3eed32fef0aL90-R90)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI workflows to use repository-matching checks for pull requests, improving reliability of label management and preview deployments.
  - Ensures automation runs only for PRs originating from the same repository, reducing false positives on forked contributions.
- Tests
  - Adjusted conditions for uploading coverage and test results, and for running bundle analysis, to align with the new repository-matching logic.
  - Improves consistency of test reporting and analysis across PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->