### PR TITLE
Integrate OAuth processing with new client structure and providers

### DIFF
--- a/.changeset/tired-drinks-shop.md
+++ b/.changeset/tired-drinks-shop.md
@@ -1,0 +1,5 @@
+---
+"@withstudiocms/internal_helpers": patch
+---
+
+Fix crypto exports

--- a/.changeset/vast-zoos-lick.md
+++ b/.changeset/vast-zoos-lick.md
@@ -1,0 +1,5 @@
+---
+"@studiocms/oauth": minor
+---
+
+Integrate now deprecated arctic code into package to handle all oauth processing

--- a/packages/@studiocms/oauth/package.json
+++ b/packages/@studiocms/oauth/package.json
@@ -71,7 +71,7 @@
   },
   "type": "module",
   "dependencies": {
-    "arctic": "catalog:"
+    "@withstudiocms/internal_helpers": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/@studiocms/oauth/src/auth0/impl.ts
+++ b/packages/@studiocms/oauth/src/auth0/impl.ts
@@ -2,9 +2,9 @@ import { getSecret } from 'astro:env/server';
 import { Session, User, VerifyEmail } from 'studiocms:auth/lib';
 import { StudioCMSRoutes } from 'studiocms:lib';
 import { SDKCore } from 'studiocms:sdk';
-import { Auth0, generateCodeVerifier, generateState } from 'arctic';
 import { Effect, genLogger, Platform, pipe, Schema } from 'studiocms/effect';
 import { getCookie, getUrlParam, ValidateAuthCodeError } from 'studiocms/oAuthUtils';
+import { Auth0, generateCodeVerifier, generateState } from '../internal/index.js';
 import { OAuthService } from '../service.js';
 import { handleExistingOAuthAccount, handleNewOAuthUser, handleOAuthLinking } from '../shared.js';
 

--- a/packages/@studiocms/oauth/src/discord/impl.ts
+++ b/packages/@studiocms/oauth/src/discord/impl.ts
@@ -2,9 +2,9 @@ import { getSecret } from 'astro:env/server';
 import { Session, User, VerifyEmail } from 'studiocms:auth/lib';
 import { StudioCMSRoutes } from 'studiocms:lib';
 import { SDKCore } from 'studiocms:sdk';
-import { Discord, generateCodeVerifier, generateState } from 'arctic';
 import { Effect, genLogger, Platform, Schema } from 'studiocms/effect';
 import { getCookie, getUrlParam, ValidateAuthCodeError } from 'studiocms/oAuthUtils';
+import { Discord, generateCodeVerifier, generateState } from '../internal/index.js';
 import { OAuthService } from '../service.js';
 import { handleExistingOAuthAccount, handleNewOAuthUser, handleOAuthLinking } from '../shared.js';
 

--- a/packages/@studiocms/oauth/src/github/impl.ts
+++ b/packages/@studiocms/oauth/src/github/impl.ts
@@ -2,9 +2,9 @@ import { getSecret } from 'astro:env/server';
 import { Session, User, VerifyEmail } from 'studiocms:auth/lib';
 import { StudioCMSRoutes } from 'studiocms:lib';
 import { SDKCore } from 'studiocms:sdk';
-import { GitHub, generateState } from 'arctic';
 import { Effect, genLogger, Platform, Schema } from 'studiocms/effect';
 import { getCookie, getUrlParam, ValidateAuthCodeError } from 'studiocms/oAuthUtils';
+import { GitHub, generateState } from '../internal/index.js';
 import { OAuthService } from '../service.js';
 import { handleExistingOAuthAccount, handleNewOAuthUser, handleOAuthLinking } from '../shared.js';
 

--- a/packages/@studiocms/oauth/src/google/impl.ts
+++ b/packages/@studiocms/oauth/src/google/impl.ts
@@ -2,9 +2,9 @@ import { getSecret } from 'astro:env/server';
 import { Session, User, VerifyEmail } from 'studiocms:auth/lib';
 import { StudioCMSRoutes } from 'studiocms:lib';
 import { SDKCore } from 'studiocms:sdk';
-import { Google, generateCodeVerifier, generateState } from 'arctic';
 import { Effect, genLogger, Platform, Schema } from 'studiocms/effect';
 import { getCookie, getUrlParam, ValidateAuthCodeError } from 'studiocms/oAuthUtils';
+import { Google, generateCodeVerifier, generateState } from '../internal/index.js';
 import { OAuthService } from '../service.js';
 import { handleExistingOAuthAccount, handleNewOAuthUser, handleOAuthLinking } from '../shared.js';
 

--- a/packages/@studiocms/oauth/src/internal/client.ts
+++ b/packages/@studiocms/oauth/src/internal/client.ts
@@ -1,0 +1,135 @@
+import type { OAuth2Tokens } from './oauth2.js';
+import { createS256CodeChallenge } from './oauth2.js';
+import {
+	createOAuth2Request,
+	encodeBasicCredentials,
+	sendTokenRequest,
+	sendTokenRevocationRequest,
+} from './request.js';
+
+export class OAuth2Client {
+	public clientId: string;
+
+	private clientPassword: string | null;
+	private redirectURI: string | null;
+
+	constructor(clientId: string, clientPassword: string | null, redirectURI: string | null) {
+		this.clientId = clientId;
+		this.clientPassword = clientPassword;
+		this.redirectURI = redirectURI;
+	}
+
+	public createAuthorizationURL(
+		authorizationEndpoint: string,
+		state: string,
+		scopes: string[]
+	): URL {
+		const url = new URL(authorizationEndpoint);
+		url.searchParams.set('response_type', 'code');
+		url.searchParams.set('client_id', this.clientId);
+		if (this.redirectURI !== null) {
+			url.searchParams.set('redirect_uri', this.redirectURI);
+		}
+		url.searchParams.set('state', state);
+		if (scopes.length > 0) {
+			url.searchParams.set('scope', scopes.join(' '));
+		}
+		return url;
+	}
+
+	public createAuthorizationURLWithPKCE(
+		authorizationEndpoint: string,
+		state: string,
+		codeChallengeMethod: CodeChallengeMethod,
+		codeVerifier: string,
+		scopes: string[]
+	): URL {
+		const url = new URL(authorizationEndpoint);
+		url.searchParams.set('response_type', 'code');
+		url.searchParams.set('client_id', this.clientId);
+		if (this.redirectURI !== null) {
+			url.searchParams.set('redirect_uri', this.redirectURI);
+		}
+		url.searchParams.set('state', state);
+		if (codeChallengeMethod === CodeChallengeMethod.S256) {
+			const codeChallenge = createS256CodeChallenge(codeVerifier);
+			url.searchParams.set('code_challenge_method', 'S256');
+			url.searchParams.set('code_challenge', codeChallenge);
+		} else if (codeChallengeMethod === CodeChallengeMethod.Plain) {
+			url.searchParams.set('code_challenge_method', 'plain');
+			url.searchParams.set('code_challenge', codeVerifier);
+		}
+		if (scopes.length > 0) {
+			url.searchParams.set('scope', scopes.join(' '));
+		}
+		return url;
+	}
+
+	public async validateAuthorizationCode(
+		tokenEndpoint: string,
+		code: string,
+		codeVerifier: string | null
+	): Promise<OAuth2Tokens> {
+		const body = new URLSearchParams();
+		body.set('grant_type', 'authorization_code');
+		body.set('code', code);
+		if (this.redirectURI !== null) {
+			body.set('redirect_uri', this.redirectURI);
+		}
+		if (codeVerifier !== null) {
+			body.set('code_verifier', codeVerifier);
+		}
+		if (this.clientPassword === null) {
+			body.set('client_id', this.clientId);
+		}
+		const request = createOAuth2Request(tokenEndpoint, body);
+		if (this.clientPassword !== null) {
+			const encodedCredentials = encodeBasicCredentials(this.clientId, this.clientPassword);
+			request.headers.set('Authorization', `Basic ${encodedCredentials}`);
+		}
+		const tokens = await sendTokenRequest(request);
+		return tokens;
+	}
+
+	public async refreshAccessToken(
+		tokenEndpoint: string,
+		refreshToken: string,
+		scopes: string[]
+	): Promise<OAuth2Tokens> {
+		const body = new URLSearchParams();
+		body.set('grant_type', 'refresh_token');
+		body.set('refresh_token', refreshToken);
+		if (this.clientPassword === null) {
+			body.set('client_id', this.clientId);
+		}
+		if (scopes.length > 0) {
+			body.set('scope', scopes.join(' '));
+		}
+		const request = createOAuth2Request(tokenEndpoint, body);
+		if (this.clientPassword !== null) {
+			const encodedCredentials = encodeBasicCredentials(this.clientId, this.clientPassword);
+			request.headers.set('Authorization', `Basic ${encodedCredentials}`);
+		}
+		const tokens = await sendTokenRequest(request);
+		return tokens;
+	}
+
+	public async revokeToken(tokenRevocationEndpoint: string, token: string): Promise<void> {
+		const body = new URLSearchParams();
+		body.set('token', token);
+		if (this.clientPassword === null) {
+			body.set('client_id', this.clientId);
+		}
+		const request = createOAuth2Request(tokenRevocationEndpoint, body);
+		if (this.clientPassword !== null) {
+			const encodedCredentials = encodeBasicCredentials(this.clientId, this.clientPassword);
+			request.headers.set('Authorization', `Basic ${encodedCredentials}`);
+		}
+		await sendTokenRevocationRequest(request);
+	}
+}
+
+export enum CodeChallengeMethod {
+	S256 = 0,
+	Plain = 1,
+}

--- a/packages/@studiocms/oauth/src/internal/index.ts
+++ b/packages/@studiocms/oauth/src/internal/index.ts
@@ -1,0 +1,17 @@
+export { CodeChallengeMethod, OAuth2Client } from './client.js';
+export { generateCodeVerifier, generateState, OAuth2Tokens } from './oauth2.js';
+export { decodeIdToken } from './oidc.js';
+export { Auth0 } from './providers/auth0.js';
+export { Authentik } from './providers/authentik.js';
+export { Discord } from './providers/discord.js';
+export { Gitea } from './providers/gitea.js';
+export { GitHub } from './providers/github.js';
+export { GitLab } from './providers/gitlab.js';
+export { Google } from './providers/google.js';
+export { Slack } from './providers/slack.js';
+export {
+	ArcticFetchError,
+	OAuth2RequestError,
+	UnexpectedErrorResponseBodyError,
+	UnexpectedResponseError,
+} from './request.js';

--- a/packages/@studiocms/oauth/src/internal/oauth2.ts
+++ b/packages/@studiocms/oauth/src/internal/oauth2.ts
@@ -1,0 +1,81 @@
+import * as sha2 from '@withstudiocms/internal_helpers/crypto/sha2';
+import * as encoding from '@withstudiocms/internal_helpers/encoding';
+
+export class OAuth2Tokens {
+	public data: object;
+
+	constructor(data: object) {
+		this.data = data;
+	}
+
+	public tokenType(): string {
+		if ('token_type' in this.data && typeof this.data.token_type === 'string') {
+			return this.data.token_type;
+		}
+		throw new Error("Missing or invalid 'token_type' field");
+	}
+
+	public accessToken(): string {
+		if ('access_token' in this.data && typeof this.data.access_token === 'string') {
+			return this.data.access_token;
+		}
+		throw new Error("Missing or invalid 'access_token' field");
+	}
+
+	public accessTokenExpiresInSeconds(): number {
+		if ('expires_in' in this.data && typeof this.data.expires_in === 'number') {
+			return this.data.expires_in;
+		}
+		throw new Error("Missing or invalid 'expires_in' field");
+	}
+
+	public accessTokenExpiresAt(): Date {
+		return new Date(Date.now() + this.accessTokenExpiresInSeconds() * 1000);
+	}
+
+	public hasRefreshToken(): boolean {
+		return 'refresh_token' in this.data && typeof this.data.refresh_token === 'string';
+	}
+
+	public refreshToken(): string {
+		if ('refresh_token' in this.data && typeof this.data.refresh_token === 'string') {
+			return this.data.refresh_token;
+		}
+		throw new Error("Missing or invalid 'refresh_token' field");
+	}
+
+	public hasScopes(): boolean {
+		return 'scope' in this.data && typeof this.data.scope === 'string';
+	}
+
+	public scopes(): string[] {
+		if ('scope' in this.data && typeof this.data.scope === 'string') {
+			return this.data.scope.split(' ');
+		}
+		throw new Error("Missing or invalid 'scope' field");
+	}
+
+	public idToken(): string {
+		if ('id_token' in this.data && typeof this.data.id_token === 'string') {
+			return this.data.id_token;
+		}
+		throw new Error("Missing or invalid field 'id_token'");
+	}
+}
+
+export function createS256CodeChallenge(codeVerifier: string): string {
+	const codeChallengeBytes = sha2.sha256(new TextEncoder().encode(codeVerifier));
+	return encoding.encodeBase64urlNoPadding(codeChallengeBytes);
+}
+
+export function generateCodeVerifier(): string {
+	const randomValues = new Uint8Array(32);
+	crypto.getRandomValues(randomValues);
+	return encoding.encodeBase64urlNoPadding(randomValues);
+}
+
+export function generateState(): string {
+	const randomValues = new Uint8Array(32);
+	crypto.getRandomValues(randomValues);
+	return encoding.encodeBase64urlNoPadding(randomValues);
+}

--- a/packages/@studiocms/oauth/src/internal/oidc.ts
+++ b/packages/@studiocms/oauth/src/internal/oidc.ts
@@ -1,0 +1,11 @@
+import * as jwt from '@withstudiocms/internal_helpers/jwt';
+
+export function decodeIdToken(idToken: string): object {
+	try {
+		return jwt.decodeJWT(idToken);
+	} catch (e) {
+		throw new Error('Invalid ID token', {
+			cause: e,
+		});
+	}
+}

--- a/packages/@studiocms/oauth/src/internal/providers/auth0.ts
+++ b/packages/@studiocms/oauth/src/internal/providers/auth0.ts
@@ -1,0 +1,54 @@
+import { CodeChallengeMethod, OAuth2Client } from '../client.js';
+
+import type { OAuth2Tokens } from '../oauth2.js';
+
+export class Auth0 {
+	private authorizationEndpoint: string;
+	private tokenEndpoint: string;
+	private tokenRevocationEndpoint: string;
+
+	private client: OAuth2Client;
+
+	constructor(domain: string, clientId: string, clientSecret: string | null, redirectURI: string) {
+		this.authorizationEndpoint = `https://${domain}/authorize`;
+		this.tokenEndpoint = `https://${domain}/oauth/token`;
+		this.tokenRevocationEndpoint = `https://${domain}/oauth/revoke`;
+		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
+	}
+	public createAuthorizationURL(state: string, codeVerifier: string | null, scopes: string[]): URL {
+		let url: URL;
+		if (codeVerifier !== null) {
+			url = this.client.createAuthorizationURLWithPKCE(
+				this.authorizationEndpoint,
+				state,
+				CodeChallengeMethod.S256,
+				codeVerifier,
+				scopes
+			);
+		} else {
+			url = this.client.createAuthorizationURL(this.authorizationEndpoint, state, scopes);
+		}
+		return url;
+	}
+
+	public async validateAuthorizationCode(
+		code: string,
+		codeVerifier: string | null
+	): Promise<OAuth2Tokens> {
+		const tokens = await this.client.validateAuthorizationCode(
+			this.tokenEndpoint,
+			code,
+			codeVerifier
+		);
+		return tokens;
+	}
+
+	public async refreshAccessToken(refreshToken: string): Promise<OAuth2Tokens> {
+		const tokens = await this.client.refreshAccessToken(this.tokenEndpoint, refreshToken, []);
+		return tokens;
+	}
+
+	public async revokeToken(token: string): Promise<void> {
+		await this.client.revokeToken(this.tokenRevocationEndpoint, token);
+	}
+}

--- a/packages/@studiocms/oauth/src/internal/providers/authentik.ts
+++ b/packages/@studiocms/oauth/src/internal/providers/authentik.ts
@@ -1,0 +1,50 @@
+import { CodeChallengeMethod, OAuth2Client } from '../client.js';
+import type { OAuth2Tokens } from '../oauth2.js';
+import { joinURIAndPath } from '../request.js';
+
+export class Authentik {
+	private authorizationEndpoint: string;
+	private tokenEndpoint: string;
+	private tokenRevocationEndpoint: string;
+
+	private client: OAuth2Client;
+
+	constructor(baseURL: string, clientId: string, clientSecret: string | null, redirectURI: string) {
+		this.authorizationEndpoint = joinURIAndPath(baseURL, '/application/o/authorize/');
+		this.tokenEndpoint = joinURIAndPath(baseURL, '/application/o/token/');
+		this.tokenRevocationEndpoint = joinURIAndPath(baseURL, '/application/o/revoke/');
+		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
+	}
+
+	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+		const url = this.client.createAuthorizationURLWithPKCE(
+			this.authorizationEndpoint,
+			state,
+			CodeChallengeMethod.S256,
+			codeVerifier,
+			scopes
+		);
+		return url;
+	}
+
+	public async validateAuthorizationCode(
+		code: string,
+		codeVerifier: string
+	): Promise<OAuth2Tokens> {
+		const tokens = await this.client.validateAuthorizationCode(
+			this.tokenEndpoint,
+			code,
+			codeVerifier
+		);
+		return tokens;
+	}
+
+	public async refreshAccessToken(refreshToken: string): Promise<OAuth2Tokens> {
+		const tokens = await this.client.refreshAccessToken(this.tokenEndpoint, refreshToken, []);
+		return tokens;
+	}
+
+	public async revokeToken(token: string): Promise<void> {
+		await this.client.revokeToken(this.tokenRevocationEndpoint, token);
+	}
+}

--- a/packages/@studiocms/oauth/src/internal/providers/discord.ts
+++ b/packages/@studiocms/oauth/src/internal/providers/discord.ts
@@ -1,0 +1,48 @@
+import { CodeChallengeMethod, OAuth2Client } from '../client.js';
+
+import type { OAuth2Tokens } from '../oauth2.js';
+
+const authorizationEndpoint = 'https://discord.com/oauth2/authorize';
+const tokenEndpoint = 'https://discord.com/api/oauth2/token';
+const tokenRevocationEndpoint = 'https://discord.com/api/oauth2/token/revoke';
+
+export class Discord {
+	private client: OAuth2Client;
+
+	constructor(clientId: string, clientSecret: string | null, redirectURI: string) {
+		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
+	}
+
+	public createAuthorizationURL(state: string, codeVerifier: string | null, scopes: string[]): URL {
+		let url: URL;
+		if (codeVerifier !== null) {
+			url = this.client.createAuthorizationURLWithPKCE(
+				authorizationEndpoint,
+				state,
+				CodeChallengeMethod.S256,
+				codeVerifier,
+				scopes
+			);
+		} else {
+			url = this.client.createAuthorizationURL(authorizationEndpoint, state, scopes);
+		}
+		return url;
+	}
+
+	public async validateAuthorizationCode(
+		code: string,
+		codeVerifier: string | null
+	): Promise<OAuth2Tokens> {
+		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, codeVerifier);
+		return tokens;
+	}
+
+	public async refreshAccessToken(refreshToken: string): Promise<OAuth2Tokens> {
+		const tokens = await this.client.refreshAccessToken(tokenEndpoint, refreshToken, []);
+		return tokens;
+	}
+
+	public async revokeToken(token: string): Promise<void> {
+		await this.client.revokeToken(tokenRevocationEndpoint, token);
+	}
+}

--- a/packages/@studiocms/oauth/src/internal/providers/gitea.ts
+++ b/packages/@studiocms/oauth/src/internal/providers/gitea.ts
@@ -1,0 +1,44 @@
+import { CodeChallengeMethod, OAuth2Client } from '../client.js';
+import type { OAuth2Tokens } from '../oauth2.js';
+import { joinURIAndPath } from '../request.js';
+
+export class Gitea {
+	private authorizationEndpoint: string;
+	private tokenEndpoint: string;
+
+	private client: OAuth2Client;
+
+	constructor(baseURL: string, clientId: string, clientSecret: string | null, redirectURI: string) {
+		this.authorizationEndpoint = joinURIAndPath(baseURL, '/login/oauth/authorize');
+		this.tokenEndpoint = joinURIAndPath(baseURL, '/login/oauth/access_token');
+		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
+	}
+
+	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+		const url = this.client.createAuthorizationURLWithPKCE(
+			this.authorizationEndpoint,
+			state,
+			CodeChallengeMethod.S256,
+			codeVerifier,
+			scopes
+		);
+		return url;
+	}
+
+	public async validateAuthorizationCode(
+		code: string,
+		codeVerifier: string
+	): Promise<OAuth2Tokens> {
+		const tokens = await this.client.validateAuthorizationCode(
+			this.tokenEndpoint,
+			code,
+			codeVerifier
+		);
+		return tokens;
+	}
+
+	public async refreshAccessToken(refreshToken: string): Promise<OAuth2Tokens> {
+		const tokens = await this.client.refreshAccessToken(this.tokenEndpoint, refreshToken, []);
+		return tokens;
+	}
+}

--- a/packages/@studiocms/oauth/src/internal/providers/github.ts
+++ b/packages/@studiocms/oauth/src/internal/providers/github.ts
@@ -1,0 +1,100 @@
+import { OAuth2Tokens } from '../oauth2.js';
+import {
+	ArcticFetchError,
+	createOAuth2Request,
+	createOAuth2RequestError,
+	encodeBasicCredentials,
+	UnexpectedErrorResponseBodyError,
+	UnexpectedResponseError,
+} from '../request.js';
+
+const authorizationEndpoint = 'https://github.com/login/oauth/authorize';
+const tokenEndpoint = 'https://github.com/login/oauth/access_token';
+
+export class GitHub {
+	private clientId: string;
+	private clientSecret: string;
+	private redirectURI: string | null;
+
+	constructor(clientId: string, clientSecret: string, redirectURI: string | null) {
+		this.clientId = clientId;
+		this.clientSecret = clientSecret;
+		this.redirectURI = redirectURI;
+	}
+
+	public createAuthorizationURL(state: string, scopes: string[]): URL {
+		const url = new URL(authorizationEndpoint);
+		url.searchParams.set('response_type', 'code');
+		url.searchParams.set('client_id', this.clientId);
+		url.searchParams.set('state', state);
+		if (scopes.length > 0) {
+			url.searchParams.set('scope', scopes.join(' '));
+		}
+		if (this.redirectURI !== null) {
+			url.searchParams.set('redirect_uri', this.redirectURI);
+		}
+		return url;
+	}
+
+	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+		const body = new URLSearchParams();
+		body.set('grant_type', 'authorization_code');
+		body.set('code', code);
+		if (this.redirectURI !== null) {
+			body.set('redirect_uri', this.redirectURI);
+		}
+		const request = createOAuth2Request(tokenEndpoint, body);
+		const encodedCredentials = encodeBasicCredentials(this.clientId, this.clientSecret);
+		request.headers.set('Authorization', `Basic ${encodedCredentials}`);
+		const tokens = await sendTokenRequest(request);
+		return tokens;
+	}
+
+	public async refreshAccessToken(refreshToken: string): Promise<OAuth2Tokens> {
+		const body = new URLSearchParams();
+		body.set('grant_type', 'refresh_token');
+		body.set('refresh_token', refreshToken);
+		const request = createOAuth2Request(tokenEndpoint, body);
+		const encodedCredentials = encodeBasicCredentials(this.clientId, this.clientSecret);
+		request.headers.set('Authorization', `Basic ${encodedCredentials}`);
+		const tokens = await sendTokenRequest(request);
+		return tokens;
+	}
+}
+
+async function sendTokenRequest(request: Request): Promise<OAuth2Tokens> {
+	let response: Response;
+	try {
+		response = await fetch(request);
+	} catch (e) {
+		throw new ArcticFetchError(e);
+	}
+
+	if (response.status !== 200) {
+		if (response.body !== null) {
+			await response.body.cancel();
+		}
+		throw new UnexpectedResponseError(response.status);
+	}
+
+	let data: unknown;
+	try {
+		data = await response.json();
+	} catch {
+		throw new UnexpectedResponseError(response.status);
+	}
+	if (typeof data !== 'object' || data === null) {
+		throw new UnexpectedErrorResponseBodyError(response.status, data);
+	}
+	if ('error' in data && typeof data.error === 'string') {
+		let error: Error;
+		try {
+			error = createOAuth2RequestError(data);
+		} catch {
+			throw new UnexpectedErrorResponseBodyError(response.status, data);
+		}
+		throw error;
+	}
+	const tokens = new OAuth2Tokens(data);
+	return tokens;
+}

--- a/packages/@studiocms/oauth/src/internal/providers/gitlab.ts
+++ b/packages/@studiocms/oauth/src/internal/providers/gitlab.ts
@@ -1,0 +1,37 @@
+import { OAuth2Client } from '../client.js';
+import type { OAuth2Tokens } from '../oauth2.js';
+import { joinURIAndPath } from '../request.js';
+
+export class GitLab {
+	private authorizationEndpoint: string;
+	private tokenEndpoint: string;
+	private tokenRevocationEndpoint: string;
+
+	private client: OAuth2Client;
+
+	constructor(baseURL: string, clientId: string, clientSecret: string | null, redirectURI: string) {
+		this.authorizationEndpoint = joinURIAndPath(baseURL, '/oauth/authorize');
+		this.tokenEndpoint = joinURIAndPath(baseURL, '/oauth/token');
+		this.tokenRevocationEndpoint = joinURIAndPath(baseURL, '/oauth/revoke');
+		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
+	}
+
+	public createAuthorizationURL(state: string, scopes: string[]): URL {
+		const url = this.client.createAuthorizationURL(this.authorizationEndpoint, state, scopes);
+		return url;
+	}
+
+	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+		const tokens = await this.client.validateAuthorizationCode(this.tokenEndpoint, code, null);
+		return tokens;
+	}
+
+	public async refreshAccessToken(refreshToken: string): Promise<OAuth2Tokens> {
+		const tokens = await this.client.refreshAccessToken(this.tokenEndpoint, refreshToken, []);
+		return tokens;
+	}
+
+	public async revokeToken(token: string): Promise<void> {
+		await this.client.revokeToken(this.tokenRevocationEndpoint, token);
+	}
+}

--- a/packages/@studiocms/oauth/src/internal/providers/google.ts
+++ b/packages/@studiocms/oauth/src/internal/providers/google.ts
@@ -1,0 +1,43 @@
+import { CodeChallengeMethod, OAuth2Client } from '../client.js';
+
+import type { OAuth2Tokens } from '../oauth2.js';
+
+const authorizationEndpoint = 'https://accounts.google.com/o/oauth2/v2/auth';
+const tokenEndpoint = 'https://oauth2.googleapis.com/token';
+const tokenRevocationEndpoint = 'https://oauth2.googleapis.com/revoke';
+
+export class Google {
+	private client: OAuth2Client;
+
+	constructor(clientId: string, clientSecret: string, redirectURI: string) {
+		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
+	}
+
+	public createAuthorizationURL(state: string, codeVerifier: string, scopes: string[]): URL {
+		const url = this.client.createAuthorizationURLWithPKCE(
+			authorizationEndpoint,
+			state,
+			CodeChallengeMethod.S256,
+			codeVerifier,
+			scopes
+		);
+		return url;
+	}
+
+	public async validateAuthorizationCode(
+		code: string,
+		codeVerifier: string
+	): Promise<OAuth2Tokens> {
+		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, codeVerifier);
+		return tokens;
+	}
+
+	public async refreshAccessToken(refreshToken: string): Promise<OAuth2Tokens> {
+		const tokens = await this.client.refreshAccessToken(tokenEndpoint, refreshToken, []);
+		return tokens;
+	}
+
+	public async revokeToken(token: string): Promise<void> {
+		await this.client.revokeToken(tokenRevocationEndpoint, token);
+	}
+}

--- a/packages/@studiocms/oauth/src/internal/providers/slack.ts
+++ b/packages/@studiocms/oauth/src/internal/providers/slack.ts
@@ -1,0 +1,24 @@
+import { OAuth2Client } from '../client.js';
+
+import type { OAuth2Tokens } from '../oauth2.js';
+
+const authorizationEndpoint = 'https://slack.com/openid/connect/authorize';
+const tokenEndpoint = 'https://slack.com/api/openid.connect.token';
+
+export class Slack {
+	private client: OAuth2Client;
+
+	constructor(clientId: string, clientSecret: string, redirectURI: string | null) {
+		this.client = new OAuth2Client(clientId, clientSecret, redirectURI);
+	}
+
+	public createAuthorizationURL(state: string, scopes: string[]): URL {
+		const url = this.client.createAuthorizationURL(authorizationEndpoint, state, scopes);
+		return url;
+	}
+
+	public async validateAuthorizationCode(code: string): Promise<OAuth2Tokens> {
+		const tokens = await this.client.validateAuthorizationCode(tokenEndpoint, code, null);
+		return tokens;
+	}
+}

--- a/packages/@studiocms/oauth/src/internal/request.ts
+++ b/packages/@studiocms/oauth/src/internal/request.ts
@@ -1,0 +1,193 @@
+import * as encoding from '@withstudiocms/internal_helpers/encoding';
+import { OAuth2Tokens } from './oauth2.js';
+import { trimLeft, trimRight } from './utils.js';
+
+export function joinURIAndPath(base: string, ...path: string[]): string {
+	let joined = trimRight(base, '/');
+	for (const part of path) {
+		joined = `${trimRight(joined, '/')}/${trimLeft(part, '/')}`;
+	}
+	return joined;
+}
+
+export function createOAuth2Request(endpoint: string, body: URLSearchParams): Request {
+	const bodyBytes = new TextEncoder().encode(body.toString());
+	const request = new Request(endpoint, {
+		method: 'POST',
+		body: bodyBytes,
+	});
+	request.headers.set('Content-Type', 'application/x-www-form-urlencoded');
+	request.headers.set('Accept', 'application/json');
+	// Required by GitHub, and probably by others as well
+	request.headers.set('User-Agent', 'arctic');
+	// Required by Reddit
+	request.headers.set('Content-Length', bodyBytes.byteLength.toString());
+	return request;
+}
+
+export function encodeBasicCredentials(username: string, password: string): string {
+	const bytes = new TextEncoder().encode(`${username}:${password}`);
+	return encoding.encodeBase64(bytes);
+}
+
+export async function sendTokenRequest(request: Request): Promise<OAuth2Tokens> {
+	let response: Response;
+	try {
+		response = await fetch(request);
+	} catch (e) {
+		throw new ArcticFetchError(e);
+	}
+
+	if (response.status === 400 || response.status === 401) {
+		let data: unknown;
+		try {
+			data = await response.json();
+		} catch {
+			throw new UnexpectedResponseError(response.status);
+		}
+		if (typeof data !== 'object' || data === null) {
+			throw new UnexpectedErrorResponseBodyError(response.status, data);
+		}
+		let error: Error;
+		try {
+			error = createOAuth2RequestError(data);
+		} catch {
+			throw new UnexpectedErrorResponseBodyError(response.status, data);
+		}
+		throw error;
+	}
+
+	if (response.status === 200) {
+		let data: unknown;
+		try {
+			data = await response.json();
+		} catch {
+			throw new UnexpectedResponseError(response.status);
+		}
+		if (typeof data !== 'object' || data === null) {
+			throw new UnexpectedErrorResponseBodyError(response.status, data);
+		}
+		const tokens = new OAuth2Tokens(data);
+		return tokens;
+	}
+
+	if (response.body !== null) {
+		await response.body.cancel();
+	}
+	throw new UnexpectedResponseError(response.status);
+}
+
+export async function sendTokenRevocationRequest(request: Request): Promise<void> {
+	let response: Response;
+	try {
+		response = await fetch(request);
+	} catch (e) {
+		throw new ArcticFetchError(e);
+	}
+
+	if (response.status === 400 || response.status === 401) {
+		let data: unknown;
+		try {
+			data = await response.json();
+		} catch {
+			throw new UnexpectedErrorResponseBodyError(response.status, null);
+		}
+		if (typeof data !== 'object' || data === null) {
+			throw new UnexpectedErrorResponseBodyError(response.status, data);
+		}
+		let error: Error;
+		try {
+			error = createOAuth2RequestError(data);
+		} catch {
+			throw new UnexpectedErrorResponseBodyError(response.status, data);
+		}
+		throw error;
+	}
+
+	if (response.status === 200) {
+		if (response.body !== null) {
+			await response.body.cancel();
+		}
+		return;
+	}
+
+	if (response.body !== null) {
+		await response.body.cancel();
+	}
+	throw new UnexpectedResponseError(response.status);
+}
+
+export function createOAuth2RequestError(result: object): OAuth2RequestError {
+	let code: string;
+	if ('error' in result && typeof result.error === 'string') {
+		code = result.error;
+	} else {
+		throw new Error('Invalid error response');
+	}
+	let description: string | null = null;
+	let uri: string | null = null;
+	let state: string | null = null;
+	if ('error_description' in result) {
+		if (typeof result.error_description !== 'string') {
+			throw new Error('Invalid data');
+		}
+		description = result.error_description;
+	}
+	if ('error_uri' in result) {
+		if (typeof result.error_uri !== 'string') {
+			throw new Error('Invalid data');
+		}
+		uri = result.error_uri;
+	}
+	if ('state' in result) {
+		if (typeof result.state !== 'string') {
+			throw new Error('Invalid data');
+		}
+		state = result.state;
+	}
+	const error = new OAuth2RequestError(code, description, uri, state);
+	return error;
+}
+
+export class ArcticFetchError extends Error {
+	constructor(cause: unknown) {
+		super('Failed to send request', {
+			cause,
+		});
+	}
+}
+
+export class OAuth2RequestError extends Error {
+	public code: string;
+	public description: string | null;
+	public uri: string | null;
+	public state: string | null;
+
+	constructor(code: string, description: string | null, uri: string | null, state: string | null) {
+		super(`OAuth request error: ${code}`);
+		this.code = code;
+		this.description = description;
+		this.uri = uri;
+		this.state = state;
+	}
+}
+
+export class UnexpectedResponseError extends Error {
+	public status: number;
+
+	constructor(responseStatus: number) {
+		super('Unexpected error response');
+		this.status = responseStatus;
+	}
+}
+
+export class UnexpectedErrorResponseBodyError extends Error {
+	public status: number;
+	public data: unknown;
+
+	constructor(status: number, data: unknown) {
+		super('Unexpected error response body');
+		this.status = status;
+		this.data = data;
+	}
+}

--- a/packages/@studiocms/oauth/src/internal/utils.ts
+++ b/packages/@studiocms/oauth/src/internal/utils.ts
@@ -1,0 +1,21 @@
+export function trimLeft(s: string, character: string): string {
+	if (character.length !== 1) {
+		throw new TypeError('Invalid character string');
+	}
+	let start = 0;
+	while (start < s.length && s[start] === character) {
+		start++;
+	}
+	return s.slice(start);
+}
+
+export function trimRight(s: string, character: string): string {
+	if (character.length !== 1) {
+		throw new TypeError('Invalid character string');
+	}
+	let end = s.length;
+	while (end > 0 && s[end - 1] === character) {
+		end--;
+	}
+	return s.slice(0, end);
+}

--- a/packages/@studiocms/oauth/test/internal/oidc.test.ts
+++ b/packages/@studiocms/oauth/test/internal/oidc.test.ts
@@ -1,13 +1,30 @@
-import * as vitest from 'vitest';
+import * as allure from 'allure-js-commons';
+import { describe, expect, test } from 'vitest';
 
 import { decodeIdToken } from '../../src/internal/oidc.js';
+import { parentSuiteName, sharedTags } from '../test-utils.js';
 
-vitest.test('decodeIdToken()', () => {
-	const jwt =
-		'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
-	vitest.expect(decodeIdToken(jwt)).toStrictEqual({
-		sub: '1234567890',
-		name: 'John Doe',
-		iat: 1516239022,
+const localSuiteName = 'OIDC Internal Tests';
+
+describe(parentSuiteName, () => {
+	test('decodeIdToken()', async () => {
+		await allure.parentSuite(parentSuiteName);
+		await allure.suite(localSuiteName);
+		await allure.subSuite('OIDC Decoding');
+		await allure.tags(...sharedTags);
+
+		await allure.step('should decode a valid ID token payload', async (ctx) => {
+			const jwt =
+				'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+			const decoded = decodeIdToken(jwt);
+
+			await ctx.parameter('decodedPayload', JSON.stringify(decoded, null, 2));
+
+			expect(decoded).toStrictEqual({
+				sub: '1234567890',
+				name: 'John Doe',
+				iat: 1516239022,
+			});
+		});
 	});
 });

--- a/packages/@studiocms/oauth/test/internal/oidc.test.ts
+++ b/packages/@studiocms/oauth/test/internal/oidc.test.ts
@@ -1,0 +1,13 @@
+import * as vitest from 'vitest';
+
+import { decodeIdToken } from '../../src/internal/oidc.js';
+
+vitest.test('decodeIdToken()', () => {
+	const jwt =
+		'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+	vitest.expect(decodeIdToken(jwt)).toStrictEqual({
+		sub: '1234567890',
+		name: 'John Doe',
+		iat: 1516239022,
+	});
+});

--- a/packages/@studiocms/oauth/test/internal/request.test.ts
+++ b/packages/@studiocms/oauth/test/internal/request.test.ts
@@ -1,21 +1,35 @@
-import * as vitest from 'vitest';
+import * as allure from 'allure-js-commons';
+import { describe, expect, test } from 'vitest';
 
 import { joinURIAndPath } from '../../src/internal/request.js';
+import { parentSuiteName, sharedTags } from '../test-utils.js';
 
-vitest.test('joinBaseURIAndPath()', () => {
-	vitest.expect(joinURIAndPath('https://example.com', '/hi')).toBe('https://example.com/hi');
-	vitest.expect(joinURIAndPath('https://example.com/', '/hi')).toBe('https://example.com/hi');
-	vitest.expect(joinURIAndPath('https://example.com/', 'hi')).toBe('https://example.com/hi');
-	vitest.expect(joinURIAndPath('https://example.com', 'hi')).toBe('https://example.com/hi');
-	vitest.expect(joinURIAndPath('https://example.com', '/hi/')).toBe('https://example.com/hi/');
+const localSuiteName = 'Request Internal Tests';
 
-	vitest
-		.expect(joinURIAndPath('https://example.com', '/hi', '/bye'))
-		.toBe('https://example.com/hi/bye');
-	vitest
-		.expect(joinURIAndPath('https://example.com', 'hi', 'bye'))
-		.toBe('https://example.com/hi/bye');
-	vitest
-		.expect(joinURIAndPath('https://example.com', '/hi/', '/bye/'))
-		.toBe('https://example.com/hi/bye/');
+describe(parentSuiteName, () => {
+	test('joinBaseURIAndPath()', async () => {
+		await allure.parentSuite(parentSuiteName);
+		await allure.suite(localSuiteName);
+		await allure.subSuite('URI Joining');
+		await allure.tags(...sharedTags);
+
+		await allure.step('should join base URI and path segments correctly', async (ctx) => {
+			await ctx.parameter('baseUri', 'https://example.com');
+			await ctx.parameter('joinedPath', joinURIAndPath('https://example.com', '/hi'));
+
+			expect(joinURIAndPath('https://example.com', '/hi')).toBe('https://example.com/hi');
+			expect(joinURIAndPath('https://example.com/', '/hi')).toBe('https://example.com/hi');
+			expect(joinURIAndPath('https://example.com/', 'hi')).toBe('https://example.com/hi');
+			expect(joinURIAndPath('https://example.com', 'hi')).toBe('https://example.com/hi');
+			expect(joinURIAndPath('https://example.com', '/hi/')).toBe('https://example.com/hi/');
+
+			expect(joinURIAndPath('https://example.com', '/hi', '/bye')).toBe(
+				'https://example.com/hi/bye'
+			);
+			expect(joinURIAndPath('https://example.com', 'hi', 'bye')).toBe('https://example.com/hi/bye');
+			expect(joinURIAndPath('https://example.com', '/hi/', '/bye/')).toBe(
+				'https://example.com/hi/bye/'
+			);
+		});
+	});
 });

--- a/packages/@studiocms/oauth/test/internal/request.test.ts
+++ b/packages/@studiocms/oauth/test/internal/request.test.ts
@@ -1,0 +1,21 @@
+import * as vitest from 'vitest';
+
+import { joinURIAndPath } from '../../src/internal/request.js';
+
+vitest.test('joinBaseURIAndPath()', () => {
+	vitest.expect(joinURIAndPath('https://example.com', '/hi')).toBe('https://example.com/hi');
+	vitest.expect(joinURIAndPath('https://example.com/', '/hi')).toBe('https://example.com/hi');
+	vitest.expect(joinURIAndPath('https://example.com/', 'hi')).toBe('https://example.com/hi');
+	vitest.expect(joinURIAndPath('https://example.com', 'hi')).toBe('https://example.com/hi');
+	vitest.expect(joinURIAndPath('https://example.com', '/hi/')).toBe('https://example.com/hi/');
+
+	vitest
+		.expect(joinURIAndPath('https://example.com', '/hi', '/bye'))
+		.toBe('https://example.com/hi/bye');
+	vitest
+		.expect(joinURIAndPath('https://example.com', 'hi', 'bye'))
+		.toBe('https://example.com/hi/bye');
+	vitest
+		.expect(joinURIAndPath('https://example.com', '/hi/', '/bye/'))
+		.toBe('https://example.com/hi/bye/');
+});

--- a/packages/@studiocms/oauth/test/internal/utils.test.ts
+++ b/packages/@studiocms/oauth/test/internal/utils.test.ts
@@ -1,0 +1,25 @@
+import * as vitest from 'vitest';
+
+import { trimLeft, trimRight } from '../../src/internal/utils.js';
+
+vitest.test('trimLeft()', () => {
+	vitest.expect(trimLeft(' hello', ' ')).toBe('hello');
+	vitest.expect(trimLeft('  hello', ' ')).toBe('hello');
+	vitest.expect(trimLeft('!!!hello', '!')).toBe('hello');
+	vitest.expect(trimLeft('!!!hello!', '!')).toBe('hello!');
+	vitest.expect(trimLeft('!!', '!')).toBe('');
+	vitest.expect(trimLeft('', '!')).toBe('');
+
+	vitest.expect(() => trimLeft('hello', '!!')).toThrow(TypeError);
+});
+
+vitest.test('trimRight()', () => {
+	vitest.expect(trimRight('hello ', ' ')).toBe('hello');
+	vitest.expect(trimRight('hello  ', ' ')).toBe('hello');
+	vitest.expect(trimRight('hello!!!', '!')).toBe('hello');
+	vitest.expect(trimRight('!hello!!!', '!')).toBe('!hello');
+	vitest.expect(trimRight('!!', '!')).toBe('');
+	vitest.expect(trimRight('', '!')).toBe('');
+
+	vitest.expect(() => trimLeft('hello', '!!')).toThrow(TypeError);
+});

--- a/packages/@studiocms/oauth/test/internal/utils.test.ts
+++ b/packages/@studiocms/oauth/test/internal/utils.test.ts
@@ -1,25 +1,45 @@
-import * as vitest from 'vitest';
+import * as allure from 'allure-js-commons';
+import { describe, expect, test } from 'vitest';
 
 import { trimLeft, trimRight } from '../../src/internal/utils.js';
+import { parentSuiteName, sharedTags } from '../test-utils.js';
 
-vitest.test('trimLeft()', () => {
-	vitest.expect(trimLeft(' hello', ' ')).toBe('hello');
-	vitest.expect(trimLeft('  hello', ' ')).toBe('hello');
-	vitest.expect(trimLeft('!!!hello', '!')).toBe('hello');
-	vitest.expect(trimLeft('!!!hello!', '!')).toBe('hello!');
-	vitest.expect(trimLeft('!!', '!')).toBe('');
-	vitest.expect(trimLeft('', '!')).toBe('');
+const localSuiteName = 'Utils Internal Tests';
 
-	vitest.expect(() => trimLeft('hello', '!!')).toThrow(TypeError);
-});
+describe(parentSuiteName, () => {
+	test('trimLeft()', async () => {
+		await allure.parentSuite(parentSuiteName);
+		await allure.suite(localSuiteName);
+		await allure.subSuite('Trim Left');
+		await allure.tags(...sharedTags);
 
-vitest.test('trimRight()', () => {
-	vitest.expect(trimRight('hello ', ' ')).toBe('hello');
-	vitest.expect(trimRight('hello  ', ' ')).toBe('hello');
-	vitest.expect(trimRight('hello!!!', '!')).toBe('hello');
-	vitest.expect(trimRight('!hello!!!', '!')).toBe('!hello');
-	vitest.expect(trimRight('!!', '!')).toBe('');
-	vitest.expect(trimRight('', '!')).toBe('');
+		await allure.step('should remove the given leading trim characters', async () => {
+			expect(trimLeft(' hello', ' ')).toBe('hello');
+			expect(trimLeft('  hello', ' ')).toBe('hello');
+			expect(trimLeft('!!!hello', '!')).toBe('hello');
+			expect(trimLeft('!!!hello!', '!')).toBe('hello!');
+			expect(trimLeft('!!', '!')).toBe('');
+			expect(trimLeft('', '!')).toBe('');
 
-	vitest.expect(() => trimLeft('hello', '!!')).toThrow(TypeError);
+			expect(() => trimLeft('hello', '!!')).toThrow(TypeError);
+		});
+	});
+
+	test('trimRight()', async () => {
+		await allure.parentSuite(parentSuiteName);
+		await allure.suite(localSuiteName);
+		await allure.subSuite('Trim Right');
+		await allure.tags(...sharedTags);
+
+		await allure.step('should remove the given trailing trim characters', async () => {
+			expect(trimRight('hello ', ' ')).toBe('hello');
+			expect(trimRight('hello  ', ' ')).toBe('hello');
+			expect(trimRight('hello!!!', '!')).toBe('hello');
+			expect(trimRight('!hello!!!', '!')).toBe('!hello');
+			expect(trimRight('!!', '!')).toBe('');
+			expect(trimRight('', '!')).toBe('');
+
+			expect(() => trimLeft('hello', '!!')).toThrow(TypeError);
+		});
+	});
 });

--- a/packages/@withstudiocms/internal_helpers/package.json
+++ b/packages/@withstudiocms/internal_helpers/package.json
@@ -103,9 +103,41 @@
       "types": "./dist/jwt/index.d.ts",
       "default": "./dist/jwt/index.js"
     },
-    "./crypto": {
-      "types": "./dist/crypto/index.d.ts",
-      "default": "./dist/crypto/index.js"
+    "./crypto/ecdsa": {
+      "types": "./dist/crypto/ecdsa/index.d.ts",
+      "default": "./dist/crypto/ecdsa/index.js"
+    },
+    "./crypto/hash": {
+      "types": "./dist/crypto/hash/index.d.ts",
+      "default": "./dist/crypto/hash/index.js"
+    },
+    "./crypto/hmac": {
+      "types": "./dist/crypto/hmac/index.d.ts",
+      "default": "./dist/crypto/hmac/index.js"
+    },
+    "./crypto/random": {
+      "types": "./dist/crypto/random/index.d.ts",
+      "default": "./dist/crypto/random/index.js"
+    },
+    "./crypto/rsa": {
+      "types": "./dist/crypto/rsa/index.d.ts",
+      "default": "./dist/crypto/rsa/index.js"
+    },
+    "./crypto/sha1": {
+      "types": "./dist/crypto/sha1/index.d.ts",
+      "default": "./dist/crypto/sha1/index.js"
+    },
+    "./crypto/sha2": {
+      "types": "./dist/crypto/sha2/index.d.ts",
+      "default": "./dist/crypto/sha2/index.js"
+    },
+    "./crypto/sha3": {
+      "types": "./dist/crypto/sha3/index.d.ts",
+      "default": "./dist/crypto/sha3/index.js"
+    },
+    "./crypto/subtle": {
+      "types": "./dist/crypto/subtle/index.d.ts",
+      "default": "./dist/crypto/subtle/index.js"
     }
   },
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ catalogs:
     '@types/semver':
       specifier: ^7.7.1
       version: 7.7.1
-    arctic:
-      specifier: ^3.7.0
-      version: 3.7.0
     deepmerge-ts:
       specifier: ^7.1.5
       version: 7.1.5
@@ -580,12 +577,12 @@ importers:
       '@withstudiocms/effect':
         specifier: workspace:^
         version: link:../../@withstudiocms/effect
+      '@withstudiocms/internal_helpers':
+        specifier: workspace:^
+        version: link:../../@withstudiocms/internal_helpers
       '@withstudiocms/kysely':
         specifier: workspace:^
         version: link:../../@withstudiocms/kysely
-      arctic:
-        specifier: 'catalog:'
-        version: 3.7.0
       effect:
         specifier: catalog:effect
         version: 3.22.1
@@ -2992,15 +2989,8 @@ packages:
     resolution: {integrity: sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  '@oslojs/encoding@0.4.1':
-    resolution: {integrity: sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q==}
-
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
-
-  '@oslojs/jwt@0.2.0':
-    resolution: {integrity: sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@outerbase/sdk-transform@1.0.8':
     resolution: {integrity: sha512-M9EGGwRXUZ7xuX012sIZpsT92Bx1dewac9iubTHsC+/6IGVM678+Vkv44bcDL5Lx6ol+FQ2Exq1TU+OGOmYFEg==}
@@ -4183,10 +4173,6 @@ packages:
 
   aproba@2.1.0:
     resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
-
-  arctic@3.7.0:
-    resolution: {integrity: sha512-ZMQ+f6VazDgUJOd+qNV+H7GohNSYal1mVjm5kEaZfE2Ifb7Ss70w+Q7xpJC87qZDkMZIXYf0pTIYZA0OPasSbw==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   are-we-there-yet@2.0.0:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
@@ -9525,13 +9511,7 @@ snapshots:
       '@oslojs/asn1': 1.0.0
       '@oslojs/binary': 1.0.0
 
-  '@oslojs/encoding@0.4.1': {}
-
   '@oslojs/encoding@1.1.0': {}
-
-  '@oslojs/jwt@0.2.0':
-    dependencies:
-      '@oslojs/encoding': 0.4.1
 
   '@outerbase/sdk-transform@1.0.8': {}
 
@@ -10476,12 +10456,6 @@ snapshots:
 
   aproba@2.1.0:
     optional: true
-
-  arctic@3.7.0:
-    dependencies:
-      '@oslojs/crypto': 1.0.1
-      '@oslojs/encoding': 1.1.0
-      '@oslojs/jwt': 0.2.0
 
   are-we-there-yet@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,7 +38,6 @@ catalog:
   "@types/mdast": ^4.0.4
   "@types/node": ^22.0.0
   "@types/semver": ^7.7.1
-  arctic: ^3.7.0
   deepmerge-ts: ^7.1.5
   esbuild: ^0.25.8
   sharp: ^0.34.3


### PR DESCRIPTION
This pull request makes significant changes to the `@studiocms/oauth` package by integrating and replacing the previously external `arctic` OAuth code with an internal implementation. It introduces a new internal OAuth client, provider classes for various OAuth services, and utility helpers, all consolidated within the package. Additionally, it updates dependencies and fixes crypto exports in a helper package.

**Integration of OAuth logic and provider refactoring:**

- The deprecated `arctic` dependency is removed from `@studiocms/oauth`, and all OAuth processing is now handled internally via new provider classes and helpers. This affects all major OAuth flows (Auth0, Discord, GitHub, Google, Gitea, Authentik, Slack, GitLab). (`.changeset/vast-zoos-lick.md`, `package.json`, [[1]](diffhunk://#diff-7fa7e8afbcb28e4894990be729a6c33067935926e3c9b0f86e6ecedfc4527c2fR1-R5) [[2]](diffhunk://#diff-87eb0ee559204b7c3f231a6534f2c8bb48c4d0b70899b4533bc2f2862c3f837aL74-R74)
- All OAuth provider implementations now import from the new internal helpers instead of `arctic`, ensuring a unified and maintainable codebase. (`impl.ts` files for Auth0, Discord, GitHub, Google, [[1]](diffhunk://#diff-52dd836f4954fed50a4432f2f52ae2c2eaaffcf7c7632c32dd729d3390fb72a4L5-R7) [[2]](diffhunk://#diff-b86410598f1a5ee493e27c9bb8921b08fb94684c55e0abfef0e058b68cdc0154L5-R7) [[3]](diffhunk://#diff-f037d24805240603530db931a67919b6c0d5b775386c7bf0c8151cad421534d9L5-R7) [[4]](diffhunk://#diff-c150eb100ae6f0be1701d4a6ab33bbde5fa73acd108bae33323c567c0d54dcb7L5-R7)

**New internal OAuth core and utilities:**

- Introduced `OAuth2Client` and related utilities in `internal/client.ts`, encapsulating common OAuth2 flows (authorization URL creation, token validation, refresh, and revocation). (`[packages/@studiocms/oauth/src/internal/client.tsR1-R135](diffhunk://#diff-9b6f08fca8d6bb9d28ec65a3fd06082297fb5ff893a05f1e2f780dd96aedd806R1-R135)`)
- Added `OAuth2Tokens` class and helper functions for code verifier, state generation, and S256 code challenge in `internal/oauth2.ts`. (`[packages/@studiocms/oauth/src/internal/oauth2.tsR1-R81](diffhunk://#diff-50260313b06571e8cce74bf96e13aeaa4127b72b737530bd0b729393ccd17c1cR1-R81)`)
- Added `decodeIdToken` utility for JWT decoding in `internal/oidc.ts`. (`[packages/@studiocms/oauth/src/internal/oidc.tsR1-R11](diffhunk://#diff-d7e99f68ceff4738869b6f1af0aa0cdbb8db485ed49f48a4ad3a7f559ef08a08R1-R11)`)

**Provider-specific implementations:**

- Added new provider classes for Auth0, Authentik, Discord, Gitea, and GitHub under `internal/providers/`, each encapsulating provider-specific endpoints and flows using the new internal client. (`[[1]](diffhunk://#diff-8f052dd862387221a5cf35a90375266c40a1787859dac81404d6f83251b232c3R1-R54)`, `[[2]](diffhunk://#diff-a199e0c5e76063fd71544ddb2ccf32c19b0b6bf557d30f06a3814622ebc469d1R1-R50)`, `[[3]](diffhunk://#diff-ddd24f5a7e3c01bcf0ce08d893beec23cae841e7934e172f29e5b939a6eeb1c4R1-R48)`, `[[4]](diffhunk://#diff-76e9c2762845a5b94cf58e77f667eec2a7fe53b4fa1b3cb7d356cb4a18fc44f8R1-R44)`, `[[5]](diffhunk://#diff-4f94f80e2e173b5890e7ec1c260b4bb8da597dff9db9d45cb3c9fee085723fe3R1-R100)`)

**Dependency and helper updates:**

- Updated dependencies to use `@withstudiocms/internal_helpers` for crypto, encoding, and JWT operations, and fixed crypto exports in that package. (`.changeset/tired-drinks-shop.md`, [.changeset/tired-drinks-shop.mdR1-R5](diffhunk://#diff-3fb7f83a9168fce52e9bea2e38dc71b4bdd0f5f1064e00bb19020fc6cdcad93fR1-R5))
- Centralized and re-exported all new internal helpers and provider classes in `internal/index.ts`. (`[packages/@studiocms/oauth/src/internal/index.tsR1-R17](diffhunk://#diff-a7e77ecf8d3ecab7451a9f5f1c01072e25bf86593ccc504cbb5e7ff145589c7dR1-R17)`)

These changes modernize and consolidate the OAuth functionality, improve maintainability, and remove reliance on the deprecated `arctic` package.

@coderabbitai ignore