### PR TITLE
feat: replace chalk with node:util's styleText for consistent styling across CLI outputs

### DIFF
--- a/.changeset/three-pandas-smash.md
+++ b/.changeset/three-pandas-smash.md
@@ -1,0 +1,6 @@
+---
+"@withstudiocms/buildkit": minor
+"studiocms": minor
+---
+
+Replaces chalk with node:util's styleText

--- a/packages/@withstudiocms/buildkit/lib/cmds/builder.js
+++ b/packages/@withstudiocms/buildkit/lib/cmds/builder.js
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs/promises';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import esbuild from 'esbuild';
 import { glob } from 'tinyglobby';
 
@@ -92,7 +92,7 @@ const dtsGen = (buildTsConfig, outdir) => ({
 		build.onEnd((result) => {
 			if (result.errors.length > 0) return;
 			const date = dt.format(new Date());
-			console.log(`${chalk.dim(`[${date}]`)} Generating TypeScript declarations...`);
+			console.log(`${styleText('dim', `[${date}]`)} Generating TypeScript declarations...`);
 			try {
 				const res = execFileSync(
 					'tsc',
@@ -100,7 +100,9 @@ const dtsGen = (buildTsConfig, outdir) => ({
 					{ encoding: 'utf8', shell: true }
 				);
 				if (res) console.log(res);
-				console.log(chalk.dim(`[${date}] `) + chalk.green('√ Generated TypeScript declarations'));
+				console.log(
+					styleText('dim', `[${date}] `) + styleText('green', '√ Generated TypeScript declarations')
+				);
 				/* v8 ignore start */
 			} catch (error) {
 				const msg =
@@ -109,7 +111,7 @@ const dtsGen = (buildTsConfig, outdir) => ({
 					// stdout/stderr may be Buffer or string depending on exec options
 					(typeof error?.stdout === 'string' ? error.stdout : (error?.stdout?.toString?.() ?? '')) +
 					(typeof error?.stderr === 'string' ? error.stderr : (error?.stderr?.toString?.() ?? ''));
-				console.error(chalk.dim(`[${date}] `) + chalk.red(msg));
+				console.error(styleText('dim', `[${date}] `) + styleText('red', msg));
 			}
 			/* v8 ignore stop */
 		});
@@ -124,7 +126,10 @@ const dtsGen = (buildTsConfig, outdir) => ({
  */
 async function clean(outdir, date, skip = []) {
 	const files = await glob([`${outdir}/**`, ...skip], { filesOnly: true });
-	console.log(chalk.dim(`[${date}] `) + chalk.dim(`Cleaning ${files.length} files from ${outdir}`));
+	console.log(
+		styleText('dim', `[${date}] `) +
+			styleText('dim', `Cleaning ${files.length} files from ${outdir}`)
+	);
 	await Promise.all(files.map((file) => fs.rm(file, { force: true })));
 }
 
@@ -191,7 +196,7 @@ export default async function builder(cmd, args) {
 		case 'dev': {
 			if (!noClean) {
 				console.log(
-					`${chalk.dim(`[${date}]`)} Cleaning ${outdir} directory... ${chalk.dim(`(${entryPoints.length} files found)`)}`
+					`${styleText('dim', `[${date}]`)} Cleaning ${outdir} directory... ${styleText('dim', `(${entryPoints.length} files found)`)}`
 				);
 				await clean(outdir, date, [`!${outdir}/**/*.d.ts`]);
 			}
@@ -213,7 +218,9 @@ export default async function builder(cmd, args) {
 								kind: 'error',
 								color: true,
 							});
-							console.error(chalk.dim(`[${date}] `) + chalk.red(formatted.join('\n')));
+							console.error(
+								styleText('dim', `[${date}] `) + styleText('red', formatted.join('\n'))
+							);
 							return;
 						}
 						if (result.warnings.length) {
@@ -222,12 +229,12 @@ export default async function builder(cmd, args) {
 								color: true,
 							});
 							console.info(
-								chalk.dim(`[${date}] `) +
-									chalk.yellow(`! updated with warnings:\n${formattedWarns.join('\n')}`)
+								styleText('dim', `[${date}] `) +
+									styleText('yellow', `! updated with warnings:\n${formattedWarns.join('\n')}`)
 							);
 						}
 						/* v8 ignore stop */
-						console.info(chalk.dim(`[${date}] `) + chalk.green('√ updated'));
+						console.info(styleText('dim', `[${date}] `) + styleText('green', '√ updated'));
 					});
 				},
 			};
@@ -242,7 +249,7 @@ export default async function builder(cmd, args) {
 			});
 
 			console.log(
-				`${chalk.dim(`[${date}] `) + chalk.gray('Watching for changes...')} ${chalk.dim(`(${entryPoints.length} files found)`)}`
+				`${styleText('dim', `[${date}] `) + styleText('gray', 'Watching for changes...')} ${styleText('dim', `(${entryPoints.length} files found)`)}`
 			);
 			await builder.watch();
 
@@ -256,12 +263,12 @@ export default async function builder(cmd, args) {
 		case 'build': {
 			if (!noClean) {
 				console.log(
-					`${chalk.dim(`[${date}]`)} Cleaning ${outdir} directory... ${chalk.dim(`(${entryPoints.length} files found)`)}`
+					`${styleText('dim', `[${date}]`)} Cleaning ${outdir} directory... ${styleText('dim', `(${entryPoints.length} files found)`)}`
 				);
 				await clean(outdir, date, [`!${outdir}/**/*.d.ts`]);
 			}
 			console.log(
-				`${chalk.dim(`[${date}]`)} Building...${bundle ? '(Bundling)' : ''} ${chalk.dim(`(${entryPoints.length} files found)`)}`
+				`${styleText('dim', `[${date}]`)} Building...${bundle ? '(Bundling)' : ''} ${styleText('dim', `(${entryPoints.length} files found)`)}`
 			);
 			await esbuild.build({
 				...config,
@@ -282,10 +289,10 @@ export default async function builder(cmd, args) {
 					`\nExternal: ${externals ? JSON.stringify(externals) : 'n/a'}` +
 					`\nFormat: ${format}` +
 					`\nOutExtension: ${JSON.stringify(outExt)}\n\n`;
-				console.log(chalk.dim(`[${date}] `) + chalk.gray(message));
+				console.log(styleText('dim', `[${date}] `) + styleText('gray', message));
 			}
 
-			console.log(chalk.dim(`[${date}] `) + chalk.green('√ Build Complete'));
+			console.log(styleText('dim', `[${date}] `) + styleText('green', '√ Build Complete'));
 			break;
 		}
 	}

--- a/packages/@withstudiocms/buildkit/lib/cmds/help.js
+++ b/packages/@withstudiocms/buildkit/lib/cmds/help.js
@@ -1,28 +1,28 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 /**
  * Show the help message for the buildkit CLI.
  */
 export default function showHelp() {
 	console.log(`
-${chalk.green('StudioCMS Buildkit')} - Build tool for StudioCMS packages
+${styleText('green', 'StudioCMS Buildkit')} - Build tool for StudioCMS packages
 
-${chalk.yellow('Usage:')}
+${styleText('yellow', 'Usage:')}
   buildkit <command> [...files] [...options]
 
-${chalk.yellow('Commands:')}
+${styleText('yellow', 'Commands:')}
   dev                     Watch files and rebuild on changes
   build                   Perform a one-time build
   help                    Show this help message
 
-${chalk.yellow('Dev and Build Options:')}
+${styleText('yellow', 'Dev and Build Options:')}
   --no-clean-dist         Skip cleaning the dist directory
   --bundle                Enable bundling mode
   --force-cjs             Force CommonJS output format
   --tsconfig=<path>       Specify TypeScript config file (default: tsconfig.json)
   --outdir=<path>         Specify output directory (default: dist)
 
-${chalk.yellow('Examples:')}
+${styleText('yellow', 'Examples:')}
   - buildkit dev "src/**/*.ts" --no-clean-dist
   - buildkit build "src/**/*.ts"
   - buildkit build "src/**/*.ts" --bundle --force-cjs

--- a/packages/@withstudiocms/buildkit/package.json
+++ b/packages/@withstudiocms/buildkit/package.json
@@ -32,8 +32,7 @@
   },
   "dependencies": {
     "esbuild": "catalog:",
-    "tinyglobby": "catalog:",
-    "chalk": "catalog:"
+    "tinyglobby": "catalog:"
   },
   "devDependencies": {
     "strip-ansi": "^7.1.2"

--- a/packages/@withstudiocms/buildkit/test/builder.test.js
+++ b/packages/@withstudiocms/buildkit/test/builder.test.js
@@ -4,7 +4,6 @@ import * as fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import * as allure from 'allure-js-commons';
-import chalk from 'chalk';
 import * as esbuild from 'esbuild';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test, vi } from 'vitest';
 import builder from '../lib/cmds/builder.js';
@@ -13,15 +12,11 @@ import { parentSuiteName, sharedTags } from './test-utils.js';
 vi.mock('esbuild');
 vi.mock('node:child_process');
 vi.mock('node:fs/promises');
-vi.mock('chalk', async (importOriginal) => {
+vi.mock('node:util', async (importOriginal) => {
 	const actual = await importOriginal();
 	return {
 		...actual,
-		dim: (str) => str,
-		green: (str) => str,
-		red: (str) => str,
-		yellow: (str) => str,
-		gray: (str) => str,
+		styleText: (_style, str) => str,
 	};
 });
 vi.mock('tinyglobby', () => ({

--- a/packages/studiocms/package.json
+++ b/packages/studiocms/package.json
@@ -249,7 +249,6 @@
 		"ace-builds": "^1.43.6",
 		"astro-integration-kit": "catalog:",
 		"boxen": "^8.0.1",
-		"chalk": "catalog:",
 		"diff": "catalog:",
 		"dompurify": "^3.3.1",
 		"dotenv": "catalog:",

--- a/packages/studiocms/src/cli/add/index.ts
+++ b/packages/studiocms/src/cli/add/index.ts
@@ -1,5 +1,6 @@
 import { existsSync, promises as fs } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { styleText } from 'node:util';
 import { cancelled, success } from '@withstudiocms/cli-kit/messages';
 import { exists, pathToFileURL, resolveRoot } from '@withstudiocms/cli-kit/utils';
 import { intro, note, outro } from '@withstudiocms/effect/clack';
@@ -179,7 +180,7 @@ export const addPlugin = Cli.Command.make(
 			genContext,
 		]);
 
-		const { cwd, chalk } = context;
+		const { cwd } = context;
 
 		yield* intro('StudioCMS CLI Utilities (add)');
 
@@ -209,7 +210,7 @@ export const addPlugin = Cli.Command.make(
 			case UpdateResult.cancelled: {
 				yield* note(
 					cancelled(
-						`Dependencies ${chalk.bold('NOT')} installed.`,
+						`Dependencies ${styleText('bold', 'NOT')} installed.`,
 						'Be sure to install them manually before continuing!'
 					)
 				);
@@ -242,7 +243,7 @@ export const addPlugin = Cli.Command.make(
 
 		switch (configResult) {
 			case UpdateResult.cancelled: {
-				yield* outro(cancelled(`Your configuration has ${chalk.bold('NOT')} been updated.`));
+				yield* outro(cancelled(`Your configuration has ${styleText('bold', 'NOT')} been updated.`));
 				break;
 			}
 			case UpdateResult.none: {

--- a/packages/studiocms/src/cli/add/tryToInstallPlugins.ts
+++ b/packages/studiocms/src/cli/add/tryToInstallPlugins.ts
@@ -1,3 +1,4 @@
+import { styleText } from 'node:util';
 import { exec } from '@withstudiocms/cli-kit/utils';
 import { askToContinue, note, spinner } from '@withstudiocms/effect/clack';
 import { detect, resolveCommand } from 'package-manager-detector';
@@ -14,7 +15,7 @@ export class TryToInstallPlugins extends Effect.Service<TryToInstallPlugins>()(
 		effect: genLogger('studiocms/cli/add/validatePlugins/TryToInstallPlugins.effect')(function* () {
 			const run = (plugins: PluginInfo[]) =>
 				genLogger('studiocms/cli/add/validatePlugins/TryToInstallPlugins.effect.run')(function* () {
-					const { chalk, cwd } = yield* CliContext;
+					const { cwd } = yield* CliContext;
 
 					const packageManager = yield* Effect.tryPromise(() =>
 						detect({
@@ -48,7 +49,7 @@ export class TryToInstallPlugins extends Effect.Service<TryToInstallPlugins>()(
 								: specifier
 					);
 
-					const coloredOutput = `${chalk.bold(installCommand.command)} ${installCommand.args.join(' ')} ${chalk.magenta(installSpecifiers.join(' '))}`;
+					const coloredOutput = `${styleText('bold', installCommand.command)} ${installCommand.args.join(' ')} ${styleText('magenta', installSpecifiers.join(' '))}`;
 
 					const boxenMessage = yield* effectBoxen((boxen) =>
 						boxen(coloredOutput, {
@@ -61,7 +62,7 @@ export class TryToInstallPlugins extends Effect.Service<TryToInstallPlugins>()(
 					const message = `\n${boxenMessage}\n`;
 
 					yield* note(
-						`${chalk.magenta('StudioCMS will run the following command:')}\n ${chalk.dim('If you skip this step, you can always run it yourself later')}\n${message}`
+						`${styleText('magenta', 'StudioCMS will run the following command:')}\n ${styleText('dim', 'If you skip this step, you can always run it yourself later')}\n${message}`
 					);
 
 					if (yield* askToContinue()) {
@@ -100,7 +101,7 @@ export class TryToInstallPlugins extends Effect.Service<TryToInstallPlugins>()(
 							// @ts-expect-error
 							yield* Console.error(`\n${response.stdout || response.message}\n`);
 							yield* Console.error(
-								`\n${chalk.yellow('You may want to try:')}\n- Checking your network connection\n- Running the package manager command manually\n- Ensuring you have permissions to install packages\n`
+								`\n${styleText('yellow', 'You may want to try:')}\n- Checking your network connection\n- Running the package manager command manually\n- Ensuring you have permissions to install packages\n`
 							);
 							return UpdateResult.failure;
 						}

--- a/packages/studiocms/src/cli/add/updateStudioCMSConfig.ts
+++ b/packages/studiocms/src/cli/add/updateStudioCMSConfig.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { styleText } from 'node:util';
 import { askToContinue, note } from '@withstudiocms/effect/clack';
 import { diffWords } from 'diff';
 import { generateCode, type ProxifiedModule } from 'magicast';
@@ -18,7 +19,6 @@ export class UpdateStudioCMSConfig extends Effect.Service<UpdateStudioCMSConfig>
 					genLogger('studiocms/cli/add/updateStudioCMSConfig/UpdateStudioCMSConfig.effect.run')(
 						function* () {
 							const context = yield* CliContext;
-							const { chalk } = context;
 
 							const input = yield* Effect.tryPromise(() =>
 								fs.readFile(fileURLToPath(configURL), { encoding: 'utf-8' })
@@ -54,7 +54,7 @@ export class UpdateStudioCMSConfig extends Effect.Service<UpdateStudioCMSConfig>
 							const message = `\n${boxenMessage}\n`;
 
 							yield* note(
-								`\n ${chalk.magenta('StudioCMS will make the following changes to your config file:')}\n${message}`
+								`\n ${styleText('magenta', 'StudioCMS will make the following changes to your config file:')}\n${message}`
 							);
 
 							if (yield* askToContinue()) {
@@ -76,7 +76,6 @@ export class UpdateStudioCMSConfig extends Effect.Service<UpdateStudioCMSConfig>
 
 const getDiffContent = (input: string, output: string) =>
 	genLogger('studiocms/cli/add/updateStudioCMSConfig.getDiffContentNew')(function* () {
-		const { chalk } = yield* CliContext;
 		const changes = [];
 		for (const change of diffWords(input, output)) {
 			const lines = change.value.trim().split('\n').slice(0, change.count);
@@ -94,7 +93,7 @@ const getDiffContent = (input: string, output: string) =>
 		for (const newContent of changes) {
 			const coloredOutput = newContent
 				.split('\n')
-				.map((ln) => (ln ? chalk.green(ln) : ''))
+				.map((ln) => (ln ? styleText('green', ln) : ''))
 				.join('\n');
 			diffed = diffed.replace(newContent, coloredOutput);
 		}

--- a/packages/studiocms/src/cli/add/validatePlugins.ts
+++ b/packages/studiocms/src/cli/add/validatePlugins.ts
@@ -1,6 +1,6 @@
+import { styleText } from 'node:util';
 import { askToContinue, spinner } from '@withstudiocms/effect/clack';
 import { Effect, genLogger } from '../../effect.js';
-import { CliContext } from '../utils/context.js';
 import { type PluginInfo, StudioCMSScopes } from './index.js';
 import { fetchPackageJson, parsePluginName } from './npm-utils.js';
 
@@ -8,7 +8,6 @@ export class ValidatePlugins extends Effect.Service<ValidatePlugins>()('Validate
 	effect: genLogger('studiocms/cli/add/validatePlugins/ValidatePlugins.effect')(function* () {
 		const run = (names: string[]) =>
 			genLogger('studiocms/cli/add/validatePlugins/ValidatePlugins.effect.run')(function* () {
-				const { chalk } = yield* CliContext;
 				const spin = yield* spinner();
 
 				yield* spin.start('Resolving packages...');
@@ -19,7 +18,9 @@ export class ValidatePlugins extends Effect.Service<ValidatePlugins>()('Validate
 					const parsed = yield* parsePluginName(plugin);
 
 					if (!parsed)
-						throw new Error(`${chalk.bold(plugin)} does not appear to be a valid package name!`);
+						throw new Error(
+							`${styleText('bold', plugin)} does not appear to be a valid package name!`
+						);
 
 					const { scope, name, tag } = parsed;
 
@@ -33,14 +34,17 @@ export class ValidatePlugins extends Effect.Service<ValidatePlugins>()('Validate
 						const firstPartyPkgCheck = yield* fetchPackageJson(scope, name, tag);
 						if (firstPartyPkgCheck instanceof Error) {
 							if (firstPartyPkgCheck.message) {
-								yield* spin.message(chalk.yellow(firstPartyPkgCheck.message));
+								yield* spin.message(styleText('yellow', firstPartyPkgCheck.message));
 							}
 							yield* spin.message(
-								chalk.yellow(`${chalk.bold(plugin)} is not an official StudioCMS package.`)
+								styleText(
+									'yellow',
+									`${styleText('bold', plugin)} is not an official StudioCMS package.`
+								)
 							);
 							if (!(yield* askToContinue())) {
 								throw new Error(
-									`No problem! Find our official plugins at ${chalk.magenta('https://docs.studiocms.dev')}`
+									`No problem! Find our official plugins at ${styleText('magenta', 'https://docs.studiocms.dev')}`
 								);
 							}
 							yield* spin.start('Resolving with third party packages...');
@@ -56,9 +60,11 @@ export class ValidatePlugins extends Effect.Service<ValidatePlugins>()('Validate
 						const thirdPartyPkgCheck = yield* fetchPackageJson(scope, name, tag);
 						if (thirdPartyPkgCheck instanceof Error) {
 							if (thirdPartyPkgCheck.message) {
-								yield* spin.message(chalk.yellow(thirdPartyPkgCheck.message));
+								yield* spin.message(styleText('yellow', thirdPartyPkgCheck.message));
 							}
-							throw new Error(`Unable to fetch ${chalk.bold(plugin)}. Does the package exist?`);
+							throw new Error(
+								`Unable to fetch ${styleText('bold', plugin)}. Does the package exist?`
+							);
 						}
 						// biome-ignore lint/suspicious/noExplicitAny: this is a valid use case for explicit any
 						pkgJson = thirdPartyPkgCheck as any;
@@ -83,7 +89,7 @@ export class ValidatePlugins extends Effect.Service<ValidatePlugins>()('Validate
 					const keywords = Array.isArray(pkgJson.keywords) ? pkgJson.keywords : [];
 					if (!keywords.includes('studiocms-plugin')) {
 						throw new Error(
-							`${chalk.bold(plugin)} doesn't appear to be an StudioCMS Plugin. Find our official plugins at ${chalk.magenta('https://docs.studiocms.dev')}`
+							`${styleText('bold', plugin)} doesn't appear to be an StudioCMS Plugin. Find our official plugins at ${styleText('magenta', 'https://docs.studiocms.dev')}`
 						);
 					}
 

--- a/packages/studiocms/src/cli/crypto/genJWT/index.ts
+++ b/packages/studiocms/src/cli/crypto/genJWT/index.ts
@@ -10,7 +10,6 @@ import { intro, log, outro, spinner } from '@withstudiocms/effect/clack';
 import { SignJWT } from 'jose';
 import { importPKCS8 } from 'jose/key/import';
 import { Cli, Effect, genLogger } from '../../../effect.js';
-import { genContext } from '../../utils/context.js';
 import { dateAdd } from '../../utils/dateAdd.js';
 import { debug } from '../../utils/debugOpt.js';
 import { StudioCMSCliError } from '../../utils/errors.js';
@@ -79,12 +78,6 @@ export const genJWT = Cli.Command.make(
 				logger.debug(`Expiration: ${exp}`);
 			}
 
-			if (debug) logger.debug('Getting context');
-
-			const context = yield* genContext;
-
-			const { chalk } = context;
-
 			if (debug) logger.debug('Init complete, starting...');
 
 			yield* intro(label('StudioCMS Crypto: Generate JWT', StudioCMSColorwayBg, 'bold'));
@@ -135,11 +128,14 @@ export const genJWT = Cli.Command.make(
 				yield* spin.stop('Token Generated.');
 
 				yield* log.success(
-					boxen(chalk.bold(`${label('Token Generated!', StudioCMSColorwayInfoBg, 'bold')}`), {
-						ln1: 'Your new Token has been generated successfully:',
-						ln3: `Token: ${chalk.magenta(jwt)}`,
-						ln5: `Base64Url Token: ${chalk.blue(base64UrlJwt)}`,
-					})
+					boxen(
+						styleText('bold', `${label('Token Generated!', StudioCMSColorwayInfoBg, 'bold')}`),
+						{
+							ln1: 'Your new Token has been generated successfully:',
+							ln3: `Token: ${styleText('magenta', jwt)}`,
+							ln5: `Base64Url Token: ${styleText('blue', base64UrlJwt)}`,
+						}
+					)
 				);
 
 				yield* outro(

--- a/packages/studiocms/src/cli/init/steps/env.ts
+++ b/packages/studiocms/src/cli/init/steps/env.ts
@@ -40,7 +40,7 @@ function NumberStringToUndefined(value: string): number | undefined {
 }
 
 export const env: EffectStepFn = Effect.fn(function* (context, debug, dryRun) {
-	const { chalk, cwd, pCancel, pOnCancel } = context;
+	const { cwd, pCancel, pOnCancel } = context;
 
 	const debugLogger = yield* buildDebugLogger(debug);
 
@@ -530,7 +530,7 @@ export const env: EffectStepFn = Effect.fn(function* (context, debug, dryRun) {
 		});
 	} else if (_env) {
 		context.tasks.push({
-			title: chalk.dim('Creating environment file...'),
+			title: styleText('dim', 'Creating environment file...'),
 			task: async (message) => {
 				try {
 					await fs.writeFile(path.join(cwd, '.env'), envFileContent, {

--- a/packages/studiocms/src/cli/init/steps/next.ts
+++ b/packages/studiocms/src/cli/init/steps/next.ts
@@ -26,7 +26,7 @@ const runCmdMap: { [key: string]: string } = {
 
 export const next = (debug: boolean) =>
 	genLogger('studiocms/cli/init/steps/next')(function* () {
-		const [{ chalk, packageManager }, debugLogger] = yield* Effect.all([
+		const [{ packageManager }, debugLogger] = yield* Effect.all([
 			CliContext,
 			buildDebugLogger(debug),
 		]);
@@ -40,13 +40,14 @@ export const next = (debug: boolean) =>
 			debugLogger('Running next steps fn...'),
 			log.success(
 				boxen(
-					chalk.bold(
+					styleText(
+						'bold',
 						`${label('Init Complete!', StudioCMSColorwayInfoBg, 'bold')} Get started with StudioCMS:`
 					),
 					{
-						ln1: `Ensure your ${chalk.cyanBright('.env')} file is configured correctly.`,
-						ln3: `Run ${chalk.cyan(`${runCmd} studiocms migrate`)} to sync your database schema.`,
-						ln4: `Run ${chalk.cyan(devCmd)} to start the dev server. ${chalk.cyanBright('CTRL+C')} to stop.`,
+						ln1: `Ensure your ${styleText('cyanBright', '.env')} file is configured correctly.`,
+						ln3: `Run ${styleText('cyan', `${runCmd} studiocms migrate`)} to sync your database schema.`,
+						ln4: `Run ${styleText('cyan', devCmd)} to start the dev server. ${styleText('cyanBright', 'CTRL+C')} to stop.`,
 					}
 				)
 			),

--- a/packages/studiocms/src/cli/migrator/index.ts
+++ b/packages/studiocms/src/cli/migrator/index.ts
@@ -102,7 +102,7 @@ const handleResults = async (results: MigrationResult[] | undefined, success: bo
 const handleError = async (
 	error: unknown,
 	success: boolean,
-	exitFn: Effect.Effect<undefined, never, never>
+	exitFn: Effect.Effect<void, never, never>
 ) => {
 	if (error) {
 		const message = success
@@ -219,15 +219,15 @@ export const migratorCMD = Cli.Command.make(
 							// If migrations are 100% applied, color green, if over 50% yellow, else red
 							const migrationTotalColor =
 								migrationPercent === 100
-									? context.chalk.green
+									? (text: string) => styleText('green', text)
 									: migrationPercent > 50
-										? context.chalk.yellow
-										: context.chalk.red;
+										? (text: string) => styleText('yellow', text)
+										: (text: string) => styleText('red', text);
 
 							const labelParts = [
 								label('Migration Status', StudioCMSColorwayInfoBg, 'black'),
 								label(
-									`(${context.chalk.green(appliedMigrations.toString())}/${migrationTotalColor(migrationTotal.toString())}) Applied`,
+									`(${styleText('green', appliedMigrations.toString())}/${migrationTotalColor(migrationTotal.toString())}) Applied`,
 									(text: string) => styleText('bold', text),
 									'black'
 								),

--- a/packages/studiocms/src/cli/users/shared.ts
+++ b/packages/studiocms/src/cli/users/shared.ts
@@ -1,6 +1,6 @@
+import { styleText } from 'node:util';
 import { Effect } from '@withstudiocms/effect';
 import { type ClackError, log } from '@withstudiocms/effect/clack';
-import chalk from 'chalk';
 
 /**
  * Validates user input and re-prompts if validation fails.
@@ -50,6 +50,6 @@ export const validateInputOrRePrompt = Effect.fn('validateInputOrRePrompt')(func
 		}
 
 		// If validation fails, log the error and re-prompt
-		yield* log.error(chalk.red(`Invalid input: ${checkResult}`));
+		yield* log.error(styleText('red', `Invalid input: ${checkResult}`));
 	}
 });

--- a/packages/studiocms/src/cli/users/steps/createUsers.ts
+++ b/packages/studiocms/src/cli/users/steps/createUsers.ts
@@ -186,7 +186,7 @@ export const createUsers: EffectStepFn = Effect.fn(function* (context, _debug, d
 
 	// Check password confirmation
 	if (newPassword !== confirmPassword) {
-		yield* log.error(context.chalk.red('Passwords do not match, exiting...'));
+		yield* log.error(styleText('red', 'Passwords do not match, exiting...'));
 		return yield* context.exit(1);
 	}
 
@@ -248,7 +248,7 @@ export const createUsers: EffectStepFn = Effect.fn(function* (context, _debug, d
 						return await runEffect(context.exit(1));
 					}
 
-					message(context.chalk.green('User created successfully!'));
+					message(styleText('green', 'User created successfully!'));
 				} catch (error) {
 					await runEffect(log.error(`Failed to create user: ${(error as Error).message}`));
 					return await runEffect(context.exit(1));

--- a/packages/studiocms/src/cli/utils/checkRequiredEnvVars.ts
+++ b/packages/studiocms/src/cli/utils/checkRequiredEnvVars.ts
@@ -1,5 +1,5 @@
+import { styleText } from 'node:util';
 import { log } from '@withstudiocms/effect/clack';
-import chalk from 'chalk';
 import { Effect } from '../../effect.js';
 
 /**
@@ -25,8 +25,8 @@ export const checkRequiredEnvVarsEffect = Effect.fn(function* (envVars: string[]
 
 	if (missingVars.length > 0) {
 		yield* log.error(
-			`${chalk.red.bold('Missing environment variables:')} ${missingVars
-				.map((v) => chalk.red(v))
+			`${styleText(['red', 'bold'], 'Missing environment variables:')} ${missingVars
+				.map((v) => styleText('red', v))
 				.join(', ')}`
 		);
 		return yield* Effect.try(() => process.exit(1));

--- a/packages/studiocms/src/cli/utils/context.ts
+++ b/packages/studiocms/src/cli/utils/context.ts
@@ -1,20 +1,16 @@
 import { detectPackageManager } from '@withstudiocms/cli-kit/context';
 import { cancelMessage, getName } from '@withstudiocms/cli-kit/messages';
 import { type ClackError, cancel, isCancel, type Task } from '@withstudiocms/effect/clack';
-import chalk from 'chalk';
 import { Context, Effect, genLogger, Layer, Option } from '../../effect.js';
 
-// TODO: Replace 'chalk' usage with node:util 'styleText' where applicable
-
 export interface BaseContext {
-	chalk: typeof chalk;
 	cwd: string;
 	packageManager: string;
 	username: string;
 	tasks: Task[];
 	pCancel(val: symbol): Effect.Effect<void, ClackError, never>;
 	pOnCancel(): Effect.Effect<void, ClackError, never>;
-	exit(code: number): Effect.Effect<undefined, never, never>;
+	exit(code: number): Effect.Effect<void, never, never>;
 }
 
 export class CliContext extends Context.Tag('CliContext')<CliContext, BaseContext>() {
@@ -37,10 +33,9 @@ export const genContext = genLogger('studiocms/cli/utils/context.genContext')(fu
 	const username = yield* Effect.tryPromise(() => getName());
 
 	const exit = (code: number) =>
-		Effect.try(() => process.exit(code)).pipe(Effect.catchAll(() => Effect.succeed(void 0)));
+		Effect.try(() => process.exit(code)).pipe(Effect.catchAll(() => Effect.void));
 
 	const context: BaseContext = {
-		chalk,
 		cwd,
 		packageManager,
 		username,

--- a/packages/studiocms/src/cli/utils/logger.ts
+++ b/packages/studiocms/src/cli/utils/logger.ts
@@ -1,6 +1,6 @@
+import { styleText } from 'node:util';
 import { supportsColor } from '@withstudiocms/cli-kit/colors';
 import { date } from '@withstudiocms/cli-kit/messages';
-import chalk from 'chalk';
 import { Effect } from 'effect';
 
 let stdout = process.stdout;
@@ -18,7 +18,7 @@ export const logger = {
 			send(`DEBUG [${date}]: ${message}`);
 			return;
 		}
-		send(`${chalk.blue.bold(`DEBUG [${date}]:`)} ${message}`);
+		send(`${styleText(['blue', 'bold'], `DEBUG [${date}]:`)} ${message}`);
 	},
 };
 
@@ -37,7 +37,7 @@ export const buildDebugLogger = Effect.fn(function* (debug: boolean) {
 				send(`DEBUG [${date}]: ${message}`);
 				return;
 			}
-			send(`${chalk.blue.bold(`DEBUG [${date}]:`)} ${message}`);
+			send(`${styleText(['blue', 'bold'], `DEBUG [${date}]:`)} ${message}`);
 		})
 	);
 });

--- a/packages/studiocms/src/cli/utils/user-utils.ts
+++ b/packages/studiocms/src/cli/utils/user-utils.ts
@@ -1,7 +1,7 @@
+import { styleText } from 'node:util';
 import { makeScrypt, Password } from '@withstudiocms/auth-kit';
 import { PasswordModOptions } from '@withstudiocms/auth-kit/config';
 import { CheckIfUnsafe } from '@withstudiocms/auth-kit/utils/unsafeCheck';
-import chalk from 'chalk';
 import dotenv from 'dotenv';
 import { Effect, runEffect } from '../../effect.js';
 
@@ -11,9 +11,10 @@ let { CMS_ENCRYPTION_KEY } = process.env;
 
 if (!CMS_ENCRYPTION_KEY) {
 	console.warn(
-		`${chalk.yellow.bold('Warning:')} ${chalk.yellow(
+		`${styleText(['yellow', 'bold'], 'Warning:')} ${styleText(
+			'yellow',
 			'CMS_ENCRYPTION_KEY is not set... '
-		)}${chalk.gray('Some commands may be disabled.')}`
+		)}${styleText('gray', 'Some commands may be disabled.')}`
 	);
 	CMS_ENCRYPTION_KEY = '+URKVIiIM1kmG6g9Znb10g=='; // Fallback key for type safety, do not use in production
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,9 +37,6 @@ catalogs:
     astro-integration-kit:
       specifier: ^0.19.1
       version: 0.19.1
-    chalk:
-      specifier: ^5.6.2
-      version: 5.6.2
     deepmerge-ts:
       specifier: ^7.1.5
       version: 7.1.5
@@ -830,9 +827,6 @@ importers:
 
   packages/@withstudiocms/buildkit:
     dependencies:
-      chalk:
-        specifier: 'catalog:'
-        version: 5.6.2
       esbuild:
         specifier: 'catalog:'
         version: 0.25.12
@@ -1152,9 +1146,6 @@ importers:
       boxen:
         specifier: ^8.0.1
         version: 8.0.1
-      chalk:
-        specifier: 'catalog:'
-        version: 5.6.2
       diff:
         specifier: 'catalog:'
         version: 8.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,6 @@ catalog:
   "@types/semver": ^7.7.1
   arctic: ^3.7.0
   astro-integration-kit: ^0.19.1
-  chalk: ^5.6.2
   deepmerge-ts: ^7.1.5
   esbuild: ^0.25.8
   sharp: ^0.34.3


### PR DESCRIPTION
This pull request replaces the use of the `chalk` library for colored CLI output with Node.js's built-in `styleText` from the `node:util` module across both the `@withstudiocms/buildkit` and `studiocms` packages. This change streamlines dependencies and modernizes how text styling is handled in CLI scripts and tools.

- Closes #1221 

**Dependency removal and code refactoring:**

* Removed the `chalk` dependency from both `@withstudiocms/buildkit` and `studiocms` by deleting it from `package.json` files and all imports, switching all color and style usages to `styleText` from `node:util`. [[1]](diffhunk://#diff-7e82f7ec2f0ef4e805516bf3bcb8e38b286e239336f36c32bf0ca6e1cecf7decL35-R35) [[2]](diffhunk://#diff-2d16107b635fed3f93e32a31b7351ed4af23aa3e9b5de69af9992939bbb41c38L252) [[3]](diffhunk://#diff-3654281248c3b783f871389435a18e31572baf73952756bdf6cb4cb023fc0456L3-R3) [[4]](diffhunk://#diff-6b3e714716f7d88da9a19eb94f81cbf3ae9fb83531f3e750fb1bb6cba5520e7eL1-R25) [[5]](diffhunk://#diff-b615e4d2633d7371a23baf052491cae2973cbffd884cdc14e8883c72f3a9aeceR3) [[6]](diffhunk://#diff-287e96088f9ac438ed1fdbce0b8771f819bddd8a01e3e2748eb3eaba2b50df27R1) [[7]](diffhunk://#diff-f5c1f76d36935a2c4e91816f0594f1c4182839b35adba84c996f8ab8780515e1R3)
* Updated all CLI messages and logging in `builder.js`, `help.js`, and relevant `studiocms` CLI scripts to use `styleText` for colors and emphasis, ensuring consistent output formatting. [[1]](diffhunk://#diff-3654281248c3b783f871389435a18e31572baf73952756bdf6cb4cb023fc0456L95-R105) [[2]](diffhunk://#diff-3654281248c3b783f871389435a18e31572baf73952756bdf6cb4cb023fc0456L112-R114) [[3]](diffhunk://#diff-3654281248c3b783f871389435a18e31572baf73952756bdf6cb4cb023fc0456L127-R132) [[4]](diffhunk://#diff-3654281248c3b783f871389435a18e31572baf73952756bdf6cb4cb023fc0456L194-R199) [[5]](diffhunk://#diff-3654281248c3b783f871389435a18e31572baf73952756bdf6cb4cb023fc0456L216-R223) [[6]](diffhunk://#diff-3654281248c3b783f871389435a18e31572baf73952756bdf6cb4cb023fc0456L225-R237) [[7]](diffhunk://#diff-3654281248c3b783f871389435a18e31572baf73952756bdf6cb4cb023fc0456L245-R252) [[8]](diffhunk://#diff-3654281248c3b783f871389435a18e31572baf73952756bdf6cb4cb023fc0456L259-R271) [[9]](diffhunk://#diff-3654281248c3b783f871389435a18e31572baf73952756bdf6cb4cb023fc0456L285-R295) [[10]](diffhunk://#diff-6b3e714716f7d88da9a19eb94f81cbf3ae9fb83531f3e750fb1bb6cba5520e7eL1-R25) [[11]](diffhunk://#diff-b615e4d2633d7371a23baf052491cae2973cbffd884cdc14e8883c72f3a9aeceL212-R213) [[12]](diffhunk://#diff-b615e4d2633d7371a23baf052491cae2973cbffd884cdc14e8883c72f3a9aeceL245-R246) [[13]](diffhunk://#diff-287e96088f9ac438ed1fdbce0b8771f819bddd8a01e3e2748eb3eaba2b50df27L51-R52) [[14]](diffhunk://#diff-287e96088f9ac438ed1fdbce0b8771f819bddd8a01e3e2748eb3eaba2b50df27L64-R65) [[15]](diffhunk://#diff-287e96088f9ac438ed1fdbce0b8771f819bddd8a01e3e2748eb3eaba2b50df27L103-R104) [[16]](diffhunk://#diff-f5c1f76d36935a2c4e91816f0594f1c4182839b35adba84c996f8ab8780515e1L57-R57) [[17]](diffhunk://#diff-f5c1f76d36935a2c4e91816f0594f1c4182839b35adba84c996f8ab8780515e1L97-R96)

**Test and mock updates:**

* Updated test mocks to replace `chalk` with `styleText` in `builder.test.js`, ensuring tests remain compatible with the new styling approach. [[1]](diffhunk://#diff-8e3ea28fe4abc00814343006ab865074704819fab446590e5068a12206b6b8c2L7) [[2]](diffhunk://#diff-8e3ea28fe4abc00814343006ab865074704819fab446590e5068a12206b6b8c2L16-R19)

**General cleanup:**

* Removed unused `chalk` references from CLI context objects and utility functions throughout the codebase. [[1]](diffhunk://#diff-b615e4d2633d7371a23baf052491cae2973cbffd884cdc14e8883c72f3a9aeceL182-R183) [[2]](diffhunk://#diff-287e96088f9ac438ed1fdbce0b8771f819bddd8a01e3e2748eb3eaba2b50df27L17-R18) [[3]](diffhunk://#diff-f5c1f76d36935a2c4e91816f0594f1c4182839b35adba84c996f8ab8780515e1L21) [[4]](diffhunk://#diff-f5c1f76d36935a2c4e91816f0594f1c4182839b35adba84c996f8ab8780515e1L79)

**Documentation:**

* Added a changeset entry documenting the switch from `chalk` to `node:util`'s `styleText` for colored output. (.changeset/three-pandas-smash.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced third-party styling library with Node.js native utilities for CLI output formatting.

* **Chores**
  * Removed external styling dependency from buildkit and CLI packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->