### PR TITLE
Fix WYSIWYG LSP errors

### DIFF
--- a/.changeset/cyan-teeth-throw.md
+++ b/.changeset/cyan-teeth-throw.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/wysiwyg": patch
+---
+
+Introduce proper RequestError typeing to prevent javascript error class leaking

--- a/.changeset/cyan-teeth-throw.md
+++ b/.changeset/cyan-teeth-throw.md
@@ -2,4 +2,4 @@
 "@studiocms/wysiwyg": patch
 ---
 
-Introduce proper RequestError typeing to prevent javascript error class leaking
+Use a tagged RequestError type to prevent generic JavaScript Error leakage

--- a/packages/@studiocms/wysiwyg/src/routes/store.ts
+++ b/packages/@studiocms/wysiwyg/src/routes/store.ts
@@ -4,6 +4,7 @@ import {
 	Cause,
 	createEffectAPIRoutes,
 	createJsonResponse,
+	Data,
 	Effect,
 	genLogger,
 	OptionsResponse,
@@ -27,6 +28,8 @@ const POSTJsonSchema = <S extends Schema.Struct<any>>(schema: S) =>
 		data: Schema.mutable(schema),
 	});
 
+export class RequestError extends Data.TaggedError("RequestError")<{ message: string }>{}
+
 /**
  * Parses and validates the JSON body of a POST request using a provided schema.
  *
@@ -47,12 +50,12 @@ const parsePOSTJsonRequest = <S extends Schema.Struct<any>>(context: APIContext,
 		Effect.mapError((error) => {
 			console.error('Error parsing POST JSON request:', error);
 			if (error instanceof ParseResult.ParseError) {
-				return new Error(`Invalid request data: ${error.message}`);
+				return new RequestError({ message: `Invalid request data: ${error.message}` });
 			}
 			if (error instanceof Cause.UnknownException) {
-				return new Error(`Unknown error occurred: ${error.message}`);
+				return new RequestError({ message: `Unknown error occurred: ${error.message}` });
 			}
-			return new Error('Failed to parse request data: Unknown error');
+			return new RequestError({ message: 'Failed to parse request data: Unknown error' });
 		})
 	);
 

--- a/packages/@studiocms/wysiwyg/src/routes/store.ts
+++ b/packages/@studiocms/wysiwyg/src/routes/store.ts
@@ -28,7 +28,7 @@ const POSTJsonSchema = <S extends Schema.Struct<any>>(schema: S) =>
 		data: Schema.mutable(schema),
 	});
 
-export class RequestError extends Data.TaggedError("RequestError")<{ message: string }>{}
+export class RequestError extends Data.TaggedError('RequestError')<{ message: string }> {}
 
 /**
  * Parses and validates the JSON body of a POST request using a provided schema.


### PR DESCRIPTION
This pull request introduces improved error handling for POST JSON requests by adding a properly typed `RequestError` class to prevent leaking generic JavaScript error classes. The changes ensure that all errors related to request parsing are consistently wrapped in the new `RequestError` type.

- Closes: #1611 

**Error handling improvements:**

* Introduced a new `RequestError` class extending `Data.TaggedError` to provide a strongly-typed error for request parsing failures in `store.ts`. [[1]](diffhunk://#diff-f2df9ca36448c0c7eb0840d7f15de8decd3f15262948bef345ff6343aea03122R31-R32) [[2]](diffhunk://#diff-007df7e0a1e6c16ebf47e40f1195e5be0fc166d8e0ddc10b9a52ffe512429becR1-R5)
* Updated the error mapping in `parsePOSTJsonRequest` to wrap all errors in the new `RequestError` type instead of using the generic `Error` class.

**Type system integration:**

* Added `Data` to the imports in `store.ts` to support the new error type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid or malformed content submissions.
  * Standardized request errors to provide clearer, more consistent messages without exposing internal JavaScript error details.
  * Added tagged request error typing to improve consistency of error reporting for failed POST JSON parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->