### PR TITLE
fix: Update Allure report deployment condition for to ensure nothing breaks from forks

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -87,7 +87,7 @@ jobs:
         run: pnpm ci:test
 
       - name: Generate Allure Report and Deploy
-        if: always()
+        if: always() && (github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main')
         uses: ./.github/actions/allure-report
         with:
           gh_pages_branch: testing/allure


### PR DESCRIPTION
This pull request introduces a conditional update to the CI workflow, specifically affecting when the Allure report is generated and deployed.

Workflow improvements:

* [`.github/workflows/ci-testing.yml`](diffhunk://#diff-82af06888290ef31d154541fdc86514e682a9b9c656353a226e1d3eed32fef0aL90-R90): The step for generating and deploying the Allure report now runs only if the workflow is triggered from a pull request originating from the same repository or from the `main` branch, instead of always running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline to restrict report generation and code coverage uploads to PRs from the main repository or changes to the main branch.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->