### PR TITLE
Migrate from @oslojs packages to internal helper exports

### DIFF
--- a/.changeset/neat-beers-turn.md
+++ b/.changeset/neat-beers-turn.md
@@ -1,0 +1,5 @@
+---
+"@withstudiocms/auth-kit": minor
+---
+
+Migrate from `@oslojs/` packages to new internal helper exports

--- a/packages/@withstudiocms/auth-kit/package.json
+++ b/packages/@withstudiocms/auth-kit/package.json
@@ -70,9 +70,7 @@
   "type": "module",
   "dependencies": {
     "@withstudiocms/effect": "workspace:^",
-    "@oslojs/binary": "^1.0.0",
-    "@oslojs/crypto": "^1.0.1",
-    "@oslojs/encoding": "^1.1.0"
+    "@withstudiocms/internal_helpers": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/@withstudiocms/auth-kit/src/modules/encryption.ts
+++ b/packages/@withstudiocms/auth-kit/src/modules/encryption.ts
@@ -1,7 +1,7 @@
 import { createCipheriv, createDecipheriv } from 'node:crypto';
-import { DynamicBuffer } from '@oslojs/binary';
-import { decodeBase64 } from '@oslojs/encoding';
 import { Effect } from '@withstudiocms/effect';
+import { DynamicBuffer } from '@withstudiocms/internal_helpers/binary';
+import { decodeBase64 } from '@withstudiocms/internal_helpers/encoding';
 import { useDecryptionError, useEncryptionError } from '../errors.js';
 
 /**

--- a/packages/@withstudiocms/auth-kit/src/modules/session.ts
+++ b/packages/@withstudiocms/auth-kit/src/modules/session.ts
@@ -1,5 +1,5 @@
-import { encodeBase32LowerCaseNoPadding } from '@oslojs/encoding';
 import { Effect } from '@withstudiocms/effect';
+import { encodeBase32LowerCaseNoPadding } from '@withstudiocms/internal_helpers/encoding';
 import type { APIContext, AstroGlobal } from 'astro';
 import { SessionError, useSessionError, useSessionErrorPromise } from '../errors.js';
 import type { SessionConfig, SessionValidationResult } from '../types.js';

--- a/packages/@withstudiocms/auth-kit/src/utils/password.ts
+++ b/packages/@withstudiocms/auth-kit/src/utils/password.ts
@@ -1,6 +1,6 @@
-import { sha1 } from '@oslojs/crypto/sha1';
-import { encodeHexLowerCase } from '@oslojs/encoding';
 import { Effect, Platform } from '@withstudiocms/effect';
+import { sha1 } from '@withstudiocms/internal_helpers/crypto/sha1';
+import { encodeHexLowerCase } from '@withstudiocms/internal_helpers/encoding';
 import { PasswordError, usePasswordError } from '../errors.js';
 import { CheckIfUnsafe } from './unsafeCheck.js';
 

--- a/packages/@withstudiocms/auth-kit/src/utils/session.ts
+++ b/packages/@withstudiocms/auth-kit/src/utils/session.ts
@@ -1,6 +1,6 @@
-import { sha256 } from '@oslojs/crypto/sha2';
-import { encodeHexLowerCase } from '@oslojs/encoding';
 import { Effect, pipe } from '@withstudiocms/effect';
+import { sha256 } from '@withstudiocms/internal_helpers/crypto/sha2';
+import { encodeHexLowerCase } from '@withstudiocms/internal_helpers/encoding';
 import { useSessionError } from '../errors.js';
 import type { SessionConfig } from '../types.js';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -727,18 +727,12 @@ importers:
       '@effect/platform':
         specifier: catalog:effect
         version: 0.97.1(effect@3.22.1)
-      '@oslojs/binary':
-        specifier: ^1.0.0
-        version: 1.0.0
-      '@oslojs/crypto':
-        specifier: ^1.0.1
-        version: 1.0.1
-      '@oslojs/encoding':
-        specifier: ^1.1.0
-        version: 1.1.0
       '@withstudiocms/effect':
         specifier: workspace:^
         version: link:../effect
+      '@withstudiocms/internal_helpers':
+        specifier: workspace:^
+        version: link:../internal_helpers
       effect:
         specifier: catalog:effect
         version: 3.22.1
@@ -2976,18 +2970,6 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
-
-  '@oslojs/asn1@1.0.0':
-    resolution: {integrity: sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
-  '@oslojs/binary@1.0.0':
-    resolution: {integrity: sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
-  '@oslojs/crypto@1.0.1':
-    resolution: {integrity: sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -9499,17 +9481,6 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
-
-  '@oslojs/asn1@1.0.0':
-    dependencies:
-      '@oslojs/binary': 1.0.0
-
-  '@oslojs/binary@1.0.0': {}
-
-  '@oslojs/crypto@1.0.1':
-    dependencies:
-      '@oslojs/asn1': 1.0.0
-      '@oslojs/binary': 1.0.0
 
   '@oslojs/encoding@1.1.0': {}
 


### PR DESCRIPTION
This pull request migrates the `@withstudiocms/auth-kit` package from using external `@oslojs` dependencies to new internal helper exports, streamlining dependency management and improving maintainability. The migration updates all relevant imports and package dependencies, and removes now-unnecessary external packages.

Dependency migration and cleanup:

* Replaced all imports from `@oslojs/binary`, `@oslojs/crypto`, and `@oslojs/encoding` in the `auth-kit` source files with corresponding imports from `@withstudiocms/internal_helpers` (`encryption.ts`, `session.ts`, `password.ts`, `utils/session.ts`). [[1]](diffhunk://#diff-20fc5cea738e2e2989ff61518bcf1ad53bb16e864f1ecd9238c6ad31b09eace3L2-R4) [[2]](diffhunk://#diff-c11149485d0f1cc410a40fa6ac2dd502fc7b377ee94aaa7f486d25d1149863c5L1-R2) [[3]](diffhunk://#diff-7220696467709b0ac6a64a8e2ea2e8326e8402155ed9f87ea5accb958a26e132L1-R3) [[4]](diffhunk://#diff-f2bc42e2f16e56435f0fa8dbe53bb4fc204d061dcd5d1b68db899e83bbe58cbeL1-R3)
* Updated `package.json` for `@withstudiocms/auth-kit` to remove `@oslojs` dependencies and add `@withstudiocms/internal_helpers` as a dependency.
* Updated `pnpm-lock.yaml` to remove references to `@oslojs/binary`, `@oslojs/crypto`, and related transitive dependencies, and add `@withstudiocms/internal_helpers`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL730-R735) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2980-L2991) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9503-L9513)

Documentation and release:

* Added a changeset documenting the migration and indicating a minor version bump for `@withstudiocms/auth-kit`.

@coderabbitai ignore