### PR TITLE
feat(patch): add patch for @changesets/assemble-release-plan

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "packages/@withstudiocms/*",
     "packages/*"
   ],
+  "pnpm": {
+    "patchedDependencies": {
+      "@changesets/assemble-release-plan": "patches/@changesets__assemble-release-plan.patch"
+    }
+  },
   "scripts": {
     "effect-language-service": "effect-language-service",
     "start": "node ./playground/dist/server/entry.mjs",

--- a/patches/@changesets__assemble-release-plan.patch
+++ b/patches/@changesets__assemble-release-plan.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
+index ae379dc5ba7ac6d40bd68c7029aca350bd92d88a..77433a695845105c041c78f7e8dd4a2622a56c0d 100644
+--- a/dist/changesets-assemble-release-plan.cjs.js
++++ b/dist/changesets-assemble-release-plan.cjs.js
+@@ -215,7 +215,7 @@ function determineDependents({
+             preInfo,
+             onlyUpdatePeerDependentsWhenOutOfRange: config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange
+           })) {
+-            type = "major";
++            type = "minor";
+           } else if ((!releases.has(dependent) || releases.get(dependent).type === "none") && (config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.updateInternalDependents === "always" || !semverSatisfies__default["default"](incrementVersion(nextRelease, preInfo), versionRange))) {
+             switch (depType) {
+               case "dependencies":
+diff --git a/dist/changesets-assemble-release-plan.esm.js b/dist/changesets-assemble-release-plan.esm.js
+index c183f2e9527403ccdab71a9ac8dfce8931caaac9..b3214ff3aa420455c09b4f72fdcbe351ee086923 100644
+--- a/dist/changesets-assemble-release-plan.esm.js
++++ b/dist/changesets-assemble-release-plan.esm.js
+@@ -204,7 +204,7 @@ function determineDependents({
+             preInfo,
+             onlyUpdatePeerDependentsWhenOutOfRange: config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange
+           })) {
+-            type = "major";
++            type = "minor";
+           } else if ((!releases.has(dependent) || releases.get(dependent).type === "none") && (config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.updateInternalDependents === "always" || !semverSatisfies(incrementVersion(nextRelease, preInfo), versionRange))) {
+             switch (depType) {
+               case "dependencies":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,11 @@ catalogs:
       specifier: ^1.1.2
       version: 1.1.2
 
+patchedDependencies:
+  '@changesets/assemble-release-plan':
+    hash: daf5c4f7356732f541b624e53456ef76097321630db86803e122ad556cefdc07
+    path: patches/@changesets__assemble-release-plan.patch
+
 importers:
 
   .:
@@ -7900,7 +7905,7 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.4
 
-  '@changesets/assemble-release-plan@6.0.9':
+  '@changesets/assemble-release-plan@6.0.9(patch_hash=daf5c4f7356732f541b624e53456ef76097321630db86803e122ad556cefdc07)':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
@@ -7924,7 +7929,7 @@ snapshots:
   '@changesets/cli@2.29.8(@types/node@22.19.6)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.14
-      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=daf5c4f7356732f541b624e53456ef76097321630db86803e122ad556cefdc07)
       '@changesets/changelog-git': 0.2.1
       '@changesets/config': 3.1.2
       '@changesets/errors': 0.2.0
@@ -7984,7 +7989,7 @@ snapshots:
 
   '@changesets/get-release-plan@4.0.14':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=daf5c4f7356732f541b624e53456ef76097321630db86803e122ad556cefdc07)
       '@changesets/config': 3.1.2
       '@changesets/pre': 2.0.2
       '@changesets/read': 0.6.6


### PR DESCRIPTION
This pull request introduces a patch to the `@changesets/assemble-release-plan` package, changing how dependent package version bumps are determined. The patch is applied via pnpm's patched dependencies mechanism and updates the lockfile accordingly. 

These changes are based on [Effect-TS](https://github.com/Effect-TS/effect/tree/main)'s patch used in their repositories

The most important changes are:

**Dependency Release Strategy Update:**

* The patch modifies the logic in `@changesets/assemble-release-plan` so that certain dependent package updates are bumped with a `minor` version instead of a `major` version, reducing unnecessary major releases for dependents.

**Build and Dependency Management:**

* Added a `pnpm.patchedDependencies` entry in `package.json` to apply the custom patch to `@changesets/assemble-release-plan`.
* Updated `pnpm-lock.yaml` to reference the patched version of `@changesets/assemble-release-plan` with the correct patch hash, ensuring the patch is tracked and applied in the lockfile. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR133-R137) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7903-R7908) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7927-R7932) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7987-R7992)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Applied a dependency patch to the release planning system that adjusts version type determination and increment calculations for dependent packages during releases, potentially affecting version number assignments in future release cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->