### PR TITLE
feat(effect): add date and multiline clack wrappers

### DIFF
--- a/.changeset/fifty-owls-mix.md
+++ b/.changeset/fifty-owls-mix.md
@@ -1,0 +1,5 @@
+---
+"@withstudiocms/effect": minor
+---
+
+Expose new `@clack/prompts` v1.7 functionality through the Effect clack wrapper: adds `date` and `multiline` prompt wrappers and re-exports the `DateOptions`, `DateFormat`, `MultiLineOptions`, and `Option` types. All existing wrapper APIs are unchanged; no consumer updates required.

--- a/packages/@withstudiocms/effect/src/clack.ts
+++ b/packages/@withstudiocms/effect/src/clack.ts
@@ -6,8 +6,10 @@ import type {
 	ClackSettings,
 	CommonOptions,
 	ConfirmOptions,
+	DateOptions,
 	GroupMultiSelectOptions,
 	LogMessageOptions,
+	MultiLineOptions,
 	MultiSelectOptions,
 	NoteOptions,
 	PasswordOptions,
@@ -34,10 +36,14 @@ export type {
 	ClackSettings,
 	CommonOptions,
 	ConfirmOptions,
+	DateFormat,
+	DateOptions,
 	GroupMultiSelectOptions,
 	LogMessageOptions,
+	MultiLineOptions,
 	MultiSelectOptions,
 	NoteOptions,
+	Option,
 	PasswordOptions,
 	PathOptions,
 	ProgressOptions,
@@ -154,6 +160,14 @@ export const confirm = Effect.fn((options: ConfirmOptions) =>
 );
 
 /**
+ * Prompts the user for a date input using Clack, with error handling.
+ *
+ * @param opts - The configuration options for the date prompt.
+ * @returns The result of the date prompt, wrapped with error handling.
+ */
+export const date = (opts: DateOptions) => useClackErrorPromise(() => ClackPrompts.date(opts));
+
+/**
  * Groups multiple prompts together and executes them as a single operation.
  * Utilizes error handling via `useClackError` to wrap the `clackGroup` execution.
  *
@@ -223,7 +237,16 @@ export const isTTY = Effect.fn((output: Writable) =>
 );
 
 /**
- * Presents a multi-select prompt to the user with error handling.
+ * Prompts the user for multi-line text input using Clack, with error handling.
+ *
+ * @param opts - The configuration options for the multiline prompt.
+ * @returns The result of the multiline prompt, wrapped with error handling.
+ */
+export const multiline = (opts: MultiLineOptions) =>
+	useClackErrorPromise(() => ClackPrompts.multiline(opts));
+
+/**
+ * Presents a multi-select prompt to the user using Clack, handling errors gracefully.
  *
  * @typeParam T - The type of the selectable options.
  * @param options - The configuration options for the multi-select prompt.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

## Description

- Closes #1573 <!-- If applicable add an issue number to this PR so it can be closed otherwise feel free to remove this. -->
- What does this PR change?

follow-up to my analysis on the issue, this adds the two things our wrapper was actually missing from the clack v1.1 to v1.7 upgrade:

- `date` and `multiline` prompt wrappers 
- re-export `DateOptions`, `DateFormat`, `MultiLineOptions`, `Option`

everything else was already covered via the re-exported types. as discussed, i'm keeping the new undimmed `note()` look and not wrapping the low-level rendering helpers (`limitOptions`, `S_*`, etc.) unless someone needs them.

no breaking changes, all existing wrapper APIs and consumer call sites untouched.

## Testing

no new unit tests

## Docs

no user-facing behavior change
<!-- Could this affect a user’s behavior? We probably need to update docs! -->

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->
