### PR TITLE
fix(studiocms): prevent the 404 route from resulting in server errors

### DIFF
--- a/.changeset/social-beds-talk.md
+++ b/.changeset/social-beds-talk.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Fixes default 404 route rendering

--- a/packages/studiocms/frontend/layouts/DashboardLayout.astro
+++ b/packages/studiocms/frontend/layouts/DashboardLayout.astro
@@ -27,7 +27,7 @@ const makePageTitle = (
 };
 
 interface Props extends ComponentProps<typeof BaseLayout> {
-	config: DynamicConfigEntry<StudioCMSSiteConfig>;
+	config: DynamicConfigEntry<Pick<StudioCMSSiteConfig, 'title' | 'description'>>;
 	sidebar?: false | 'single' | 'double';
 	requiredPermission?: AvailablePermissionRanks | 'none';
 	currentUser: UserSessionData | null;

--- a/packages/studiocms/frontend/pages/404.astro
+++ b/packages/studiocms/frontend/pages/404.astro
@@ -1,15 +1,12 @@
 ---
+import { config } from 'studiocms:config';
 import '../styles/404.css';
 import { useTranslations } from 'studiocms:i18n';
 import { Button } from 'studiocms:ui/components/button';
 import Layout from '../layouts/DashboardLayout.astro';
 
-const lang = Astro.locals.StudioCMS.defaultLang;
+const lang = config.locale.i18n.defaultLocale;
 const t = useTranslations(lang, '@studiocms/dashboard:404');
-
-const { siteConfig: config, security } = Astro.locals.StudioCMS;
-
-const currentUser = security?.userSessionData ?? null;
 ---
 
 <Layout 
@@ -17,9 +14,9 @@ const currentUser = security?.userSessionData ?? null;
   description={t('description')}
   sidebar={false} 
   requiredPermission="none"
-  {lang}
-  {config}
-  {currentUser}>
+  config={{ data: { title: t('title'), description: t('description') }, id: ''  }}
+  currentUser={null}
+  {lang}>
   <div class="notfound-container">
     <div class="notfound">
       <svg viewBox="0 0 755 792" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
This pull request addresses a bug with the default 404 route rendering in StudioCMS and updates how configuration and localization are handled in the 404 page. The main focus is to ensure the 404 page displays correctly with the appropriate title, description, and localization, while simplifying the props passed to the layout component.

404 Page Fixes and Improvements:

* The 404 page now imports configuration directly from `studiocms:config` and uses the correct localization key for the default language, ensuring accurate translations and config usage.
* The `DashboardLayout` component's `config` prop is now restricted to only include `title` and `description`, reducing unnecessary data being passed and improving type safety.

Bug Fix:

* Fixes the default 404 route rendering issue, ensuring users see the correct not found page when accessing invalid routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of the default 404 error page to properly display when users navigate to non-existent routes.

* **Improvements**
  * Optimized how configuration data is managed across dashboard components to enhance stability and reduce unnecessary data exposure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->