### PR TITLE
fix(deps): add mysql2 to ignored dependencies in renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -69,6 +69,7 @@
     "codemirror",
     "vite",
     "vitest",
-    "zod"
+    "zod",
+    "mysql2"
   ]
 }


### PR DESCRIPTION
This pull request makes a minor update to the dependency configuration in `.github/renovate.json`. The change adds the `mysql2` package to the list of dependencies managed by Renovate.

* Added `mysql2` to the `packageRules` list to ensure it is tracked and updated by Renovate.

Related: https://github.com/kysely-org/kysely/issues/1722

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to refine automated update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->