### PR TITLE
Tweak tsdown configuration for internal helpers

### DIFF
--- a/packages/@withstudiocms/internal_helpers/tsdown.config.ts
+++ b/packages/@withstudiocms/internal_helpers/tsdown.config.ts
@@ -5,4 +5,7 @@ export default defineConfig({
 	...sharedConfig,
 	entry: 'src/**/*.ts',
 	unbundle: true,
+	deps: {
+		onlyBundle: ["@types/mdast", "@types/unist"],
+	},
 });

--- a/packages/@withstudiocms/internal_helpers/tsdown.config.ts
+++ b/packages/@withstudiocms/internal_helpers/tsdown.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
 	entry: 'src/**/*.ts',
 	unbundle: true,
 	deps: {
-		onlyBundle: ["@types/mdast", "@types/unist"],
+		onlyBundle: ['@types/mdast', '@types/unist'],
 	},
 });


### PR DESCRIPTION
This pull request makes a configuration update to the TypeScript build process for the `@withstudiocms/internal_helpers` package. The main change is ensuring that only specific type dependencies are bundled, which can help reduce bundle size and avoid unnecessary dependencies in the output.

- Closes: #1608 

Dependency bundling:

* Updated `tsdown.config.ts` to bundle only the `@types/mdast` and `@types/unist` type dependencies by adding them to the `onlyBundle` list within the `deps` configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package build handling for type-related dependencies.
  * No user-visible functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->