### PR TITLE
fix: remove integration-utils from ignore list in changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "access": "public",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",
-  "ignore": ["node-playground", "@test-config-utils/integration-utils"],
+  "ignore": ["node-playground"],
   "privatePackages": false,
   "changedFilePatterns": [
     "**/src/**/**.*",


### PR DESCRIPTION
trying to fix this:

<img width="693" height="148" alt="image" src="https://github.com/user-attachments/assets/f8035e9e-7de6-47af-9b10-ca68fde554e0" />


That should not be on the release list...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog management configuration to adjust package tracking in versioning processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->