### PR TITLE
fix: Fix create folder bug in s3-storage PUT request handler

### DIFF
--- a/.changeset/lemon-flowers-mix.md
+++ b/.changeset/lemon-flowers-mix.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Fix create folder bug in s3-storage PUT request handler

--- a/packages/studiocms/src/virtuals/scripts/StorageFileBrowser.ts
+++ b/packages/studiocms/src/virtuals/scripts/StorageFileBrowser.ts
@@ -1602,7 +1602,7 @@ class StorageFileBrowser extends HTMLElement {
 				method: 'PUT',
 				headers: {
 					'Content-Type': 'text/plain',
-					'x-s3-key': folderKey,
+					'x-storage-key': folderKey,
 				},
 				body: '',
 			});


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

## Description

When creating a new folder using the S3 Storage Manager, the PUT request returns an error : 

`Missing x-storage-key`

This PR resolves this issue.

## Testing

The change was tested manually, using a [Garage S3 Storage](https://garagehq.deuxfleurs.fr/) provider on a local setup environment. Other S3 providers mentioned in the docs are not tested and might need to be verified.

<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed folder creation in the S3 storage file browser. Users can now successfully create and organize new folders in their storage system, resolving the previous issue that prevented proper folder management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->