### PR TITLE
fix(studiocms): update peerDependencies and metadata

### DIFF
--- a/.changeset/honest-taxes-bathe.md
+++ b/.changeset/honest-taxes-bathe.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Fixes peerDependencies and associated metadata

--- a/packages/studiocms/package.json
+++ b/packages/studiocms/package.json
@@ -284,6 +284,7 @@
 	},
 	"peerDependencies": {
 		"@effect/platform": "catalog:effect",
+		"@effect/platform-node": "catalog:effect",
 		"@libsql/client": "catalog:kysely",
 		"astro": "catalog:min",
 		"effect": "catalog:effect",
@@ -291,8 +292,20 @@
 		"mysql2": "catalog:kysely"
 	},
 	"peerDependenciesMeta": {
+		"@effect/platform": {
+			"optional": false
+		},
+		"@effect/platform-node": {
+			"optional": false
+		},
 		"@libsql/client": {
 			"optional": true
+		},
+		"astro": {
+			"optional": false
+		},
+		"effect": {
+			"optional": false
 		},
 		"pg": {
 			"optional": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1099,6 +1099,9 @@ importers:
       '@effect/platform':
         specifier: catalog:effect
         version: 0.94.5(effect@3.19.19)
+      '@effect/platform-node':
+        specifier: catalog:effect
+        version: 0.104.1(@effect/cluster@0.56.1(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
       '@iconify-json/circle-flags':
         specifier: ^1.2.10
         version: 1.2.10


### PR DESCRIPTION
This pull request focuses on fixing and clarifying the `peerDependencies` and their metadata for the `studiocms` package. The main changes ensure that required peer dependencies are correctly listed and marked as non-optional, improving dependency management and compatibility.

Dependency metadata updates:

* Added `@effect/platform-node` as a required peer dependency in `package.json` and marked it as non-optional in `peerDependenciesMeta`.
* Updated `peerDependenciesMeta` to explicitly mark `@effect/platform`, `astro`, and `effect` as non-optional dependencies, ensuring they are required for consumers of the package.

Lockfile updates:

* Updated `pnpm-lock.yaml` to include the new `@effect/platform-node` dependency and its version, reflecting the changes in `package.json`.

Documentation:

* Added a changeset file describing the patch and clarifying the fixes to peer dependencies and metadata.

@coderabbitai ignore