### PR TITLE
fix: update ignored dependencies in renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,6 +49,7 @@
   "ignoreDeps": [
     "@libsql/client",
     "@types/node",
+    "@vitest/coverage-v8",
     "drizzle-orm",
     "sharp",
     "node",
@@ -56,6 +57,8 @@
     "pnpm",
     "esbuild",
     "codemirror",
-    "vite"
+    "vite",
+    "vitest",
+    "zod"
   ]
 }


### PR DESCRIPTION
This pull request updates the dependency management configuration in `.github/renovate.json` to exclude additional packages from automated updates. The goal is to prevent Renovate from creating pull requests for these dependencies, likely because they are managed manually or require special handling.

Dependency update configuration:

* Added `@libsql/client`, `@vitest/coverage-v8`, `vitest`, and `zod` to the `ignoreDeps` list to prevent Renovate from updating these dependencies automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->