### PR TITLE
chore(deps): add label for template dependencies in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -53,7 +53,8 @@
     {
       "groupName": "Template Dependencies",
       "matchManagers": ["npm"],
-      "matchFileNames": ["templates/*/package.json"]
+      "matchFileNames": ["templates/*/package.json"],
+      "labels": ["templates"]
     }
   ],
   "ignoreDeps": [

--- a/.github/workflows/ci-bot-changesets.yml
+++ b/.github/workflows/ci-bot-changesets.yml
@@ -24,7 +24,7 @@ jobs:
   renovate-effect:
     name: Update Renovate Effect PR
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'effect-deps')
+    if: contains(github.event.pull_request.labels.*.name, 'effect-deps') && !contains(github.event.pull_request.labels.*.name, 'templates')
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
This pull request introduces changes to improve label management and workflow execution for Renovate and CI processes. The main focus is to better categorize Renovate PRs related to templates and to prevent certain workflows from running on those PRs.

Label management improvements:

* Updated `.github/renovate.json` to automatically add a `templates` label to Renovate PRs that update dependencies in `templates/*/package.json`, making it easier to identify and filter these PRs.

Workflow execution control:

* Modified `.github/workflows/ci-bot-changesets.yml` so that the `renovate-effect` job will not run if the PR has the `templates` label, even if it also has the `effect-deps` label. This prevents unnecessary workflow runs for template-related dependency updates.

@coderabbitai ignore