### PR TITLE
fix(users): Prevent unauthorized modification of user notification preferences

### DIFF
--- a/.changeset/strict-socks-remain.md
+++ b/.changeset/strict-socks-remain.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Prevents unauthorized modification of user notification preferences

--- a/packages/studiocms/frontend/pages/studiocms_api/_handlers/dashboard/users.ts
+++ b/packages/studiocms/frontend/pages/studiocms_api/_handlers/dashboard/users.ts
@@ -277,6 +277,12 @@ export const UsersHandlers = HttpApiBuilder.group(StudioCMSDashboardApiSpec, 'us
 					});
 				}
 
+				if (id !== userData.user?.id && !userData.userPermissionLevel.isAdmin) {
+					return yield* new DashboardAPIError({
+						error: "Unauthorized: cannot modify another user's notification preferences",
+					});
+				}
+
 				const existingUser = yield* sdk.GET.users.byId(id);
 
 				if (!existingUser) {


### PR DESCRIPTION
This pull request introduces a patch to the `studiocms` package aimed at improving security around user notification preferences. The main change prevents unauthorized users from modifying notification settings for other users.

Security enhancements:

* Added a check in `dashboard/users.ts` to prevent non-admin users from modifying another user's notification preferences. If a user attempts this action, an unauthorized error is returned.
* Documented the change in `.changeset/strict-socks-remain.md` to clarify that unauthorized modification of user notification preferences is now prevented.

@coderabbitai ignore