### PR TITLE
fix(tsdown): Update tsdown configs across repo

### DIFF
--- a/packages/@studiocms/markdown-remark/tsdown.config.ts
+++ b/packages/@studiocms/markdown-remark/tsdown.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
 		{ from: 'src/styles/**/*.css', to: 'dist', flatten: false },
 		{ from: 'src/**/*.d.ts', to: 'dist', flatten: false },
 	],
-	external: ['studiocms:markdown-remark', 'studiocms:markdown-remark/user-components'],
-	inlineOnly: ['@types/hast', '@types/mdast', '@types/unist'],
+	deps: {
+		neverBundle: ['studiocms:markdown-remark', 'studiocms:markdown-remark/user-components'],
+		onlyAllowBundle: ['@types/hast', '@types/mdast', '@types/unist'],
+	},
 });

--- a/packages/@studiocms/upgrade/tsdown.config.ts
+++ b/packages/@studiocms/upgrade/tsdown.config.ts
@@ -4,5 +4,7 @@ export default defineConfig({
 	entry: 'src/index.ts',
 	clean: true,
 	treeshake: true,
-	inlineOnly: false,
+	deps: {
+		onlyAllowBundle: false,
+	},
 });

--- a/packages/create-studiocms/tsdown.config.ts
+++ b/packages/create-studiocms/tsdown.config.ts
@@ -4,5 +4,7 @@ export default defineConfig({
 	entry: 'src/index.ts',
 	clean: true,
 	treeshake: true,
-	inlineOnly: false,
+	deps: {
+		onlyAllowBundle: false,
+	},
 });


### PR DESCRIPTION
This pull request updates the dependency bundling configuration in several `tsdown.config.ts` files to use a new `deps` object format. The changes improve clarity and consistency in specifying which dependencies should be bundled or excluded during builds.

- Closes: #1458 

Dependency configuration refactor:

* Replaced the `external` and `inlineOnly` fields in `packages/@studiocms/markdown-remark/tsdown.config.ts` with a new `deps` object containing `neverBundle` and `onlyAllowBundle` arrays, clarifying the handling of external and bundled dependencies.
* Updated `packages/@studiocms/upgrade/tsdown.config.ts` and `packages/create-studiocms/tsdown.config.ts` to replace the `inlineOnly` field with a `deps` object containing `onlyAllowBundle`, aligning with the new configuration structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured build configuration across multiple packages to use a new unified object structure for managing bundle dependencies. Configuration changes consolidate related bundling settings under a nested deps object structure, replacing previous configuration options while maintaining equivalent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->