### PR TITLE
Fix client-payload formatting in Crowdin CI workflow

### DIFF
--- a/.github/workflows/ci-crowdin-sync.yml
+++ b/.github/workflows/ci-crowdin-sync.yml
@@ -72,7 +72,7 @@ jobs:
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           event-type: crowdin.create
-          client-payload: '{ "pull_request_url": ${{ steps.crowdin-pull.outputs.pull_request_url }} }'
+          client-payload: '{ "pull_request_url": ${{ toJSON(steps.crowdin-pull.outputs.pull_request_url) }} }'
 
   crowdin-upload:
     name: Upload Crowdin Sources


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow for Crowdin sync. The change adjusts the way the `pull_request_url` is passed in the `client-payload` to ensure proper value interpolation.

* Updated the `client-payload` field in `.github/workflows/ci-crowdin-sync.yml` to remove quotes around the interpolated `pull_request_url`, allowing GitHub Actions to correctly substitute the value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow payload formatting to change how pull request URLs are serialized in integration syncs, improving reliability and consistency of automated synchronization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->