### PR TITLE
Refactor TypeScript SDK paths and simplify component registry

### DIFF
--- a/.changeset/beige-lizards-cover.md
+++ b/.changeset/beige-lizards-cover.md
@@ -1,0 +1,5 @@
+---
+"@withstudiocms/component-registry": patch
+---
+
+Fixes component registry path resolution

--- a/.changeset/whole-clocks-say.md
+++ b/.changeset/whole-clocks-say.md
@@ -1,0 +1,5 @@
+---
+"studiocms": patch
+---
+
+Fixes Code component script, as well as i18n import logic

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
     },
     "vscode": {
       "settings": {
-        "typescript.tsdk": "node_modules/typescript/lib",
+        "js/ts.tsdk.path": "node_modules/typescript/lib",
         "editor.codeActionsOnSave": {
           "source.fixAll.biome": "explicit"
         },

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
     "astro-build.astro-vscode",
     "astro-build.houston",
     "biomejs.biome",
-    "eamodio.gitlens",
     "redhat.vscode-yaml",
     "ms-vscode-remote.remote-containers",
     "ms-azuretools.vscode-containers",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "editor.fontFamily": "Fira Code Retina, Menlo, Monaco, 'Courier New', monospace",
   "editor.fontLigatures": true,
   "editor.fontSize": 14.2,
@@ -24,7 +24,6 @@
   "[yaml]": {
     "editor.defaultFormatter": "redhat.vscode-yaml"
   },
-  "vitest.disableWorkspaceWarning": true,
   "knip.requireConfig": true,
   "knip.configFilePath": "./knip.config.ts",
   "knip.editor.exports.hover.includeImportLocationSnippet": true

--- a/packages/@withstudiocms/component-registry/src/registry/handler.ts
+++ b/packages/@withstudiocms/component-registry/src/registry/handler.ts
@@ -151,10 +151,14 @@ export const componentRegistryHandler = async (
 		Effect.gen(function* () {
 			// Decode and validate options using Effect's Schema
 			const {
-				config: { verbose = false, name, virtualId },
+				config: { verbose = false, name: preName, virtualId },
 				builtInComponents = {},
 				componentRegistry = {},
 			} = yield* Schema.decode(ComponentRegistryOptionsSchema)(opts);
+
+			const name = preName.includes('-component-registry')
+				? preName
+				: `${preName}-component-registry`;
 
 			// Fork a logger for the component registry
 			const logger = params.logger.fork(`${name}:component-registry`);

--- a/packages/@withstudiocms/component-registry/src/registry/handler.ts
+++ b/packages/@withstudiocms/component-registry/src/registry/handler.ts
@@ -2,9 +2,10 @@
 
 import { deepmerge, Effect, runEffect, Schema } from '@withstudiocms/effect';
 import { addVirtualImports } from '@withstudiocms/internal_helpers/astro-integration';
+import createPathResolver from '@withstudiocms/internal_helpers/pathResolver';
 import type { HookParameters } from 'astro';
 import type { ComponentRegistryEntry } from '../types.js';
-import { convertHyphensToUnderscores, integrationLogger, resolver } from '../utils.js';
+import { convertHyphensToUnderscores, integrationLogger } from '../utils.js';
 import {
 	buildAliasExports,
 	buildVirtualImport,
@@ -162,12 +163,11 @@ export const componentRegistryHandler = async (
 			// Log the start of the component registry setup
 			integrationLogger(logInfo, 'Setting up component registry...');
 
+			const { resolve } = createPathResolver(import.meta.url);
+			const { resolve: astroConfigResolve } = createPathResolver(params.config.root.pathname);
+
 			// Resolve necessary paths and registry
-			const [resolve, astroConfigResolve, registry] = yield* Effect.all([
-				resolver(import.meta.url),
-				resolver(params.config.root.pathname),
-				ComponentRegistry,
-			]);
+			const registry = yield* ComponentRegistry;
 
 			// Setup Components and Component Keys Arrays
 			const componentKeys: string[] = [];
@@ -217,12 +217,7 @@ export const componentRegistryHandler = async (
 					integrationLogger(logInfo, `Resolving path for component "${key}"...`);
 
 					// Use Effect's error handling instead of try/catch
-					const resolvedPath = yield* astroConfigResolve((fn) => fn(value)).pipe(
-						Effect.catchAll((error) => {
-							integrationLogger(logInfo, `Failed to resolve path for component "${key}": ${error}`);
-							return Effect.succeed(null); // Return null to indicate failure
-						})
-					);
+					const resolvedPath = astroConfigResolve(value);
 
 					// Check if the resolved path is empty
 					if (!resolvedPath) {
@@ -276,7 +271,7 @@ export const componentRegistryHandler = async (
 			}
 
 			// Resolve the virtual runtime import path
-			const virtualRuntimeImport = yield* resolve((fn) => fn('../runtime.js'));
+			const virtualRuntimeImport = resolve('../runtime.js');
 
 			addVirtualImports(params, {
 				name,

--- a/packages/@withstudiocms/component-registry/src/utils.ts
+++ b/packages/@withstudiocms/component-registry/src/utils.ts
@@ -1,7 +1,4 @@
-import { posix } from 'node:path';
-import { Effect } from '@withstudiocms/effect';
 import type { AstroIntegrationLogger } from 'astro';
-import { ComponentRegistryError } from './errors.js';
 
 /**
  * Options for configuring the logger.
@@ -93,36 +90,3 @@ export function dedent(str: string): string {
 	if (indent.length === 0) return lns.join('\n');
 	return lns.map((ln) => (ln.startsWith(indent) ? ln.slice(indent.length) : ln)).join('\n');
 }
-
-/**
- * Creates an Effect-based resolver function for resolving component paths.
- *
- * @param base - The base path used to initialize the resolver.
- * @returns An Effect-wrapped function that accepts a callback. The callback receives a `resolve` function,
- * which can be used to resolve component paths relative to the base. If an error occurs during resolution,
- * it is caught, logged to the console, and an Error object is returned with the original error as its cause.
- *
- * @example
- * const resolveEffect = resolver('/components');
- * const result = yield* resolveEffect((resolve) => resolve('Button'));
- */
-export const resolver = Effect.fn(function* (base: string) {
-	const isUrlBase = /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(base);
-
-	function _resolve(...path: string[]) {
-		if (isUrlBase) {
-			return new URL(path.join('/'), base).toString();
-		}
-
-		return posix.join(base, ...path);
-	}
-	return Effect.fn((fn: (resolve: (...path: Array<string>) => string) => string) =>
-		Effect.try({
-			try: () => fn(_resolve),
-			catch: (error) => {
-				console.error('Error occurred while resolving component:', error);
-				return new ComponentRegistryError({ message: 'Failed to resolve component', cause: error });
-			},
-		})
-	);
-});

--- a/packages/@withstudiocms/component-registry/test/utils.test.ts
+++ b/packages/@withstudiocms/component-registry/test/utils.test.ts
@@ -1,15 +1,12 @@
-import { Effect } from '@withstudiocms/effect';
 import * as allure from 'allure-js-commons';
 import type { AstroIntegrationLogger } from 'astro';
 import { describe, expect, test } from 'vitest';
-import type { ComponentRegistryError } from '../src/errors.js';
 import {
 	convertHyphensToUnderscores,
 	convertUnderscoresToHyphens,
 	dedent,
 	getIndent,
 	integrationLogger,
-	resolver,
 } from '../src/utils.js';
 import { createMockLogger, parentSuiteName, sharedTags } from './test-utils.js';
 
@@ -293,78 +290,6 @@ line 3`,
 			await ctx.parameter('converted', converted);
 
 			expect(converted).toBe(expected);
-		});
-	});
-});
-
-describe(parentSuiteName, () => {
-	const basePath = '/base/path';
-
-	test('Handler - resolver - returns Effect-wrapped resolver function that resolves paths correctly', async () => {
-		await allure.parentSuite(parentSuiteName);
-		await allure.suite(localSuiteName);
-		await allure.subSuite('resolver Tests');
-		await allure.tags(...sharedTags);
-
-		let resolveEffect: (
-			fn: (resolve: (...path: Array<string>) => string) => string
-		) => Effect.Effect.AsEffect<Effect.Effect<string, Error, never>>;
-
-		await allure.step('Create resolver Effect', async () => {
-			resolveEffect = await Effect.runPromise(resolver(basePath));
-			expect(typeof resolveEffect).toBe('function');
-		});
-
-		await allure.step('Resolve a path using the resolver Effect', async () => {
-			const result = await Effect.runPromise(
-				resolveEffect((resolve) => resolve('component.astro'))
-			);
-			expect(result).toBe('/base/path/component.astro');
-		});
-	});
-
-	test('Handler - resolver - Catches errors thrown in the callback and returns an Error', async () => {
-		await allure.parentSuite(parentSuiteName);
-		await allure.suite(localSuiteName);
-		await allure.subSuite('resolver Tests');
-		await allure.tags(...sharedTags);
-
-		await allure.step('Invoke resolver Effect with a callback that throws an error', async () => {
-			const errorMsg = 'Test error';
-			const resolveEffect = await Effect.runPromise(resolver(basePath));
-			const result = await Effect.runPromise(
-				Effect.exit(
-					resolveEffect(() => {
-						throw new Error(errorMsg);
-					})
-				)
-			);
-			expect(result._tag).toBe('Failure');
-
-			const resultData = result.toJSON() as any;
-
-			console.log(resultData);
-
-			expect((resultData.cause.failure as ComponentRegistryError).message).toBe(
-				'Failed to resolve component'
-			);
-			// @ts-expect-error - this is a test
-			expect((resultData.cause.failure as ComponentRegistryError).cause?.message).toBe(errorMsg);
-		});
-	});
-
-	test('Handler - resolver - passes correct resolve function to callback', async () => {
-		await allure.parentSuite(parentSuiteName);
-		await allure.suite(localSuiteName);
-		await allure.subSuite('resolver Tests');
-		await allure.tags(...sharedTags);
-
-		await allure.step('Get resolve function from resolver Effect and verify it works', async () => {
-			const resolveEffect = await Effect.runPromise(resolver(basePath));
-			const result = await Effect.runPromise(
-				resolveEffect((resolve) => resolve('foo', 'bar.astro'))
-			);
-			expect(result).toBe('/base/path/foo/bar.astro');
 		});
 	});
 });

--- a/packages/studiocms/frontend/components/shared/Code.astro
+++ b/packages/studiocms/frontend/components/shared/Code.astro
@@ -42,33 +42,35 @@ const id = __test_mode ? 'test-id' : Math.random().toString(36).substring(2, 9);
 <pre
 	class="scms-code-container scrollbar"><code id={id} class:list={["custom-code", (del || ins) ? 'diff' : '']} {...props} set:html={htmlCode} /></pre>
 <script is:inline define:vars={{ id: id }}>
-	const codesWithDiff = document.getElementById(id);
+	(function () {
+		const codesWithDiff = document.getElementById(id);
 
-	if (!codesWithDiff) return;
+		if (!codesWithDiff) return;
 
-	const code = codesWithDiff.classList.contains("diff");
+		const code = codesWithDiff.classList.contains("diff");
 
-	if (!code) return;
+		if (!code) return;
 
-	const linesInserted = codesWithDiff.getAttribute("data-lines-inserted");
-	const linesDeleted = codesWithDiff.getAttribute("data-lines-deleted");
+		const linesInserted = codesWithDiff.getAttribute("data-lines-inserted");
+		const linesDeleted = codesWithDiff.getAttribute("data-lines-deleted");
 
-	if (!linesInserted && !linesDeleted) return;
+		if (!linesInserted && !linesDeleted) return;
 
-	const parsedInsertedLines =
-		linesInserted?.split(",").map((line) => parseInt(line, 10)) || [];
-	const parsedDeletedLines =
-		linesDeleted?.split(",").map((line) => parseInt(line, 10)) || [];
+		const parsedInsertedLines =
+			linesInserted?.split(",").map((line) => parseInt(line, 10)) || [];
+		const parsedDeletedLines =
+			linesDeleted?.split(",").map((line) => parseInt(line, 10)) || [];
 
-	const codeLines = codesWithDiff.querySelectorAll(".line");
+		const codeLines = codesWithDiff.querySelectorAll(".line");
 
-	codeLines.forEach((line, index) => {
-		if (parsedInsertedLines.includes(index + 1)) {
-			line.classList.add("diff", "ins");
-		}
+		codeLines.forEach((line, index) => {
+			if (parsedInsertedLines.includes(index + 1)) {
+				line.classList.add("diff", "ins");
+			}
 
-		if (parsedDeletedLines.includes(index + 1)) {
-			line.classList.add("diff", "del");
-		}
-	});
+			if (parsedDeletedLines.includes(index + 1)) {
+				line.classList.add("diff", "del");
+			}
+		});
+	})();
 </script>

--- a/packages/studiocms/src/index.ts
+++ b/packages/studiocms/src/index.ts
@@ -10,11 +10,7 @@
 import { promises as fsP, writeFileSync } from 'node:fs';
 import studiocmsUi from '@studiocms/ui';
 import { componentRegistryHandler } from '@withstudiocms/component-registry';
-import {
-	configResolverBuilderEffect,
-	exists,
-	watchConfigFileBuilder,
-} from '@withstudiocms/config-utils';
+import { configResolverBuilder, exists, watchConfigFileBuilder } from '@withstudiocms/config-utils';
 import { Effect, runEffect } from '@withstudiocms/effect';
 import {
 	addIntegrationArray,
@@ -101,7 +97,7 @@ export const studiocms = (): AstroIntegration => {
 	});
 
 	// Config Resolver Builder
-	const configResolver = configResolverBuilderEffect({
+	const configResolver = configResolverBuilder({
 		configPaths,
 		label: name,
 		effectSchema: StudioCMSOptionsSchema,

--- a/packages/studiocms/src/virtuals/i18n/config.ts
+++ b/packages/studiocms/src/virtuals/i18n/config.ts
@@ -23,11 +23,7 @@ export const defaultLang: UiTranslationKey = config.defaultLocale;
  *
  * - These translations are also converted to a client-friendly format.
  */
-export const baseServerTranslations = (
-	await import('./translations/en.json', {
-		with: { type: 'json' },
-	})
-).default;
+export const baseServerTranslations = (await import('./translations/en.json')).default;
 
 /**
  * Represents a translation record for StudioCMS.

--- a/packages/studiocms/test/__snapshots__/components.test.ts.snap
+++ b/packages/studiocms/test/__snapshots__/components.test.ts.snap
@@ -3,35 +3,37 @@
 exports[`studiocms Package Tests > Components Container tests - Code component 1`] = `
 "<pre class="scms-code-container scrollbar"><code id="test-id" class="custom-code"><span class="line">export const hello = &quot;hello world!&quot;;</span></code></pre> <script>(function(){const id = "test-id";
 
-	const codesWithDiff = document.getElementById(id);
+	(function () {
+		const codesWithDiff = document.getElementById(id);
 
-	if (!codesWithDiff) return;
+		if (!codesWithDiff) return;
 
-	const code = codesWithDiff.classList.contains("diff");
+		const code = codesWithDiff.classList.contains("diff");
 
-	if (!code) return;
+		if (!code) return;
 
-	const linesInserted = codesWithDiff.getAttribute("data-lines-inserted");
-	const linesDeleted = codesWithDiff.getAttribute("data-lines-deleted");
+		const linesInserted = codesWithDiff.getAttribute("data-lines-inserted");
+		const linesDeleted = codesWithDiff.getAttribute("data-lines-deleted");
 
-	if (!linesInserted && !linesDeleted) return;
+		if (!linesInserted && !linesDeleted) return;
 
-	const parsedInsertedLines =
-		linesInserted?.split(",").map((line) => parseInt(line, 10)) || [];
-	const parsedDeletedLines =
-		linesDeleted?.split(",").map((line) => parseInt(line, 10)) || [];
+		const parsedInsertedLines =
+			linesInserted?.split(",").map((line) => parseInt(line, 10)) || [];
+		const parsedDeletedLines =
+			linesDeleted?.split(",").map((line) => parseInt(line, 10)) || [];
 
-	const codeLines = codesWithDiff.querySelectorAll(".line");
+		const codeLines = codesWithDiff.querySelectorAll(".line");
 
-	codeLines.forEach((line, index) => {
-		if (parsedInsertedLines.includes(index + 1)) {
-			line.classList.add("diff", "ins");
-		}
+		codeLines.forEach((line, index) => {
+			if (parsedInsertedLines.includes(index + 1)) {
+				line.classList.add("diff", "ins");
+			}
 
-		if (parsedDeletedLines.includes(index + 1)) {
-			line.classList.add("diff", "del");
-		}
-	});
+			if (parsedDeletedLines.includes(index + 1)) {
+				line.classList.add("diff", "del");
+			}
+		});
+	})();
 })();</script>"
 `;
 

--- a/playground/package.json
+++ b/playground/package.json
@@ -25,7 +25,6 @@
     "@studiocms/blog": "workspace:*",
     "@studiocms/md": "workspace:*",
     "@studiocms/wysiwyg": "workspace:*",
-    "@studiocms/s3-storage": "workspace:*",
     "astro": "catalog:astrojs-current",
     "kysely-turso": "catalog:kysely",
     "studiocms": "workspace:*",

--- a/playground/studiocms.config.mts
+++ b/playground/studiocms.config.mts
@@ -1,13 +1,13 @@
 import blog from '@studiocms/blog';
 import md from '@studiocms/md';
-import studiocmsS3Storage from '@studiocms/s3-storage';
 import wysiwyg from '@studiocms/wysiwyg';
 import { defineStudioCMSConfig } from 'studiocms/config';
+// import studiocmsS3Storage from '@studiocms/s3-storage';
 
 export default defineStudioCMSConfig({
 	dbStartPage: false,
 	verbose: true,
-	storageManager: studiocmsS3Storage(),
+	// storageManager: studiocmsS3Storage(),
 	plugins: [md(), blog(), wysiwyg()],
 	features: {
 		webVitals: false,

--- a/playground/studiocms.config.mts
+++ b/playground/studiocms.config.mts
@@ -2,12 +2,10 @@ import blog from '@studiocms/blog';
 import md from '@studiocms/md';
 import wysiwyg from '@studiocms/wysiwyg';
 import { defineStudioCMSConfig } from 'studiocms/config';
-// import studiocmsS3Storage from '@studiocms/s3-storage';
 
 export default defineStudioCMSConfig({
 	dbStartPage: false,
 	verbose: true,
-	// storageManager: studiocmsS3Storage(),
 	plugins: [md(), blog(), wysiwyg()],
 	features: {
 		webVitals: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1305,9 +1305,6 @@ importers:
       '@studiocms/md':
         specifier: workspace:*
         version: link:../packages/@studiocms/md
-      '@studiocms/s3-storage':
-        specifier: workspace:*
-        version: link:../packages/@studiocms/s3-storage
       '@studiocms/wysiwyg':
         specifier: workspace:*
         version: link:../packages/@studiocms/wysiwyg


### PR DESCRIPTION
This pull request includes several dependency and codebase cleanups, as well as improvements to path resolution and configuration handling in the component registry. The most significant changes are the removal of the custom `resolver` utility in favor of a new `createPathResolver`, simplification of the code and tests, and removal of the S3 storage integration from the playground. There are also minor updates to VSCode settings and the frontend code component.

- Closes #1555 
- Overrides #1556

**Component Registry Refactoring and Path Resolution:**

* Replaced the custom `resolver` utility with a new `createPathResolver` from `@withstudiocms/internal_helpers/pathResolver`, simplifying path resolution logic in `handler.ts` and removing the old implementation and related tests (`packages/@withstudiocms/component-registry/src/registry/handler.ts`, `packages/@withstudiocms/component-registry/src/utils.ts`, `packages/@withstudiocms/component-registry/test/utils.test.ts`). [[1]](diffhunk://#diff-b633a8dda1f6e9c157e11061c783d370659fec05a43484895bc9f28424e6c43fR5-R8) [[2]](diffhunk://#diff-b633a8dda1f6e9c157e11061c783d370659fec05a43484895bc9f28424e6c43fL153-R174) [[3]](diffhunk://#diff-b633a8dda1f6e9c157e11061c783d370659fec05a43484895bc9f28424e6c43fL220-R224) [[4]](diffhunk://#diff-b633a8dda1f6e9c157e11061c783d370659fec05a43484895bc9f28424e6c43fL279-R278) [[5]](diffhunk://#diff-768ae7899734a46056416f4d3bd68df108684fe33d3de5b3284359f3fb0812e0L1-L4) [[6]](diffhunk://#diff-768ae7899734a46056416f4d3bd68df108684fe33d3de5b3284359f3fb0812e0L96-L128) [[7]](diffhunk://#diff-bae0ccda7e6026a007e2d3e094a74c93288d57367a76bd09a9fbe3406a941d6fL1-L12) [[8]](diffhunk://#diff-bae0ccda7e6026a007e2d3e094a74c93288d57367a76bd09a9fbe3406a941d6fL299-L370)

* Improved naming logic for the registry name to ensure it always includes `-component-registry` (`packages/@withstudiocms/component-registry/src/registry/handler.ts`).

**Configuration and Integration Cleanup:**

* Updated the StudioCMS config resolver to use the non-Effect version (`configResolverBuilder`) and removed the S3 storage manager integration from the playground and related dependency files (`packages/studiocms/src/index.ts`, `playground/package.json`, `playground/studiocms.config.mts`, `pnpm-lock.yaml`). [[1]](diffhunk://#diff-acb4a7fbcdb98537d3c96596b3f5ba1d778913c6b1d764de60dd9a2c761b4c46L13-R13) [[2]](diffhunk://#diff-acb4a7fbcdb98537d3c96596b3f5ba1d778913c6b1d764de60dd9a2c761b4c46L104-R100) [[3]](diffhunk://#diff-d10bbb79c9085774698fcb9f1badf3ac65912cbde60d22eeb18259814ab89688L28) [[4]](diffhunk://#diff-be12308e5770dad638e5ae48b618289c7ea71ea8ec57e124c854c1919646bbd4L3-L10) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1308-L1310)

**VSCode and Dev Environment Updates:**

* Updated VSCode settings to use the new `js/ts.tsdk.path` key and removed unused or deprecated settings and extensions (`.devcontainer/devcontainer.json`, `.vscode/settings.json`, `.vscode/extensions.json`). [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L20-R20) [[2]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L2-R2) [[3]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L27) [[4]](diffhunk://#diff-c16655a98a3ee89a7636a59c59a72b0e93649e3a1e947327cfc43a1336b4e912L6)

**Frontend and Test Improvements:**

* Wrapped the code-diff highlighting logic in an IIFE for better encapsulation and updated related tests and snapshots (`packages/studiocms/frontend/components/shared/Code.astro`, `packages/studiocms/test/__snapshots__/components.test.ts.snap`). [[1]](diffhunk://#diff-080413ce4fb5434999ab9b6bb3fdef1b3ac81dec6ca586e107dbd0353e1ffc82R45) [[2]](diffhunk://#diff-080413ce4fb5434999ab9b6bb3fdef1b3ac81dec6ca586e107dbd0353e1ffc82R75) [[3]](diffhunk://#diff-16cfa0455f44567bf9041b6f1ab7e975caab23c1d9e735f15b54c1d35c1e7572R6) [[4]](diffhunk://#diff-16cfa0455f44567bf9041b6f1ab7e975caab23c1d9e735f15b54c1d35c1e7572R36)

**Miscellaneous:**

* Simplified the dynamic import for server translations in the i18n config (`packages/studiocms/src/virtuals/i18n/config.ts`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved component registry path resolution for more reliable component loading.
  - Fixed Code component script execution and translation import handling.
  - Simplified configuration and translation loading for improved compatibility.

- **Chores**
  - Removed S3 storage from the playground configuration.
  - Updated development environment TypeScript settings and extension recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->