### PR TITLE
feat(api): add admin API token revocation endpoint

### DIFF
--- a/.changeset/eighty-forks-attend.md
+++ b/.changeset/eighty-forks-attend.md
@@ -1,0 +1,6 @@
+---
+"@withstudiocms/api-spec": minor
+"studiocms": minor
+---
+
+Introduces new admin level api token revocation endpoint

--- a/.changeset/sweet-jars-remain.md
+++ b/.changeset/sweet-jars-remain.md
@@ -1,0 +1,5 @@
+---
+"@withstudiocms/auth-kit": patch
+---
+
+Corrects permission ranks order

--- a/packages/@withstudiocms/api-spec/src/dashboard/index.ts
+++ b/packages/@withstudiocms/api-spec/src/dashboard/index.ts
@@ -3,7 +3,7 @@ import { Description, License, Title, Transform, Version } from '@effect/platfor
 import pkg from '../../package.json';
 import { StudioCMSLicenseAnnotation, StudioCMSTransformAnnotation } from '../consts.js';
 import { DashboardAPIError } from './errors.js';
-import { apiTokensDelete, apiTokensPost } from './routes/api-tokens.js';
+import { adminApiTokensDelete, apiTokensDelete, apiTokensPost } from './routes/api-tokens.js';
 import { configPost } from './routes/config.js';
 import {
 	contentDiffPost,
@@ -44,6 +44,7 @@ export class DashboardApiTokensGroup extends HttpApiGroup.make('apiTokens')
 	.annotate(License, StudioCMSLicenseAnnotation)
 	.add(apiTokensPost)
 	.add(apiTokensDelete)
+	.add(adminApiTokensDelete)
 	.addError(DashboardAPIError, { status: 500 })
 	.prefix('/dashboard') {}
 

--- a/packages/@withstudiocms/api-spec/src/dashboard/routes/api-tokens.ts
+++ b/packages/@withstudiocms/api-spec/src/dashboard/routes/api-tokens.ts
@@ -3,6 +3,7 @@ import { Description, Summary, Title } from '@effect/platform/OpenApi';
 import { AstroLocalsMiddleware } from '../../astro-context.js';
 import { DashboardAPIError } from '../errors.js';
 import {
+	AdminDeleteApiTokenPayload,
 	CreateApiTokenPayload,
 	CreateApiTokenResponse,
 	DeleteApiTokenPayload,
@@ -50,6 +51,31 @@ export const apiTokensDelete = HttpApiEndpoint.del('revokeApiToken', '/api-token
 	)
 	.middleware(AstroLocalsMiddleware)
 	.setPayload(DeleteApiTokenPayload)
+	.addSuccess(successResponseSchema)
+	.addError(DashboardAPIError, { status: 400 })
+	.addError(DashboardAPIError, { status: 403 })
+	.addError(DashboardAPIError, { status: 500 });
+
+/**
+ * Admin Revoke User API Token Endpoint
+ *
+ * This endpoint allows Admin users to revoke any user's API token for the StudioCMS Dashboard API.
+ */
+export const adminApiTokensDelete = HttpApiEndpoint.del(
+	'adminRevokeUserApiToken',
+	'/api-tokens/admin'
+)
+	.annotate(Title, 'Admin Revoke User API Token')
+	.annotate(
+		Summary,
+		"Admin level endpoint to revoke any user's API token for the StudioCMS Dashboard API"
+	)
+	.annotate(
+		Description,
+		"Admin level endpoint that allows revoking any user's API token for the StudioCMS Dashboard API. This endpoint requires additional permission checks to ensure only Admin users can revoke tokens that they do not own.\n\n> [!note]\n> This endpoint verifies User authentication using [Astro Locals Context](https://docs.astro.build/en/guides/middleware/#storing-data-in-contextlocals) and requires users to be logged into the current StudioCMS instance with Admin level permissions."
+	)
+	.middleware(AstroLocalsMiddleware)
+	.setPayload(AdminDeleteApiTokenPayload)
 	.addSuccess(successResponseSchema)
 	.addError(DashboardAPIError, { status: 400 })
 	.addError(DashboardAPIError, { status: 403 })

--- a/packages/@withstudiocms/api-spec/src/dashboard/schemas.ts
+++ b/packages/@withstudiocms/api-spec/src/dashboard/schemas.ts
@@ -7,8 +7,6 @@ import {
 import * as Schema from 'effect/Schema';
 import { StudioCMSDynamicSiteConfigData } from '../rest-api/schemas.js';
 
-// TODO: Implement Admin level API token revocation that allows revoking any token, not just tokens owned by the user. This will require additional permission checks to ensure only Admin users can revoke tokens that they do not own.
-
 /**
  * Standard error response schema for the StudioCMS Dashboard API.
  *
@@ -294,6 +292,18 @@ export const DeleteApiTokenPayload = Schema.Struct({
 }).annotations({
 	title: 'Delete API Token Payload',
 	description: 'Payload schema for deleting an existing API token in the StudioCMS Dashboard API.',
+});
+
+/**
+ * Payload schema for Admin users to delete any user's API token in the StudioCMS Dashboard API.
+ */
+export const AdminDeleteApiTokenPayload = Schema.Struct({
+	...DeleteApiTokenPayload.fields,
+	userID: Schema.String,
+}).annotations({
+	title: 'Admin Delete API Token Payload',
+	description:
+		"Payload schema for Admin users to delete any user's API token in the StudioCMS Dashboard API. This includes the token ID of the token to be revoked and the user ID of the token owner.",
 });
 
 /**

--- a/packages/@withstudiocms/auth-kit/src/types.ts
+++ b/packages/@withstudiocms/auth-kit/src/types.ts
@@ -92,7 +92,7 @@ export interface OAuthData {
  * - 'visitor': A low-level permission, for users who can view content but not modify it.
  * - 'unknown': A default or fallback permission rank for users with undefined roles.
  */
-export const availablePermissionRanks = ['owner', 'admin', 'editor', 'visitor', 'unknown'] as const;
+export const availablePermissionRanks = ['unknown', 'visitor', 'editor', 'admin', 'owner'] as const;
 
 /**
  * Represents the available permission ranks for a user.

--- a/packages/studiocms/frontend/pages/[dashboard]/user-management/edit.astro
+++ b/packages/studiocms/frontend/pages/[dashboard]/user-management/edit.astro
@@ -530,61 +530,51 @@ setDataContext(Astro, {
         button.addEventListener('click', async (event) => {
             event.preventDefault();
 
-            // TODO: Implement Admin level API token revocation that allows revoking any token, not just tokens owned by the user. This will require additional permission checks to ensure only Admin users can revoke tokens that they do not own.
-
-            toast({
-              title: 'Error',
-              description: 'Not Currently implemented',
-              type: 'danger',
-              duration: 5000,
-            });
-            return;
-
-            // const tokenID = button.getAttribute('data-token');
-            // const userID = button.getAttribute('data-user');
+            const tokenID = button.getAttribute('data-token');
+            const userID = button.getAttribute('data-user');
             
-            // if (!tokenID || !userID) {
-            //     toast({
-            //         title: 'Error',
-            //         description: 'Missing necessary data to revoke API token.',
-            //         type: 'danger',
-            //         duration: 5000
-            //     })
-            //     return;
-            // }
+            if (!tokenID || !userID) {
+                toast({
+                    title: 'Error',
+                    description: 'Missing necessary data to revoke API token.',
+                    type: 'danger',
+                    duration: 5000
+                })
+                return;
+            }
 
-            // const response = await dashboardClient.pipe(
-            //   Effect.flatMap((client) =>
-            //     client.apiTokens.revokeApiToken({
-            //       payload: {
-            //         tokenID,
-            //         userID
-            //       }
-            //     })
-            //   ),
-            //   Effect.catchTags(dashboardSharedCatchTags),
-            //   Effect.runPromise
-            // );
+            const response = await dashboardClient.pipe(
+              Effect.flatMap((client) =>
+                client.apiTokens.adminRevokeUserApiToken({
+                  payload: {
+                    tokenID,
+                    userID
+                  }
+                })
+              ),
+              Effect.catchTags(dashboardSharedCatchTags),
+              Effect.runPromise
+            );
 
-            // if ('error' in response) {
-            //   toast({
-            //     title: 'Error',
-            //     description: response.error,
-            //     type: 'danger',
-            //     duration: 5000
-            //   })
-            //   return;
-            // } else {
-            //   toast({
-            //     title: 'Success',
-            //     description: response.message || 'API token revoked successfully.',
-            //     type: 'success',
-            //     duration: 5000
-            //   })
-            //   setTimeout(() => {
-            //     window.location.reload();
-            //   }, 1000);
-            // }
+            if ('error' in response) {
+              toast({
+                title: 'Error',
+                description: response.error,
+                type: 'danger',
+                duration: 5000
+              })
+              return;
+            } else {
+              toast({
+                title: 'Success',
+                description: response.message || 'API token revoked successfully.',
+                type: 'success',
+                duration: 5000
+              })
+              setTimeout(() => {
+                window.location.reload();
+              }, 1000);
+            }
         });
     });
   </script>

--- a/packages/studiocms/frontend/pages/studiocms_api/_handlers/dashboard/apiTokens.ts
+++ b/packages/studiocms/frontend/pages/studiocms_api/_handlers/dashboard/apiTokens.ts
@@ -5,10 +5,9 @@ import { HttpApiBuilder } from '@effect/platform';
 import { StudioCMSDashboardApiSpec } from '@withstudiocms/api-spec';
 import { CurrentUser } from '@withstudiocms/api-spec/astro-context';
 import { DashboardAPIError } from '@withstudiocms/api-spec/dashboard';
+import { availablePermissionRanks } from '@withstudiocms/auth-kit/types';
 import { Effect } from 'effect';
 import { sharedDBErrors } from './_shared.js';
-
-// TODO: Implement Admin level API token revocation that allows revoking any token, not just tokens owned by the user. This will require additional permission checks to ensure only Admin users can revoke tokens that they do not own.
 
 /**
  * Check if the Dashboard API is enabled in the route configuration.
@@ -83,6 +82,49 @@ export const ApiTokensHandler = HttpApiBuilder.group(
 					}
 
 					yield* sdk.REST_API.tokens.delete({ tokenId: tokenID, userId: userData.user.id });
+
+					return {
+						message: 'Token deleted',
+					};
+				}, Effect.catchTags(sharedDBErrors))
+			)
+			.handle(
+				'adminRevokeUserApiToken',
+				Effect.fn(function* ({ payload: { tokenID, userID } }) {
+					if (!dashboardAPIEnabled) {
+						return yield* new DashboardAPIError({ error: 'Dashboard API is disabled' });
+					}
+
+					if (developerConfig.demoMode !== false) {
+						return yield* new DashboardAPIError({
+							error: 'Demo mode is enabled, this action is not allowed.',
+						});
+					}
+
+					const [sdk, userData] = yield* Effect.all([SDKCore, CurrentUser]);
+
+					const isAuthorized = userData.userPermissionLevel.isAdmin;
+
+					if (!userData.isLoggedIn || !isAuthorized) {
+						return yield* new DashboardAPIError({ error: 'Unauthorized' });
+					}
+
+					const tokenData = yield* sdk.REST_API.tokens.verify(tokenID);
+
+					if (!tokenData) {
+						return yield* new DashboardAPIError({ error: 'Token not found' });
+					}
+
+					const targetPerms = availablePermissionRanks.indexOf(tokenData.rank);
+					const userPerms = availablePermissionRanks.indexOf(userData.permissionLevel);
+
+					if (targetPerms >= userPerms) {
+						return yield* new DashboardAPIError({
+							error: 'Unauthorized - insufficient permissions to revoke this token',
+						});
+					}
+
+					yield* sdk.REST_API.tokens.delete({ tokenId: tokenID, userId: userID });
 
 					return {
 						message: 'Token deleted',

--- a/packages/studiocms/frontend/pages/studiocms_api/_handlers/dashboard/create.ts
+++ b/packages/studiocms/frontend/pages/studiocms_api/_handlers/dashboard/create.ts
@@ -9,7 +9,7 @@ import { HttpApiBuilder } from '@effect/platform';
 import { StudioCMSDashboardApiSpec } from '@withstudiocms/api-spec';
 import { AstroAPIContext, CurrentUser } from '@withstudiocms/api-spec/astro-context';
 import { DashboardAPIError } from '@withstudiocms/api-spec/dashboard';
-import type { AvailablePermissionRanks } from '@withstudiocms/auth-kit/types';
+import { availablePermissionRanks } from '@withstudiocms/auth-kit/types';
 import { appendSearchParamsToUrl } from '@withstudiocms/effect/effect';
 import type { APIContext } from 'astro';
 import { Effect, pipe } from 'effect';
@@ -21,17 +21,6 @@ import { sharedDBErrors, sharedNotifierErrors } from './_shared.js';
  * Check if the Dashboard API is enabled in the route configuration.
  */
 const dashboardAPIEnabled = routeConfig.dashboardAPIEnabled;
-
-/**
- * Array of available permission levels for the REST API. This is used to check user permissions when accessing secure endpoints, ensuring that only users with the appropriate rank can perform certain actions. The ranks are defined in ascending order of permissions, with 'unknown' having the least permissions and 'owner' having the most.
- */
-const permissionLevels: AvailablePermissionRanks[] = [
-	'unknown',
-	'visitor',
-	'editor',
-	'admin',
-	'owner',
-];
 
 /**
  * Type definition for the token object returned when creating a password reset link. This includes the token ID, the user ID it is associated with, and the token string itself. This type is used to ensure that the correct data structure is returned and handled when generating password reset links for users.
@@ -188,8 +177,8 @@ export const CreateHandlers = HttpApiBuilder.group(
 							return yield* new DashboardAPIError({ error: 'Invalid rank' });
 						}
 
-						const callerPerm = permissionLevels.indexOf(userData.permissionLevel);
-						const targetPerm = permissionLevels.indexOf(rank);
+						const callerPerm = availablePermissionRanks.indexOf(userData.permissionLevel);
+						const targetPerm = availablePermissionRanks.indexOf(rank);
 
 						if (targetPerm >= callerPerm) {
 							return yield* new DashboardAPIError({
@@ -325,9 +314,14 @@ export const CreateHandlers = HttpApiBuilder.group(
 
 						const { username, email, displayname, rank, originalUrl } = payload;
 
-						const userPerms = userData.userPermissionLevel;
+						if (!ValidRanks.has(rank) || rank === 'unknown') {
+							return yield* new DashboardAPIError({ error: 'Invalid rank' });
+						}
 
-						if (rank === 'owner' && !userPerms?.isOwner) {
+						const callerPerm = availablePermissionRanks.indexOf(userData.permissionLevel);
+						const targetPerm = availablePermissionRanks.indexOf(rank);
+
+						if (targetPerm >= callerPerm) {
 							return yield* new DashboardAPIError({
 								error: 'Unauthorized: insufficient permissions to assign target rank',
 							});

--- a/packages/studiocms/frontend/pages/studiocms_api/_handlers/dashboard/users.ts
+++ b/packages/studiocms/frontend/pages/studiocms_api/_handlers/dashboard/users.ts
@@ -7,7 +7,7 @@ import { HttpApiBuilder } from '@effect/platform';
 import { StudioCMSDashboardApiSpec } from '@withstudiocms/api-spec';
 import { CurrentUser } from '@withstudiocms/api-spec/astro-context';
 import { DashboardAPIError } from '@withstudiocms/api-spec/dashboard';
-import type { AvailablePermissionRanks } from '@withstudiocms/auth-kit/types';
+import { availablePermissionRanks } from '@withstudiocms/auth-kit/types';
 import { Effect } from 'effect';
 import { ValidRanks } from '#consts';
 import { sharedDBErrors, sharedNotifierErrors } from './_shared.js';
@@ -16,17 +16,6 @@ import { sharedDBErrors, sharedNotifierErrors } from './_shared.js';
  * Check if the Dashboard API is enabled in the route configuration.
  */
 const dashboardAPIEnabled = routeConfig.dashboardAPIEnabled;
-
-/**
- * Array of available permission levels for the REST API. This is used to check user permissions when accessing secure endpoints, ensuring that only users with the appropriate rank can perform certain actions. The ranks are defined in ascending order of permissions, with 'unknown' having the least permissions and 'owner' having the most.
- */
-const permissionLevels: AvailablePermissionRanks[] = [
-	'unknown',
-	'visitor',
-	'editor',
-	'admin',
-	'owner',
-];
 
 /**
  * Users Handlers for the Dashboard API
@@ -80,11 +69,11 @@ export const UsersHandlers = HttpApiBuilder.group(StudioCMSDashboardApiSpec, 'us
 						});
 					}
 
-					const userPerms = permissionLevels.indexOf(userData.permissionLevel);
-					const targetCurrentLevel = permissionLevels.indexOf(
+					const userPerms = availablePermissionRanks.indexOf(userData.permissionLevel);
+					const targetCurrentLevel = availablePermissionRanks.indexOf(
 						user.permissionsData?.rank || 'unknown'
 					);
-					const targetNewLevel = permissionLevels.indexOf(rank);
+					const targetNewLevel = availablePermissionRanks.indexOf(rank);
 
 					if (userPerms === -1 || targetCurrentLevel === -1 || targetNewLevel === -1) {
 						return yield* new DashboardAPIError({
@@ -203,8 +192,8 @@ export const UsersHandlers = HttpApiBuilder.group(StudioCMSDashboardApiSpec, 'us
 						});
 					}
 
-					const actorPerms = permissionLevels.indexOf(userData.permissionLevel);
-					const targetPerms = permissionLevels.indexOf(
+					const actorPerms = availablePermissionRanks.indexOf(userData.permissionLevel);
+					const targetPerms = availablePermissionRanks.indexOf(
 						targetUser.permissionsData?.rank || 'unknown'
 					);
 

--- a/packages/studiocms/frontend/pages/studiocms_api/_handlers/rest-api/v1/secure.ts
+++ b/packages/studiocms/frontend/pages/studiocms_api/_handlers/rest-api/v1/secure.ts
@@ -10,7 +10,10 @@ import {
 	CurrentRestAPIUser,
 	RestAPIError,
 } from '@withstudiocms/api-spec/rest-api';
-import type { AvailablePermissionRanks } from '@withstudiocms/auth-kit/types';
+import {
+	type AvailablePermissionRanks,
+	availablePermissionRanks,
+} from '@withstudiocms/auth-kit/types';
 import {
 	StudioCMSPageData,
 	StudioCMSPageDataCategories,
@@ -37,17 +40,6 @@ const StringArrayCodec = Schema.transform(Schema.String, Schema.Array(Schema.Str
  * Function that uses the String Array Schema to create a JSON.stringify like function for string arrays
  */
 const encodeStringArray = Schema.encode(StringArrayCodec);
-
-/**
- * Array of available permission levels for the REST API. This is used to check user permissions when accessing secure endpoints, ensuring that only users with the appropriate rank can perform certain actions. The ranks are defined in ascending order of permissions, with 'unknown' having the least permissions and 'owner' having the most.
- */
-const permissionLevels: AvailablePermissionRanks[] = [
-	'unknown',
-	'visitor',
-	'editor',
-	'admin',
-	'owner',
-];
 
 /**
  * REST API v1 Secure Handler
@@ -1488,8 +1480,8 @@ export const RestApiSecureHandler = HttpApiBuilder.group(
 						const { permissionsData } = existingUser;
 
 						const existingUserRank = permissionsData?.rank ?? 'unknown';
-						const existingUserRankIndex = permissionLevels.indexOf(existingUserRank);
-						const loggedInUserRankIndex = permissionLevels.indexOf(user.rank);
+						const existingUserRankIndex = availablePermissionRanks.indexOf(existingUserRank);
+						const loggedInUserRankIndex = availablePermissionRanks.indexOf(user.rank);
 
 						if (loggedInUserRankIndex <= existingUserRankIndex) {
 							return yield* new RestAPIError({
@@ -1556,17 +1548,17 @@ export const RestApiSecureHandler = HttpApiBuilder.group(
 						const { permissionsData } = existingUser;
 
 						const existingUserRank = permissionsData?.rank ?? 'unknown';
-						const existingUserRankIndex = permissionLevels.indexOf(existingUserRank);
-						const loggedInUserRankIndex = permissionLevels.indexOf(user.rank);
+						const existingUserRankIndex = availablePermissionRanks.indexOf(existingUserRank);
+						const loggedInUserRankIndex = availablePermissionRanks.indexOf(user.rank);
 
-						if (loggedInUserRankIndex < existingUserRankIndex) {
+						if (loggedInUserRankIndex <= existingUserRankIndex) {
 							return yield* new RestAPIError({
 								error: 'Unauthorized to update user with higher rank',
 							});
 						}
 
 						if (payload.rank) {
-							const payloadRankIndex = permissionLevels.indexOf(payload.rank);
+							const payloadRankIndex = availablePermissionRanks.indexOf(payload.rank);
 
 							if (loggedInUserRankIndex <= payloadRankIndex) {
 								return yield* new RestAPIError({
@@ -1712,10 +1704,10 @@ export const RestApiSecureHandler = HttpApiBuilder.group(
 							username,
 						};
 
-						const existingUserRankIndex = permissionLevels.indexOf(existingUserRank);
-						const loggedInUserRankIndex = permissionLevels.indexOf(user.rank);
+						const existingUserRankIndex = availablePermissionRanks.indexOf(existingUserRank);
+						const loggedInUserRankIndex = availablePermissionRanks.indexOf(user.rank);
 
-						if (loggedInUserRankIndex < existingUserRankIndex) {
+						if (loggedInUserRankIndex <= existingUserRankIndex) {
 							return yield* new RestAPIError({
 								error: 'Unauthorized to view user with higher rank',
 							});


### PR DESCRIPTION
This pull request introduces a new admin-level API token revocation endpoint and refactors permission rank handling across the codebase. The most important changes are grouped below:

- Closes: #1439 

### New Admin API Token Revocation Endpoint

* Added `adminApiTokensDelete` endpoint to allow admin users to revoke any user's API token, with additional permission checks and documentation. (`packages/@withstudiocms/api-spec/src/dashboard/routes/api-tokens.ts`, `packages/@withstudiocms/api-spec/src/dashboard/index.ts`, `.changeset/eighty-forks-attend.md`, [[1]](diffhunk://#diff-f0a444f834efdf9b7e3166dce6e02a0e98163993422b2b3ef6c2e8a2a700b1f9R58-R82) [[2]](diffhunk://#diff-63587212400ad22ce704be2132a526d5e0344877675f70190dbe4c04ddfbb170R47) [[3]](diffhunk://#diff-63587212400ad22ce704be2132a526d5e0344877675f70190dbe4c04ddfbb170L6-R6) [[4]](diffhunk://#diff-e0f29ef767c564fc3a77d35d24b4a5d8a47f9b3ff957dc76d6a22195ccd20337R1-R6)
* Introduced `AdminDeleteApiTokenPayload` schema for admin token revocation, including `userID` and enhanced documentation. (`packages/@withstudiocms/api-spec/src/dashboard/schemas.ts`, [packages/@withstudiocms/api-spec/src/dashboard/schemas.tsR297-R308](diffhunk://#diff-9d0110a2bd9b64bd05d7957570611fab26cb284b83b09e01afa4d50ba5adeeb5R297-R308))
* Implemented admin token revocation logic in the dashboard handler, enforcing permission checks and demo mode restrictions. (`packages/studiocms/frontend/pages/studiocms_api/_handlers/dashboard/apiTokens.ts`, [packages/studiocms/frontend/pages/studiocms_api/_handlers/dashboard/apiTokens.tsR86-R128](diffhunk://#diff-b41ebbc016b67dcd1d6327cfc6445309e289522355bc0bc9c1a5aca9586adb81R86-R128))
* Updated frontend user management page to use the new admin token revocation endpoint and handle responses appropriately. (`packages/studiocms/frontend/pages/[dashboard]/user-management/edit.astro`, [packages/studiocms/frontend/pages/[dashboard]/user-management/edit.astroL533-R577](diffhunk://#diff-073d8be21af24f78624a526658134ef0e6784dbdeffdbe22bb8762dbdbb4f739L533-R577))

### Permission Rank Handling Refactor

* Corrected the order of `availablePermissionRanks` to ascending (from 'unknown' to 'owner'), and replaced all local `permissionLevels` arrays with the shared constant. (`packages/@withstudiocms/auth-kit/src/types.ts`, [[1]](diffhunk://#diff-c33c7b623d9e4b58910e58d420c81f5e43f4290bce45867423170b09ba5a4dceL95-R95); various dashboard and REST API handlers, [[2]](diffhunk://#diff-23465c20b091eaab377e905edcf36d60948ceae6968b54746969fc7020c0d459L12-R12) [[3]](diffhunk://#diff-23465c20b091eaab377e905edcf36d60948ceae6968b54746969fc7020c0d459L25-L35) [[4]](diffhunk://#diff-23465c20b091eaab377e905edcf36d60948ceae6968b54746969fc7020c0d459L191-R181) [[5]](diffhunk://#diff-23465c20b091eaab377e905edcf36d60948ceae6968b54746969fc7020c0d459L328-R324) [[6]](diffhunk://#diff-eb79c164bfe8a3c130661d3fd9bc8dc00a773d61be42bbbc807bc5fbecf5d3d7L10-R10) [[7]](diffhunk://#diff-eb79c164bfe8a3c130661d3fd9bc8dc00a773d61be42bbbc807bc5fbecf5d3d7L20-L30) [[8]](diffhunk://#diff-eb79c164bfe8a3c130661d3fd9bc8dc00a773d61be42bbbc807bc5fbecf5d3d7L83-R76) [[9]](diffhunk://#diff-eb79c164bfe8a3c130661d3fd9bc8dc00a773d61be42bbbc807bc5fbecf5d3d7L206-R196) [[10]](diffhunk://#diff-c64b6bf2efb16c9ff62e853506124d0ad74d39b4f624cb4383fe58484ef0bcd7L13-R16) [[11]](diffhunk://#diff-c64b6bf2efb16c9ff62e853506124d0ad74d39b4f624cb4383fe58484ef0bcd7L41-L51) [[12]](diffhunk://#diff-c64b6bf2efb16c9ff62e853506124d0ad74d39b4f624cb4383fe58484ef0bcd7L1491-R1484); `.changeset/sweet-jars-remain.md`, [[13]](diffhunk://#diff-d3e338fd24fba35a490758aa5b875bdc255d79015f4cefb3354d5030adfc3abcR1-R5)

These changes improve security and maintainability by centralizing permission logic and enabling admin users to manage API tokens more effectively.

@coderabbitai ignore