### PR TITLE
fix(s3-storage): await authorization checks in S3ApiService methods

### DIFF
--- a/.changeset/social-mails-check.md
+++ b/.changeset/social-mails-check.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/s3-storage": patch
+---
+
+Fixes missing awaits in the Storage Manager

--- a/packages/@studiocms/s3-storage/src/s3-storage-manager.ts
+++ b/packages/@studiocms/s3-storage/src/s3-storage-manager.ts
@@ -197,7 +197,7 @@ export default class S3ApiService<C, R> implements StorageApiBuilderDefinition<C
 				'test',
 				'list',
 			];
-			if (authRequiredActions.includes(jsonBody.action) && !isAuthorized(type)) {
+			if (authRequiredActions.includes(jsonBody.action) && !(await isAuthorized(type))) {
 				return { data: { error: 'Unauthorized' }, status: 401 };
 			}
 
@@ -369,7 +369,7 @@ export default class S3ApiService<C, R> implements StorageApiBuilderDefinition<C
 
 	getPUT(type?: AuthorizationType): StorageAPIEndpointFn<C, R> {
 		return this.driver.handleEndpoint(async ({ getArrayBuffer, getHeader, isAuthorized }) => {
-			if (!isAuthorized(type)) {
+			if (!(await isAuthorized(type))) {
 				return { data: { error: 'Unauthorized' }, status: 401 };
 			}
 


### PR DESCRIPTION
This pull request addresses a bug in the S3 Storage Manager where authorization checks were missing `await`, potentially leading to incorrect authentication results. The fix ensures that all authorization checks are properly awaited, improving security and reliability.

Authentication improvements:

* Added missing `await` to the `isAuthorized` check for actions requiring authentication in the `S3ApiService` class within `s3-storage-manager.ts`, ensuring proper asynchronous authorization handling.
* Added missing `await` to the `isAuthorized` check in the `getPUT` method of `S3ApiService`, preventing unauthorized access due to premature evaluation.

Documentation:

* Added a changeset file `.changeset/social-mails-check.md` documenting the patch and the fix for missing awaits in the Storage Manager.

@coderabbitai ignore