### PR TITLE
chore: add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it
+privately rather than opening a public issue.
+
+Please include as much of the following information as possible:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce, or a proof-of-concept if you have one
+- The affected version(s) or commit hash
+- Any suggested mitigation
+
+You can expect an initial response within a few days. Please do not disclose
+the vulnerability publicly until it has been addressed.
+
+## Supported Versions
+
+Only the latest released version is actively maintained. If you're on an older
+version, please try to reproduce the issue on the latest before reporting.
+


### PR DESCRIPTION
Adds a security policy at `SECURITY.md`. This is what GitHub's community-standards checklist looks for, and it gives external reporters a clear path for private disclosure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security policy with guidance for privately reporting vulnerabilities.
  * Documented recommended report details, response expectations, and responsible disclosure practices.
  * Clarified supported-version policy and reproduction guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->