### PR TITLE
Unlink version releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,23 +2,7 @@
   "$schema": "../node_modules/@changesets/config/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "withstudiocms/studiocms" }],
   "commit": false,
-  "fixed": [
-    [
-      "studiocms",
-      "@studiocms/auth0",
-      "@studiocms/blog",
-      "@studiocms/cloudinary-image-service",
-      "@studiocms/devapps",
-      "@studiocms/discord",
-      "@studiocms/github",
-      "@studiocms/google",
-      "@studiocms/html",
-      "@studiocms/markdoc",
-      "@studiocms/md",
-      "@studiocms/mdx",
-      "@studiocms/wysiwyg"
-    ]
-  ],
+  "fixed": [],
   "linked": [],
   "access": "public",
   "baseBranch": "origin/main",


### PR DESCRIPTION
This pull request makes a small configuration change to the `.changeset/config.json` file. The update removes the list of packages from the `fixed` field, leaving it as an empty array. This means that these packages are no longer considered to have linked versioning.

- Removed all package names from the `fixed` array in `.changeset/config.json`, so that no packages are fixed/linked for versioning.

This change will simplify releases when making small changes that don't need to update every single package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration for release and dependency management to improve internal package tracking and versioning workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->