### PR TITLE
fix(kysely): collision-free `_kysely_schema_v1` ids

### DIFF
--- a/.changeset/olive-kids-join.md
+++ b/.changeset/olive-kids-join.md
@@ -1,0 +1,5 @@
+---
+"@withstudiocms/kysely": patch
+---
+
+fix `_kysely_schema_v1` primary-key collisions when several migrations run in one transaction. schema-history ids are now `max(now(), max(id)+1)` instead of a second-granularity timestamp, the retry loop is gone, and `saveSchema` no longer swallows errors.

--- a/packages/@withstudiocms/kysely/src/utils/migrator.ts
+++ b/packages/@withstudiocms/kysely/src/utils/migrator.ts
@@ -1,7 +1,7 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: It's okay, doing dynamic stuff */
 /* v8 ignore start */
 
-import { Data, Effect, Schedule } from 'effect';
+import { Effect } from 'effect';
 import type { Kysely } from 'kysely';
 import { handleCause, SqlError } from './errors.js';
 import { addMissingIndexes, dropRemovedIndexes, getTableIndexes } from './indexes.js';
@@ -22,7 +22,21 @@ function now() {
 	return Math.floor(diff / 1000);
 }
 
-class SaveError extends Data.TaggedError('SaveError')<{ cause: unknown }> {}
+/**
+ * Next id for the schema history table: the greater of the current wall-clock
+ * value and `max(id) + 1`. Reads its own writes inside a transaction, so several
+ * migrations saved in the same second (e.g. a fresh install batched in one
+ * Postgres transaction) never collide on the primary key.
+ */
+const nextId = (db: Kysely<any>) =>
+	Effect.tryPromise({
+		try: () =>
+			db
+				.selectFrom(v1TableName)
+				.select(db.fn.max<number | null>('id').as('max'))
+				.executeTakeFirst(),
+		catch: (cause) => new SqlError({ cause }),
+	}).pipe(Effect.map((row) => Math.max(now(), Number(row?.max ?? 0) + 1)));
 
 const schemaManager = Effect.fn('schemaManager')(function* (
 	db: Kysely<any>,
@@ -72,9 +86,9 @@ const schemaManager = Effect.fn('schemaManager')(function* (
 
 		if (!v1HasRows && previousSchemaDefinitionInternal.length > 0) {
 			const definition = yield* stringifyTableSchema(previousSchemaDefinitionInternal);
+			const id = yield* nextId(db);
 			yield* Effect.tryPromise({
-				try: () =>
-					db.insertInto(v1TableName).values({ definition, id: now() }).executeTakeFirstOrThrow(),
+				try: () => db.insertInto(v1TableName).values({ definition, id }).executeTakeFirstOrThrow(),
 				catch: (cause) => new SqlError({ cause }),
 			});
 		}
@@ -135,44 +149,12 @@ const schemaManager = Effect.fn('schemaManager')(function* (
 			yield* createTable;
 		}
 
-		let attempt = 0;
-		const maxAttempts = 9; // With 1 second fixed delay, this allows for up to ~10 seconds of retries, which should be sufficient to resolve clock issues in most cases.
-
-		yield* Effect.retry(
-			Effect.gen(function* () {
-				const id = now() + attempt;
-				attempt++;
-				return yield* Effect.tryPromise({
-					try: () =>
-						db.insertInto(v1TableName).values({ definition, id }).executeTakeFirstOrThrow(),
-					catch: (cause) => {
-						// 23505 means unique ID conflict
-						if (cause instanceof Error && 'code' in cause && cause.code === '23505') {
-							return new SaveError({ cause });
-						}
-						return new SqlError({ cause });
-					},
-				}).pipe(Effect.andThen(() => Effect.succeed(true)));
-			}),
-			{
-				times: maxAttempts,
-				schedule: Schedule.fixed('1 seconds'),
-				while: (e) => e._tag === 'SaveError',
-			}
-		).pipe(
-			Effect.catchTag(
-				'SaveError',
-				() =>
-					new SqlError({
-						cause: new Error(
-							`Failed to save schema after ${maxAttempts + 1} attempts due to repeated ID conflicts, which is likely caused by a clock issue. Please ensure the system clock is accurate and try again.`
-						),
-					})
-			)
-		);
-
-		return;
-	}, Effect.catchAll(Effect.logError));
+		const id = yield* nextId(db);
+		yield* Effect.tryPromise({
+			try: () => db.insertInto(v1TableName).values({ definition, id }).executeTakeFirstOrThrow(),
+			catch: (cause) => new SqlError({ cause }),
+		});
+	});
 
 	return {
 		getPreviousSchema,

--- a/packages/@withstudiocms/kysely/src/utils/migrator.ts
+++ b/packages/@withstudiocms/kysely/src/utils/migrator.ts
@@ -27,6 +27,10 @@ function now() {
  * value and `max(id) + 1`. Reads its own writes inside a transaction, so several
  * migrations saved in the same second (e.g. a fresh install batched in one
  * Postgres transaction) never collide on the primary key.
+ *
+ * Not an atomic allocator: concurrent callers outside a transaction (or in
+ * separate transactions) can compute the same id. Callers are expected to be
+ * serialized, Kysely's `Migrator` does this via `kysely_migration_lock`.
  */
 const nextId = (db: Kysely<any>) =>
 	Effect.tryPromise({
@@ -179,6 +183,10 @@ const schemaManager = Effect.fn('schemaManager')(function* (
  * - Wraps SQL-level failures in SqlError and delegates error handling to the
  *   configured `handleCause` handler (via Effect.catchAllCause).
  *
+ * Concurrency: calls must be serialized (e.g. run from a Kysely `Migrator`, which
+ * holds `kysely_migration_lock`). Concurrent direct calls can collide on the
+ * schema-history primary key.
+ *
  * Important notes:
  * - This operation performs destructive changes (drops tables/indexes/triggers)
  *   when the schema indicates removal or deprecation — ensure you have backups
@@ -307,6 +315,8 @@ export const syncDatabaseSchema = (
  * - Logs progress and outcomes for each table and for the overall rollback procedure.
  * - Uses the provided `db` Kysely instance's schema API to perform table existence checks
  *   and drops.
+ *
+ * Concurrency: same contract as `syncDatabaseSchema` — calls must be serialized.
  *
  * Notes and guarantees:
  * - The operation is executed asynchronously and returns a promise that resolves

--- a/packages/@withstudiocms/kysely/test/utils/migrator.test.ts
+++ b/packages/@withstudiocms/kysely/test/utils/migrator.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect } from 'vitest';
+import { syncDatabaseSchema, type TableDefinition } from '../../src/utils/migrator';
+import { allureTester, DBClientFixture, parentSuiteName, sharedTags } from '../test-utils';
+
+const localSuiteName = 'Migrator Utilities';
+
+const schemaA: TableDefinition[] = [
+	{ name: 'a', columns: [{ name: 'id', type: 'integer', primaryKey: true }] },
+];
+const schemaB: TableDefinition[] = [
+	...schemaA,
+	{ name: 'b', columns: [{ name: 'id', type: 'integer', primaryKey: true }] },
+];
+
+describe(parentSuiteName, () => {
+	const test = allureTester({
+		suiteParentName: parentSuiteName,
+		suiteName: localSuiteName,
+	});
+
+	const { js: dbFixture } = DBClientFixture(localSuiteName);
+
+	beforeEach(async () => {
+		await dbFixture.cleanup();
+	});
+
+	afterEach(async () => {
+		await dbFixture.cleanup();
+	});
+
+	test('saveSchema does not collide when several migrations run in the same second (#1558)', async ({
+		setupAllure,
+		step,
+	}) => {
+		await setupAllure({
+			subSuiteName: 'schema history ids',
+			tags: [...sharedTags],
+		});
+
+		await step(
+			'two syncs back-to-back produce two strictly increasing ids, without waiting',
+			async () => {
+				const { db } = await dbFixture.getClient();
+
+				const start = Date.now();
+				await syncDatabaseSchema(db, schemaA, []);
+				await syncDatabaseSchema(db, schemaB, schemaA);
+				const elapsed = Date.now() - start;
+
+				const rows = await db
+					.selectFrom('_kysely_schema_v1')
+					.select('id')
+					.orderBy('id', 'asc')
+					.execute();
+
+				expect(rows).toHaveLength(2);
+				expect(rows[1].id).toBeGreaterThan(rows[0].id);
+				// the old retry loop slept 1s per collision; the fix must not
+				expect(elapsed).toBeLessThan(900);
+			}
+		);
+	});
+});

--- a/packages/@withstudiocms/kysely/test/utils/migrator.test.ts
+++ b/packages/@withstudiocms/kysely/test/utils/migrator.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 import { syncDatabaseSchema, type TableDefinition } from '../../src/utils/migrator';
 import { allureTester, DBClientFixture, parentSuiteName, sharedTags } from '../test-utils';
 
@@ -22,9 +22,13 @@ describe(parentSuiteName, () => {
 
 	beforeEach(async () => {
 		await dbFixture.cleanup();
+		// freeze the wall clock so both saves fall in the same second
+		vi.useFakeTimers({ toFake: ['Date'] });
+		vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
 	});
 
 	afterEach(async () => {
+		vi.useRealTimers();
 		await dbFixture.cleanup();
 	});
 
@@ -37,27 +41,23 @@ describe(parentSuiteName, () => {
 			tags: [...sharedTags],
 		});
 
-		await step(
-			'two syncs back-to-back produce two strictly increasing ids, without waiting',
-			async () => {
-				const { db } = await dbFixture.getClient();
+		await step('two syncs in one transaction and one second get consecutive ids', async () => {
+			const { db } = await dbFixture.getClient();
 
-				const start = Date.now();
-				await syncDatabaseSchema(db, schemaA, []);
-				await syncDatabaseSchema(db, schemaB, schemaA);
-				const elapsed = Date.now() - start;
+			// mirrors Kysely's Migrator on transactional-DDL dialects: one transaction for the batch
+			await db.transaction().execute(async (trx) => {
+				await syncDatabaseSchema(trx, schemaA, []);
+				await syncDatabaseSchema(trx, schemaB, schemaA);
+			});
 
-				const rows = await db
-					.selectFrom('_kysely_schema_v1')
-					.select('id')
-					.orderBy('id', 'asc')
-					.execute();
+			const rows = await db
+				.selectFrom('_kysely_schema_v1')
+				.select('id')
+				.orderBy('id', 'asc')
+				.execute();
 
-				expect(rows).toHaveLength(2);
-				expect(rows[1].id).toBeGreaterThan(rows[0].id);
-				// the old retry loop slept 1s per collision; the fix must not
-				expect(elapsed).toBeLessThan(900);
-			}
-		);
+			expect(rows).toHaveLength(2);
+			expect(rows[1].id).toBe(rows[0].id + 1);
+		});
 	});
 });


### PR DESCRIPTION

#### Description

- Closes: #1558 
- What does this PR change? Give us a brief description.

turns out the #1372 retry fix never got a real second chance on postgres: all migrations run in one transaction, so the first `23505` on `_kysely_schema_v1` poisons it and every retry just gets `25P02`, rolling back the whole fresh install. this swaps the second-granularity timestamp id for `max(now(), max(id)+1)` read inside the same transaction, so collisions can't happen by construction no retry loop, no 1s sleeps, no schema change.

also dropped the `catchAll(logError)` in `saveSchema` so a failed history write actually fails the migration instead of getting swallowed. added a regression test (two back-to-back syncs to two rows, fails on main) and verified on a fresh postgres 14 that `migrate --latest`, `--rollback` and re-apply all work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved schema migration history tracking with reliably increasing IDs.
- Prevented collisions during back-to-back schema synchronizations without unnecessary delays.
- Standardized migration failure handling for more consistent error reporting.

## Tests

- Added coverage confirming consecutive schema synchronizations create unique, increasing history IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->