### PR TITLE
fix: Make sure edit page tabs don't overflow

### DIFF
--- a/.changeset/vast-areas-stand.md
+++ b/.changeset/vast-areas-stand.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Fixes edit page tabs overflowing

--- a/packages/studiocms/frontend/components/dashboard/content-mgmt/EditPage.astro
+++ b/packages/studiocms/frontend/components/dashboard/content-mgmt/EditPage.astro
@@ -704,6 +704,14 @@ const t = useTranslations(lang, '@studiocms/dashboard:content-page');
      	display: flex;
       flex-direction: column;
 
+      .sui-tab-header.active::after {
+				bottom: 1px;
+			}
+
+      > .sui-tabs-list {
+      	overflow-y: hidden;
+      }
+
       > .sui-tabs-content {
       	height: 100%;
 

--- a/packages/studiocms/frontend/components/dashboard/taxonomy/InnerSidebarElement.astro
+++ b/packages/studiocms/frontend/components/dashboard/taxonomy/InnerSidebarElement.astro
@@ -139,8 +139,8 @@ const tagData = tagsToTaxonomyNodes(tags);
         overflow: hidden;
 
         > button {
-        width: 100%;
-        justify-content: center;
+		        width: 100%;
+		        justify-content: center;
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

## Description

- Fixes an overflow issue with the tabs on the edit page

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where tabs on the edit page were overflowing, improving layout stability and display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->