### PR TITLE
fix(api): improve user filtering logic in RestApiSecureHandler

### DIFF
--- a/.changeset/itchy-tips-own.md
+++ b/.changeset/itchy-tips-own.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Fix user filtering logic in RestApiSecureHandler

--- a/packages/studiocms/frontend/pages/studiocms_api/_handlers/rest-api/v1/secure.ts
+++ b/packages/studiocms/frontend/pages/studiocms_api/_handlers/rest-api/v1/secure.ts
@@ -1636,19 +1636,24 @@ export const RestApiSecureHandler = HttpApiBuilder.group(
 							})
 						);
 
-						if (rank !== 'owner') {
-							data = data.filter((user) => user.rank !== 'owner');
-						}
+						const loggedInUserRankIndex = availablePermissionRanks.indexOf(user.rank);
+
+						data = data.filter((candidate) => {
+							const candidateRankIndex = availablePermissionRanks.indexOf(candidate.rank);
+							return loggedInUserRankIndex > candidateRankIndex;
+						});
 
 						if (name) {
-							data = data.filter((user) => user.name.toLowerCase().includes(name.toLowerCase()));
+							data = data.filter((candidate) =>
+								candidate.name.toLowerCase().includes(name.toLowerCase())
+							);
 						}
 						if (rank) {
-							data = data.filter((user) => user.rank === rank);
+							data = data.filter((candidate) => candidate.rank === rank);
 						}
 						if (username) {
-							data = data.filter((user) =>
-								user.username.toLowerCase().includes(username.toLowerCase())
+							data = data.filter((candidate) =>
+								candidate.username.toLowerCase().includes(username.toLowerCase())
 							);
 						}
 


### PR DESCRIPTION
This pull request addresses a bug in the user filtering logic within the `RestApiSecureHandler`, ensuring that users are filtered according to their permission ranks rather than just excluding owners. The update improves the accuracy and security of user data returned through the API.

User filtering improvements:

* Updated the filtering logic in `RestApiSecureHandler` to compare the logged-in user's rank against candidate users using the `availablePermissionRanks` array, ensuring only users with lower ranks are included.
* Refactored filtering conditions to use `candidate` instead of `user` for clarity and consistency throughout the code.

Bug fix documentation:

* Added a patch changeset file `.changeset/itchy-tips-own.md` describing the fix to user filtering logic in `RestApiSecureHandler`.

@coderabbitai ignore