### PR TITLE
fix: wrap Code.astro inline script in IIFE to fix top-level return error

### DIFF
--- a/packages/studiocms/frontend/components/shared/Code.astro
+++ b/packages/studiocms/frontend/components/shared/Code.astro
@@ -42,33 +42,35 @@ const id = __test_mode ? 'test-id' : Math.random().toString(36).substring(2, 9);
 <pre
 	class="scms-code-container scrollbar"><code id={id} class:list={["custom-code", (del || ins) ? 'diff' : '']} {...props} set:html={htmlCode} /></pre>
 <script is:inline define:vars={{ id: id }}>
-	const codesWithDiff = document.getElementById(id);
+	(function () {
+		const codesWithDiff = document.getElementById(id);
 
-	if (!codesWithDiff) return;
+		if (!codesWithDiff) return;
 
-	const code = codesWithDiff.classList.contains("diff");
+		const code = codesWithDiff.classList.contains("diff");
 
-	if (!code) return;
+		if (!code) return;
 
-	const linesInserted = codesWithDiff.getAttribute("data-lines-inserted");
-	const linesDeleted = codesWithDiff.getAttribute("data-lines-deleted");
+		const linesInserted = codesWithDiff.getAttribute("data-lines-inserted");
+		const linesDeleted = codesWithDiff.getAttribute("data-lines-deleted");
 
-	if (!linesInserted && !linesDeleted) return;
+		if (!linesInserted && !linesDeleted) return;
 
-	const parsedInsertedLines =
-		linesInserted?.split(",").map((line) => parseInt(line, 10)) || [];
-	const parsedDeletedLines =
-		linesDeleted?.split(",").map((line) => parseInt(line, 10)) || [];
+		const parsedInsertedLines =
+			linesInserted?.split(",").map((line) => parseInt(line, 10)) || [];
+		const parsedDeletedLines =
+			linesDeleted?.split(",").map((line) => parseInt(line, 10)) || [];
 
-	const codeLines = codesWithDiff.querySelectorAll(".line");
+		const codeLines = codesWithDiff.querySelectorAll(".line");
 
-	codeLines.forEach((line, index) => {
-		if (parsedInsertedLines.includes(index + 1)) {
-			line.classList.add("diff", "ins");
-		}
+		codeLines.forEach((line, index) => {
+			if (parsedInsertedLines.includes(index + 1)) {
+				line.classList.add("diff", "ins");
+			}
 
-		if (parsedDeletedLines.includes(index + 1)) {
-			line.classList.add("diff", "del");
-		}
-	});
+			if (parsedDeletedLines.includes(index + 1)) {
+				line.classList.add("diff", "del");
+			}
+		});
+	})();
 </script>


### PR DESCRIPTION
Fixes #1555

The `is:inline` script in Code.astro uses bare `return` statements for early exits, but since inline scripts get placed directly in a `<script>` tag in the HTML output, `return` outside a function body is a syntax error.

Wrapped the script body in an IIFE so the early returns work as intended.

-- saschabuehrle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code diff highlighting so inserted and deleted lines are consistently marked in code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->