### PR TITLE
fix(deps): remove mysql2 from ignored dependencies list

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -70,7 +70,6 @@
     "vite",
     "vitest",
     "zod",
-    "mysql2",
     "astro",
     "@astrojs/node",
     "@astrojs/rss",


### PR DESCRIPTION
This pull request makes a minor update to the Renovate configuration by removing the `mysql2` package from the list of ignored dependencies.
- Closes: #1409 

@coderabbitai ignore