### PR TITLE
Fix the page data form validation parsing of boolean select fields

### DIFF
--- a/.changeset/giant-signs-tickle.md
+++ b/.changeset/giant-signs-tickle.md
@@ -2,4 +2,4 @@
 "studiocms": patch
 ---
 
-Fix the form validation parsing of boolean select fields values by transforming the string values to boolean
+Fixes the form validation parsing of boolean select fields values by transforming the string values to boolean for content management pages.

--- a/packages/studiocms/src/components/dashboard/content-mgmt/formdata-utils.ts
+++ b/packages/studiocms/src/components/dashboard/content-mgmt/formdata-utils.ts
@@ -51,28 +51,16 @@ export const studioCMSCreatePageDataSchema = z.object({
 	}),
 	description: z.string().optional(),
 	package: z.string(),
-	showOnNav: z
-		.string()
-		.optional()
-		.transform((v) => !!v && v.toLowerCase() === 'true'),
+	showOnNav: z.string().optional().transform(transformStringToBoolean),
 	heroImage: z.string().optional(),
 	parentFolder: z
 		.union([z.string(), z.null()])
 		.transform((value) => (value === 'null' || value === null ? null : value))
 		.optional()
 		.default(null),
-	draft: z
-		.string()
-		.optional()
-		.transform((v) => !!v && v.toLowerCase() === 'true'),
-	showAuthor: z
-		.string()
-		.optional()
-		.transform((v) => !!v && v.toLowerCase() === 'true'),
-	showContributors: z
-		.string()
-		.optional()
-		.transform((v) => !!v && v.toLowerCase() === 'true'),
+	draft: z.string().optional().transform(transformStringToBoolean),
+	showAuthor: z.string().optional().transform(transformStringToBoolean),
+	showContributors: z.string().optional().transform(transformStringToBoolean),
 	categories: z
 		.string()
 		.or(z.array(z.string()))
@@ -113,4 +101,16 @@ export function formDataToRecord(formData: FormData, keyRemapping?: Record<strin
 		record[mappedKey] = value;
 	}
 	return record;
+}
+
+/**
+ * Transform a string true/false value to boolean.
+ *
+ * - If the input value is undefined, return false.
+ *
+ * @param value - The value to transform, can be undefined, 'true' or 'false'.
+ * @returns Transformed value in boolean.
+ */
+export function transformStringToBoolean(value: string | undefined): boolean {
+	return !!value && value.toLowerCase() === 'true';
 }


### PR DESCRIPTION
Fix the page data form validation parsing of boolean select fields values by transforming the string values to boolean.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

## Description

The true/false select fields of the page edit form use the string type data. z.coerce.boolean() will result in the value being always true as 'false' is a truthy value. Use transform to map these values to a boolean.

We can improve the parsing of boolean string values when Astro upgrades zod to 4.0 which introduces the z.stringbool() function.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form validation so boolean select fields submitted as strings are correctly interpreted as booleans.
  * Improved handling of categories and tags to normalize arrays consistently.

* **New Features**
  * Added explicit support for tags in content management forms.

* **Chores**
  * Added a changeset entry for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->