### PR TITLE
fix(rest-api): Improve permission checks for user rank assignment

### DIFF
--- a/.changeset/gold-canyons-cough.md
+++ b/.changeset/gold-canyons-cough.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Improves permission checks for user ranks during user creation in the REST API endpoint

--- a/packages/studiocms/frontend/pages/studiocms_api/_handlers/rest-api/v1/secure.ts
+++ b/packages/studiocms/frontend/pages/studiocms_api/_handlers/rest-api/v1/secure.ts
@@ -1362,20 +1362,17 @@ export const RestApiSecureHandler = HttpApiBuilder.group(
 							});
 						}
 
-						if (newUserRank === 'owner' && rank !== 'owner') {
+						const callerPerm = availablePermissionRanks.indexOf(rank);
+						const targetPerm = availablePermissionRanks.indexOf(newUserRank);
+
+						if (targetPerm >= callerPerm) {
 							return yield* new RestAPIError({
-								error: 'Unauthorized to create user with owner rank',
+								error: 'Unauthorized: insufficient permissions to assign target rank',
 							});
 						}
 
 						if (!password) {
 							password = yield* sdk.UTIL.Generators.generateRandomPassword(12);
-						}
-
-						if (rank === 'admin' && newUserRank === 'owner') {
-							return yield* new RestAPIError({
-								error: 'Unauthorized to create user with owner rank',
-							});
 						}
 
 						const checkEmail = isValidEmail(email);


### PR DESCRIPTION
This pull request introduces a patch to improve permission checks in the user creation process for the REST API endpoint. The main change ensures that only users with sufficient rank can assign target ranks, preventing unauthorized privilege escalation.

Permission logic improvements:

* Updated the permission check in `secure.ts` to compare the indices of `rank` and `newUserRank` in `availablePermissionRanks`, ensuring callers cannot assign a rank equal to or higher than their own.
* Removed redundant and less comprehensive checks for assigning the 'owner' rank, consolidating the logic for clarity and security.

Documentation:

* Added a changeset describing the patch and its focus on improving permission checks for user ranks during user creation in the REST API endpoint. (.changeset/gold-canyons-cough.md)

@coderabbitai ignore
