### PR TITLE
chore(deps): add AWS S3 dependencies group to renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,7 +43,7 @@
     {
       "groupName": "AWS S3 Dependencies",
       "matchManagers": ["npm"],
-      "matchPackageNames": ["@aws-sdk/**"]
+      "matchPackageNames": ["@aws-sdk/client-s3", "@aws-sdk/s3-request-presigner"]
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
This pull request updates the Renovate configuration to improve dependency management for AWS S3-related packages. The main change is the addition of a new grouping rule for AWS S3 dependencies.

Dependency grouping improvements:

* [`.github/renovate.json`](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3R42-R46): Added a new group named "AWS S3 Dependencies" to group updates for `@aws-sdk/client-s3` and `@aws-sdk/s3-request-presigner` packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a dependency update grouping for AWS S3 packages (npm): groups @aws-sdk/client-s3 and @aws-sdk/s3-request-presigner to streamline maintenance and coordinated updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->