### PR TITLE
Refine test conditions for improved accuracy

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -87,9 +87,9 @@ jobs:
       - name: Run Tests & Code Coverage
         run: pnpm ci:test
 
-      # Only run on PRs
+      # Only run on PRs that are from our org (no forks)
       - name: Report Allure results
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.repo.full_name, 'withstudiocms/')
         uses: allure-framework/allure-action@bd0373251ed3f1c5ac9aa44ac86ed40d839b3094 # v0.8.0
         with:
           report-directory: "./allure-report"


### PR DESCRIPTION
This pull request updates the CI workflow to ensure Allure test reports are only generated for pull requests originating from the main organization, not from forks. This improves security by preventing secrets exposure to external contributors.

CI workflow security:

* [`.github/workflows/ci-testing.yml`](diffhunk://#diff-82af06888290ef31d154541fdc86514e682a9b9c656353a226e1d3eed32fef0aL90-R92): Modified the condition for running the "Report Allure results" step so that it only executes on pull requests where the source repository is under the `withstudiocms` organization, preventing it from running on PRs from forks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Allure test result reporting is now limited to pull requests from approved project repositories.
  * Pull requests from other repositories will no longer run this reporting step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->