### PR TITLE
Ensure test pages deployment includes cname

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -103,6 +103,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: allure/report
           publish_dir: ./allure-report
+          cname: tests.studiocms.dev
 
       # Only upload Allure report results to Github if we are a push to main
       - name: Upload Allure History to Github Branch

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![NPM Version](https://img.shields.io/npm/v/studiocms)](https://npm.im/studiocms)
 [![Formatted with Biome](https://img.shields.io/badge/Formatted_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev/)
 [![GitHub Actions Workflow Status (ci-testing.yml) ](https://img.shields.io/github/actions/workflow/status/withstudiocms/studiocms/ci-testing.yml?branch=main&logo=githubactions&logoColor=%232088FF&label=repo%20tests)](https://github.com/withstudiocms/studiocms/actions/workflows/ci-testing.yml)
-[![Allure Test Report](https://img.shields.io/badge/Allure%20Test%20Report-blue?style=flat)](https://tests.studiocms.dev/allure-reports/main/studiocms-tests/latest)
+[![Allure Test Report](https://img.shields.io/badge/Allure%20Test%20Report-blue?style=flat)](https://tests.studiocms.dev/)
 [![Crowdin](https://badges.crowdin.net/studiocms/localized.svg)](https://crowdin.com/project/studiocms)
 [![pkg.pr.new](https://img.shields.io/badge/Continuous%20Releases-pkg.pr.new-8A2BE2?logo=pkgsrc&logoColor=FFF)](https://pkg.pr.new/~/withstudiocms/studiocms)
 [![Built with Astro](https://astro.badg.es/v2/built-with-astro/tiny.svg)](https://astro.build)


### PR DESCRIPTION
This pull request makes a small update to the CI workflow configuration. The change sets a custom domain name for the Allure report deployment.

- [`.github/workflows/ci-testing.yml`](diffhunk://#diff-82af06888290ef31d154541fdc86514e682a9b9c656353a226e1d3eed32fef0aR106): Added the `cname` parameter with the value `tests.studiocms.dev` to configure a custom domain for the Allure report.

@coderabbitai ignore