### PR TITLE
Refactor CI by removing unused Zizmor security analysis job

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -19,7 +19,7 @@ env:
   NODE_OPTIONS: --max-old-space-size=6144
 
 jobs:
-  # Knip Reporter only supports pull requests at the moment 
+  # Knip Reporter only supports pull requests at the moment
   # (We are using a custom github action in the automation for github action alerts)
   lint-knip:
     name: Run Knip Linter and Report
@@ -33,18 +33,3 @@ jobs:
     secrets: inherit
     with:
       pre-knip-cmd: "pnpm ci:build"
-
-  security-zizmor:
-    name: Run Zizmor Actions Security Analysis
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Run zizmor
-        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2


### PR DESCRIPTION
This pull request removes the Zizmor Actions Security Analysis job from the CI workflow configuration. This means the security analysis step using Zizmor will no longer be run as part of the CI checks.

Unlocks: https://github.com/withstudiocms/studiocms/pull/1549

CI workflow updates:

* Removed the `security-zizmor` job from `.github/workflows/ci-checks.yml`, eliminating the Zizmor Actions Security Analysis from the CI pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a dedicated code-quality check to the continuous integration workflow.
  * Removed the previous security scanning job from the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->