### PR TITLE
fix: exclude apollo-git-bot from changeset status check in CI workflow

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -27,7 +27,7 @@ jobs:
 
   check-changeset:
     name: Check Changesets Status
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'apollo-git-bot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
This pull request makes a small update to the CI workflow configuration. The change ensures that the "Check Changesets Status" job only runs on pull requests that are not opened by the `apollo-git-bot[bot]` user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to skip changeset validation for automated bot-origin pull requests, reducing unnecessary failures and improving signal-to-noise.
  * Speeds up contributor feedback without affecting build outputs.
  * No changes to app functionality, runtime behavior, or user interface.
  * Human-authored pull requests continue to run all checks as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->