### PR TITLE
chore: remove legacy email domain verification code

### DIFF
--- a/.changeset/shy-bobcats-cheer.md
+++ b/.changeset/shy-bobcats-cheer.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Removes legacy email domain verification code

--- a/packages/studiocms/frontend/pages/studiocms_api/auth/[path].ts
+++ b/packages/studiocms/frontend/pages/studiocms_api/auth/[path].ts
@@ -356,12 +356,6 @@ const router = {
 					if (!checkEmail.success)
 						return yield* badFormDataEntry('Invalid email', checkEmail.error.message);
 
-					const invalidEmailDomains: string[] = ['example.com', 'test.com', 'testing.com'];
-
-					if (invalidEmailDomains.includes(checkEmail.data.split('@')[1])) {
-						return yield* badFormDataEntry('Invalid Email', 'Must be from a valid domain');
-					}
-
 					const { usernameSearch, emailSearch } =
 						yield* sdk.AUTH.user.searchUsersForUsernameOrEmail(username, checkEmail.data);
 


### PR DESCRIPTION
This pull request removes legacy email domain verification logic from the StudioCMS authentication API. The change eliminates the restriction that previously blocked signups from certain email domains (such as `example.com` and `test.com`).

Authentication logic cleanup:

* Removed the check for invalid email domains (`example.com`, `test.com`, `testing.com`) from the signup/authentication flow in `studiocms_api/auth/[path].ts`. 

Documentation:

* Added a changeset entry documenting the removal of legacy email domain verification code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed legacy email domain validation restrictions that were blocking certain email addresses during user registration, allowing broader email domain support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->