### PR TITLE
Update JSDoc for S3 storage plugin

### DIFF
--- a/.changeset/sparkly-lizards-tease.md
+++ b/.changeset/sparkly-lizards-tease.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/s3-storage": patch
+---
+
+Correct jsdocs note about which endpoints require authorization.

--- a/packages/@studiocms/s3-storage/src/s3-storage-manager.ts
+++ b/packages/@studiocms/s3-storage/src/s3-storage-manager.ts
@@ -156,7 +156,7 @@ const generateUrlMetadata = ({ publicEndpoint, bucketName, client }: S3ClientInt
  *
  * PUT requests are used for direct file uploads with the file key specified in the `x-storage-key` header.
  *
- * Most operations require authorization except for `resolveUrl` and `publicUrl` which are publicly accessible.
+ * Most operations require authorization except for `resolveUrl`, `download` and `publicUrl` which are publicly accessible.
  *
  * @example
  * ```typescript


### PR DESCRIPTION
This pull request updates the documentation for the `@studiocms/s3-storage` package to clarify which endpoints require authorization. The main change corrects the JSDoc comments to accurately reflect that the `download` endpoint, in addition to `resolveUrl` and `publicUrl`, is publicly accessible.

Documentation updates:

* Updated the JSDoc comment in `s3-storage-manager.ts` to state that `resolveUrl`, `download`, and `publicUrl` endpoints are publicly accessible, clarifying previous documentation.
* Added a changeset file to document the patch and describe the correction to the jsdocs note about endpoint authorization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which storage endpoints support public access.
  * Corrected the release note describing authorization requirements.

* **Chores**
  * Prepared a patch release for the S3 storage package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->