### PR TITLE
fix(deps): correct now deprecated `onlyAllowBundle` to `onlyBundle` in tsdown configs

### DIFF
--- a/packages/@studiocms/markdown-remark/tsdown.config.ts
+++ b/packages/@studiocms/markdown-remark/tsdown.config.ts
@@ -11,6 +11,6 @@ export default defineConfig({
 	],
 	deps: {
 		neverBundle: [/^studiocms:markdown-remark/],
-		onlyAllowBundle: ['@types/hast', '@types/mdast', '@types/unist'],
+		onlyBundle: ['@types/hast', '@types/mdast', '@types/unist'],
 	},
 });

--- a/packages/@studiocms/upgrade/tsdown.config.ts
+++ b/packages/@studiocms/upgrade/tsdown.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
 	...sharedConfig,
 	entry: 'src/index.ts',
 	deps: {
-		onlyAllowBundle: false,
+		onlyBundle: false,
 	},
 });

--- a/packages/create-studiocms/tsdown.config.ts
+++ b/packages/create-studiocms/tsdown.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
 	...sharedConfig,
 	entry: 'src/index.ts',
 	deps: {
-		onlyAllowBundle: false,
+		onlyBundle: false,
 	},
 });


### PR DESCRIPTION
This pull request updates the dependency bundling configuration in several `tsdown.config.ts` files to use the new `onlyBundle` option instead of the deprecated `onlyAllowBundle` option. This change ensures compatibility with the latest version of the build tooling.

**Build configuration updates:**

* Replaced `onlyAllowBundle` with `onlyBundle` in the `deps` section of `tsdown.config.ts` for `@studiocms/markdown-remark`, `@studiocms/upgrade`, and `create-studiocms` packages to align with updated build tool conventions. [[1]](diffhunk://#diff-2be2d73b99a69e19d3922183d4605cde10b974cd0323606f900ecd6c5242b1c0L14-R14) [[2]](diffhunk://#diff-155c993458681f0f1611c8ba0535a7cc3e316910a556e070873bc6a51d47abfeL8-R8) [[3]](diffhunk://#diff-cfa4950a44c661b0c064a989b603e5f03d1de669dfa7236c566b26d0c9ee2dc1L8-R8)

@coderabbitai ignore