### PR TITLE
fix(folder): update folder deletion schemas to prevent server errors

### DIFF
--- a/.changeset/common-poets-wish.md
+++ b/.changeset/common-poets-wish.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Fixes folder deletion schema calls that caused folder deletion to return a server error

--- a/packages/studiocms/frontend/pages/studiocms_api/dashboard/content/folder.ts
+++ b/packages/studiocms/frontend/pages/studiocms_api/dashboard/content/folder.ts
@@ -116,7 +116,7 @@ export const { POST, PATCH, DELETE, OPTIONS, ALL } = createEffectAPIRoutes(
 				 */
 				const checkForChildrenFolders = sdk.dbService.withCodec({
 					encoder: Schema.String,
-					decoder: Schema.Array(StudioCMSPageFolderStructure),
+					decoder: Schema.Array(StudioCMSPageFolderStructure.Select),
 					callbackFn: (client, id) =>
 						client((db) =>
 							db
@@ -132,7 +132,7 @@ export const { POST, PATCH, DELETE, OPTIONS, ALL } = createEffectAPIRoutes(
 				 */
 				const checkForChildrenPages = sdk.dbService.withCodec({
 					encoder: Schema.String,
-					decoder: Schema.Array(StudioCMSPageData),
+					decoder: Schema.Array(StudioCMSPageData.Select),
 					callbackFn: (client, id) =>
 						client((db) =>
 							db


### PR DESCRIPTION
This pull request addresses a server error that occurred during folder deletion in StudioCMS by updating the schemas used in database calls. The main changes focus on correcting the decoder types for child folder and page checks, ensuring that only the necessary fields are selected.

- Closes: #1350 

Fixes for folder deletion errors:

* Updated the decoder for child folder checks to use `StudioCMSPageFolderStructure.Select` instead of the full structure, reducing data fetched and preventing schema mismatches.
* Updated the decoder for child page checks to use `StudioCMSPageData.Select` instead of the full data object, similarly optimizing the query and avoiding errors.

General bug fix:

* Added a changeset documenting the patch for folder deletion schema errors that previously caused server failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a server error that occurred when deleting folders, restoring the ability to successfully remove folders from the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->