### PR TITLE
Fix LSP warnings in SDK

### DIFF
--- a/.changeset/silly-trains-bow.md
+++ b/.changeset/silly-trains-bow.md
@@ -1,0 +1,5 @@
+---
+"@withstudiocms/sdk": patch
+---
+
+Fix Effect LSP diagnostic warnings

--- a/packages/@withstudiocms/sdk/src/modules/diffTracking/index.ts
+++ b/packages/@withstudiocms/sdk/src/modules/diffTracking/index.ts
@@ -358,6 +358,7 @@ export const SDKDiffTrackingModule = Effect.gen(function* () {
 	 * @param diffId - The ID of the diff tracking record to retrieve.
 	 * @returns The diff tracking record with parsed metadata, or undefined if not found.
 	 */
+	// @effect-diagnostics-next-line effectSucceedWithVoid:off
 	const _getSingleDiffById = Effect.fn((diffId: string) =>
 		_selectDiffById(diffId).pipe(
 			Effect.flatMap((diffOrNull) =>

--- a/packages/@withstudiocms/sdk/src/modules/get/index.ts
+++ b/packages/@withstudiocms/sdk/src/modules/get/index.ts
@@ -1,3 +1,4 @@
+/** @effect-diagnostics effectSucceedWithVoid:skip-file */
 import { Effect, type ParseResult, Schema } from '@withstudiocms/effect';
 import type { DBCallbackFailure } from '@withstudiocms/kysely/client';
 import type { DatabaseError } from '@withstudiocms/kysely/core/errors';


### PR DESCRIPTION
This pull request introduces minor updates to improve diagnostics handling in the SDK modules. The main changes are:

- Closes: #1612 

Diagnostics and Linting:

* Added a file-level directive to skip the `effectSucceedWithVoid` diagnostic in `get/index.ts`, which suppresses related lint warnings for the entire file.
* Added an inline directive to suppress the `effectSucceedWithVoid` diagnostic for the `_getSingleDiffById` function in `diffTracking/index.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Effect language-server diagnostic warnings in the SDK.
  * No changes to runtime behavior, database operations, or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->