### PR TITLE
fix(ci): Update Allure report deployment branch to testing/pages

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -73,8 +73,8 @@ jobs:
         continue-on-error: true
         with:
           persist-credentials: true
-          ref: gh-pages
-          path: gh-pages
+          ref: testing/pages
+          path: testing/pages
 
       - name: Generate Allure Report
         uses: simple-elf/allure-report-action@53ebb757a2097edc77c53ecef4d454fc2f2f774c #master
@@ -82,7 +82,7 @@ jobs:
         id: allure-report
         with:
           allure_results: allure-results
-          gh_pages: gh-pages
+          gh_pages: testing/pages
           allure_report: allure-report
           allure_history: allure-history
           keep_reports: 20
@@ -93,7 +93,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e #v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
+          publish_branch: testing/pages
           publish_dir: allure-history
           keep_files: true
 


### PR DESCRIPTION
This pull request updates the CI testing workflow to use a new branch and directory for Allure report publishing, shifting from the previous `gh-pages` branch to `testing/pages`. This change ensures that Allure reports generated during CI tests are kept separate from production documentation.

**Reasoning:**

While Allure reports do appear to be working. Due to the current git history on the `gh-pages` branch including all StudioCMS assets Jekyll (github pages runner) is throwing a fit trying to parse things and causing an error on CI, this PR moves deployments to a new EMPTY branch!

**Workflow configuration updates:**

* Changed the checkout and Allure report generation steps in `.github/workflows/ci-testing.yml` to use the `testing/pages` branch and directory instead of `gh-pages`.
* Updated the GitHub Pages publishing action to publish the Allure report to the `testing/pages` branch rather than `gh-pages`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to adjust deployment targets and artifact paths for publishing static pages and test reports, improving reliability of automated publishing and retention of test history across runs.
  * Streamlined build and release automation for the testing environment to ensure consistent availability of reports and pages after each pipeline execution. No changes to features or user interface; application behavior remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->