### PR TITLE
Fix pnpm catalog version for studiocms-peerlock dependency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,7 +57,7 @@
       "labels": ["templates"]
     },
     {
-      "matchDepTypes": ["pnpm.catalog.astrojs-min", "pnpm.catalog:studiocms-peerlock"],
+      "matchDepTypes": ["pnpm.catalog.astrojs-min", "pnpm.catalog.studiocms-peerlock"],
       "enabled": false
     }
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,7 +125,7 @@ catalogs:
       version: 1.2.1
   studiocms-peerlock:
     astro:
-      specifier: ^7.1.6
+      specifier: ^7.0.0
       version: 7.1.6
     vite:
       specifier: ^8.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,7 +69,7 @@ catalogs:
     "@studiocms/ui": ^1.2.1
 
   studiocms-peerlock:
-    astro: ^7.1.6
+    astro: ^7.0.0
     vite: ^8.0.0
 
   effect:


### PR DESCRIPTION
This pull request makes minor dependency and configuration adjustments related to the `studiocms-peerlock` package and its `astro` version specification. The changes ensure consistency in version requirements and correct a configuration typo.

The most important changes are:

Dependency version specification alignment:

* Updated the `astro` version specifier for `studiocms-peerlock` from `^7.1.6` to `^7.0.0` in both `pnpm-workspace.yaml` and `pnpm-lock.yaml` to allow compatibility with all `7.x.x` versions. [[1]](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL72-R72) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL128-R128)

Configuration fixes:

* Fixed a typo in the `matchDepTypes` field in `.github/renovate.json` by changing `pnpm.catalog:studiocms-peerlock` to `pnpm.catalog.studiocms-peerlock` for accurate dependency matching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected dependency update configuration for improved compatibility with the package manager.
  * Broadened the supported Astro version range to include releases from 7.0.0 onward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->