### PR TITLE
feat(crowdin): add support for dispatching events on PR creation

### DIFF
--- a/.github/workflows/ci-crowdin-sync.yml
+++ b/.github/workflows/ci-crowdin-sync.yml
@@ -72,7 +72,7 @@ jobs:
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           event-type: crowdin.create
-          client-payload: '{ pull_request_url: "${{ steps.crowdin-pull.outputs.pull_request_url }}" }'
+          client-payload: '{ "pull_request_url": "${{ steps.crowdin-pull.outputs.pull_request_url }}" }'
 
   crowdin-upload:
     name: Upload Crowdin Sources


### PR DESCRIPTION
This pull request updates the Crowdin sync workflow to better integrate with Artemis by dispatching a repository event when a Crowdin pull request is created. The main changes involve adding a step to detect PR creation and trigger an event with the relevant pull request URL.

**Crowdin sync workflow improvements:**

* Added `id: crowdin-pull` to the Crowdin pull step, enabling output variables for downstream steps.
* Added a new step to dispatch a `crowdin.create` event using `peter-evans/repository-dispatch` if a Crowdin pull request was created, passing the pull request URL as a payload for Artemis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automation for Crowdin integration workflow to streamline pull request handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->