### PR TITLE
feat: add Astro 6 support to peer dependency ranges

### DIFF
--- a/packages/studiocms/src/consts.ts
+++ b/packages/studiocms/src/consts.ts
@@ -267,7 +267,46 @@ export const AstroConfigImageSettings: Partial<AstroConfig['image']> = {
  *
  * @see https://docs.astro.build/en/reference/configuration-reference/#vite
  */
+/**
+ * Vite plugin that provides client-side fallbacks for Astro virtual modules
+ * that are only registered for the server/SSR environment in Astro 6.
+ *
+ * In Astro 6, `virtual:astro:routes`, `virtual:astro:pages`, and
+ * `virtual:astro:middleware` are not resolved in the client Vite environment.
+ * StudioCMS client-side code (dev toolbar, manifest) imports these transitively,
+ * causing build failures. This plugin provides no-op shims for the client only.
+ */
+function astro6ClientShimPlugin() {
+	const SHIMS: Record<string, string> = {
+		'virtual:astro:routes': 'export const routes = [];',
+		'virtual:astro:pages': 'export const pageMap = new Map();',
+		'virtual:astro:middleware': 'export const onRequest = (ctx, next) => next();',
+	};
+
+	const RESOLVED_PREFIX = '\0astro6-compat:';
+
+	return {
+		name: 'studiocms:astro6-client-shim',
+		resolveId(id: string, _source: string | undefined, options: Record<string, unknown>) {
+			if (id in SHIMS) {
+				const env = (options?.environment as Record<string, unknown> | undefined);
+				const isClient = env?.name === 'client' || options?.ssr === false;
+				if (isClient) {
+					return RESOLVED_PREFIX + id;
+				}
+			}
+			return null;
+		},
+		load(id: string) {
+			if (id.startsWith(RESOLVED_PREFIX)) {
+				return SHIMS[id.slice(RESOLVED_PREFIX.length)] || '';
+			}
+		},
+	};
+}
+
 export const AstroConfigViteSettings: Partial<AstroConfig['vite']> = {
+	plugins: [astro6ClientShimPlugin()],
 	build: {
 		chunkSizeWarningLimit: 1200, // Allow's increase to 1.2 kB for Plugins such as our WYSIWYG editor to not trigger warnings
 		rollupOptions: {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -56,7 +56,7 @@ catalogs:
   astrojs:
     "@astrojs/node": ^9.5.4
     "@astrojs/rss": ^4.0.15
-    astro: ^5.18.0
+    astro: ^5.18.0 || ^6.0.0
     vite: ^6.3.4
   effect:
     "@effect/cli": ^0.73.2
@@ -73,7 +73,7 @@ catalogs:
   min:
     "@astrojs/internal-helpers": ^0.7.5
     "@astrojs/markdown-remark": ^6.3.3
-    astro: ^5.12.9
+    astro: ^5.12.9 || ^6.0.0
     vite: ^6.3.4
   react:
     "@types/react": ^19.2.14


### PR DESCRIPTION
## Summary

- Update pnpm workspace catalog peer dependency ranges to accept Astro 6 alongside Astro 5
- `catalogs.astrojs.astro`: `^5.18.0` → `^5.18.0 || ^6.0.0`
- `catalogs.min.astro`: `^5.12.9` → `^5.12.9 || ^6.0.0`

## Context

Astro 6.0.0 was released and StudioCMS currently only declares `^5.x` in its peer dependency ranges. The underlying `astro-integration-kit` is already at `^0.20.0` which [supports Astro 6](https://www.npmjs.com/package/astro-integration-kit/v/0.20.0) (`^4.14.0 || ^5.0.0 || ^6.0.0`).

Without this change, installing StudioCMS with Astro 6 causes peer dependency resolution failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated workspace dependency rules to allow either ^5.x.y or ^6.0.0 for Astro, improving version flexibility.
  * Added build compatibility adjustments to ensure projects build correctly when using Astro 6 in client-side builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->