### PR TITLE
fix(studiocms): enhance rank validation in createResetLink endpoint

### DIFF
--- a/.changeset/floppy-keys-shave.md
+++ b/.changeset/floppy-keys-shave.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Fixes createResetLink endpoints rank check

--- a/packages/studiocms/frontend/pages/studiocms_api/_handlers/dashboard/create.ts
+++ b/packages/studiocms/frontend/pages/studiocms_api/_handlers/dashboard/create.ts
@@ -90,13 +90,35 @@ export const CreateHandlers = HttpApiBuilder.group(
 							return yield* new DashboardAPIError({ error: 'Unauthorized' });
 						}
 
-						const [token, user] = yield* Effect.all([
-							sdk.resetTokenBucket.new(userId),
-							sdk.GET.users.byId(userId),
-						]);
+						const user = yield* sdk.GET.users.byId(userId);
 
-						if (!token || !user) {
+						if (!user) {
 							return yield* new DashboardAPIError({ error: 'User not found' });
+						}
+
+						const rank = user.permissionsData?.rank;
+
+						if (!rank) {
+							return yield* new DashboardAPIError({ error: 'User rank not found' });
+						}
+
+						if (!ValidRanks.has(rank) || rank === 'unknown') {
+							return yield* new DashboardAPIError({ error: 'Invalid rank' });
+						}
+
+						const callerPerm = availablePermissionRanks.indexOf(userData.permissionLevel);
+						const targetPerm = availablePermissionRanks.indexOf(rank);
+
+						if (targetPerm >= callerPerm) {
+							return yield* new DashboardAPIError({
+								error: 'Unauthorized: insufficient permissions to assign target rank',
+							});
+						}
+
+						const token = yield* sdk.resetTokenBucket.new(userId);
+
+						if (!token) {
+							return yield* new DashboardAPIError({ error: 'Failed to generate reset token' });
 						}
 
 						yield* notifier


### PR DESCRIPTION
This pull request addresses a permissions issue in the Studiocms "createResetLink" endpoint to ensure that only users with sufficient rank can generate reset links for other users. The main fixes involve adding proper rank validation and improving error handling for unauthorized actions.

**Permissions and Authorization Improvements:**

* Added a check to ensure the target user's rank is valid and not 'unknown' before proceeding with reset link creation (`create.ts`).
* Implemented logic to compare the caller's permission level with the target user's rank, preventing users from generating reset links for users with equal or higher rank (`create.ts`).
* Improved error messages for cases where the user rank is missing, invalid, or when the caller lacks sufficient permissions (`create.ts`).

**Token Generation and Error Handling:**

* Moved reset token generation to occur only after all permission checks pass, and added error handling for failed token generation (`create.ts`).

**Documentation:**

* Added a changeset documenting the patch and the rank check fix for the createResetLink endpoint (`.changeset/floppy-keys-shave.md`).

@coderabbitai ignore