### PR TITLE
fix(migrator): remove non-existent 'augments' column from pagedata schema

### DIFF
--- a/.changeset/chubby-animals-learn.md
+++ b/.changeset/chubby-animals-learn.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/migrator": patch
+---
+
+Fixes issue with a column that does not exist on previous schema but does now

--- a/packages/@studiocms/migrator/src/db/astro-db-schema.ts
+++ b/packages/@studiocms/migrator/src/db/astro-db-schema.ts
@@ -50,7 +50,6 @@ export const StudioCMSPageData = defineTable({
 		showContributors: column.boolean({ default: false, optional: true }),
 		parentFolder: column.text({ optional: true }),
 		draft: column.boolean({ optional: true }),
-		augments: column.json({ default: [], optional: true }),
 	},
 });
 


### PR DESCRIPTION
This pull request addresses a schema issue in the `@studiocms/migrator` package by removing a problematic column and documenting the fix. The main change ensures compatibility with previous schema versions where the column did not exist.

Schema compatibility fix:

* Removed the `augments` column from the `StudioCMSPageData` table definition in `astro-db-schema.ts` to resolve issues with the column not existing in earlier schema versions.

Documentation:

* Added a changeset describing the patch and the schema compatibility fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a schema consistency issue affecting the pages data structure.
  * Removed the augments field from pages to maintain database compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->