### PR TITLE
fix(upgrade): update upgrade guide URL generation for versioning

### DIFF
--- a/.changeset/floppy-days-eat.md
+++ b/.changeset/floppy-days-eat.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/upgrade": patch
+---
+
+Replace base Docs url with proper version url generation based on docs urls

--- a/packages/@studiocms/upgrade/src/steps/verify.ts
+++ b/packages/@studiocms/upgrade/src/steps/verify.ts
@@ -318,9 +318,10 @@ const resolveTargetVersion = Effect.fn('resolveTargetVersion')(function* (
 	if ((bump === 'major' && toVersion.prerelease.length === 0) || bump === 'premajor') {
 		packageInfo.isMajor = true;
 		if (packageInfo.name === 'studiocms') {
-			// TODO: Setup proper upgrade guide URLs per major version
-			// const upgradeGuide = `https://docs.studiocms.dev/en/guides/upgrade-to/v${toVersion.major}/`;
-			const upgradeGuide = 'https://docs.studiocms.dev';
+			// Replace dots with dashes for URL fragment
+			const versionSafe = toVersion.version.replace(/\./g, '-');
+			// URL for the StudioCMS upgrade guide
+			const upgradeGuide = `https://docs.studiocms.dev/en/guides/upgrade/version-guides/${versionSafe}/`;
 			const docsRes = yield* Effect.tryPromise({
 				try: () => fetch(upgradeGuide),
 				catch: (cause) => new CLIError({ cause }),


### PR DESCRIPTION
This pull request updates the way documentation URLs are generated for major StudioCMS upgrades. Instead of using a static base Docs URL, it now generates a version-specific upgrade guide URL, improving accuracy and user experience.

- Closes #1223

**Upgrade guide URL improvements:**

* In `verify.ts`, the upgrade guide URL for major StudioCMS upgrades is now dynamically generated to point to the correct version-specific guide, replacing dots with dashes in the version string for the URL fragment.
* The `.changeset/floppy-days-eat.md` changelog documents this update as a patch for `@studiocms/upgrade`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the upgrade process to generate version-specific documentation URLs for upgrade guides. The system now attempts to fetch version-targeted resources first, automatically falling back to the default changelog mechanism if version-specific guides are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->