### PR TITLE
chore(studiocms): remove deprecated `studiocmsMinimumVersion` from Plugin API

### DIFF
--- a/.changeset/silent-hands-attend.md
+++ b/.changeset/silent-hands-attend.md
@@ -1,0 +1,6 @@
+---
+"studiocms": minor
+"@studiocms/blog": patch
+---
+
+Removes the deprecated `studiocmsMinimumVersion` field from the Plugin API (`StudioCMSPluginBaseSchema`) and cleans up stale JSDoc that still referenced version checks. Plugins still passing the field will get a TypeScript excess-property error in `definePlugin()`; use `peerDependencies` to declare StudioCMS compatibility instead.

--- a/packages/@studiocms/blog/src/index.ts
+++ b/packages/@studiocms/blog/src/index.ts
@@ -89,7 +89,7 @@ export function internalBlogIntegration(options: StudioCMSBlogOptions = {}): Ast
  *
  * @remarks
  * This function sets up the StudioCMS Blog plugin with the provided options or default values.
- * It configures the plugin's identifier, name, minimum version, frontend navigation links, page types,
+ * It configures the plugin's identifier, name, frontend navigation links, page types,
  * sitemap settings, and integration hooks.
  *
  * @example

--- a/packages/studiocms/src/handlers/pluginHandler.ts
+++ b/packages/studiocms/src/handlers/pluginHandler.ts
@@ -222,7 +222,7 @@ type Options = {
  * Handles the setup and configuration of StudioCMS plugins during the Astro build process.
  *
  * This utility function is registered for the `astro:config:setup` hook and is responsible for:
- * - Initializing and validating StudioCMS plugins, including checking minimum version requirements.
+ * - Initializing and validating StudioCMS plugins.
  * - Collecting integrations, dashboard grid items, dashboard pages, plugin endpoints, renderers, image services, and other plugin-related data.
  * - Invoking plugin hooks (`studiocms:astro:config`, `studiocms:config:setup`) to allow plugins to register their features and integrations.
  * - Setting up virtual imports for plugin components, endpoints, renderers, and image services for use in the StudioCMS dashboard and editor.
@@ -238,7 +238,6 @@ type Options = {
  *   - `safePluginList`: List of validated and processed plugins with their safe configuration data.
  *   - `messages`: Informational messages about the plugin setup process.
  *
- * @throws {StudioCMSError} If a plugin specifies an invalid minimum version requirement or if no rendering plugins are found.
  * @throws {AstroError} If no rendering plugins are installed.
  */
 export const pluginHandler = async (
@@ -554,11 +553,10 @@ export const pluginHandler = async (
 	}
 
 	/**
-	 * Extracts and validates plugin data, ensuring it meets the required format and version.
+	 * Extracts plugin data, ensuring it meets the required format.
 	 *
 	 * @param plugin - The StudioCMSPlugin instance to process.
 	 * @returns An object containing the validated plugin data, including hooks and other properties.
-	 * @throws {StudioCMSError} If the plugin's minimum version requirement is not met.
 	 */
 	function getPluginData(plugin: StudioCMSPlugin) {
 		const { hooks = {}, requires, ...safeData } = plugin;

--- a/packages/studiocms/src/handlers/storage-manager/no-op.ts
+++ b/packages/studiocms/src/handlers/storage-manager/no-op.ts
@@ -8,7 +8,6 @@ const { resolve } = createPathResolver(import.meta.url);
  *
  * This storage manager performs no operations and serves as a placeholder.
  *
- * @param version - The minimum StudioCMS version required for this storage manager.
  * @returns A StudioCMSStorageManager plugin definition.
  */
 export const NoOpStorageManager = (): StudioCMSStorageManagerDef =>

--- a/packages/studiocms/src/schemas/plugins/index.ts
+++ b/packages/studiocms/src/schemas/plugins/index.ts
@@ -416,25 +416,19 @@ export const StorageManagerPluginHooksSchema = Schema.mutable(
  */
 export type StorageManagerPluginHooks = typeof StorageManagerPluginHooksSchema.Type;
 
-// TODO: Remove `studiocmsMinimumVersion` from Plugin API in a future release.
-
 /**
- * Schema for validating the structure of the base plugin configuration, including essential metadata such as identifier, name, minimum required version of StudioCMS, and dependencies on other plugins. This schema ensures that the basic information about the plugin is correctly structured, allowing for seamless integration of plugins into the StudioCMS system while providing necessary information about the plugin and its functionality.
+ * Schema for validating the structure of the base plugin configuration, including essential metadata such as identifier, name, and dependencies on other plugins. This schema ensures that the basic information about the plugin is correctly structured, allowing for seamless integration of plugins into the StudioCMS system while providing necessary information about the plugin and its functionality.
  */
 export class StudioCMSPluginBaseSchema extends Schema.Class<StudioCMSPluginBaseSchema>(
 	'StudioCMSPluginBaseSchema'
 )({
 	identifier: Schema.String,
 	name: Schema.String,
-	/**
-	 * @deprecated The `studiocmsMinimumVersion` property is deprecated and will be removed in a future release. Please ensure that your plugin is compatible with the latest version of StudioCMS and remove this property from your plugin configuration. It is recommended to use `peerDependencies` in your plugin's package.json to specify the compatible versions of StudioCMS instead of relying on this property for version compatibility checks.
-	 */
-	studiocmsMinimumVersion: Schema.optional(Schema.String),
 	requires: Schema.optional(Schema.Array(Schema.String)),
 }) {}
 
 /**
- * Schema for validating the structure of the entire plugin configuration, including metadata such as identifier, name, minimum required version of StudioCMS, dependencies on other plugins, and the hooks that the plugin implements. This schema ensures that the plugin configuration adheres to the expected structure, allowing for seamless integration of plugins into the StudioCMS system while providing necessary information about the plugin and its functionality.
+ * Schema for validating the structure of the entire plugin configuration, including metadata such as identifier, name, dependencies on other plugins, and the hooks that the plugin implements. This schema ensures that the plugin configuration adheres to the expected structure, allowing for seamless integration of plugins into the StudioCMS system while providing necessary information about the plugin and its functionality.
  */
 export class StudioCMSPluginSchema extends StudioCMSPluginBaseSchema.extend<StudioCMSPluginSchema>(
 	'StudioCMSPluginSchema'
@@ -462,7 +456,7 @@ export type PluginHookParameters<
 > = Fn extends (...args: any) => any ? Parameters<Fn>[0] : never;
 
 /**
- * Schema for validating the structure of the storage manager plugin configuration, including metadata such as identifier, name, minimum required version of StudioCMS, dependencies on other plugins, and the specific hooks related to storage management that the plugin implements. This schema extends the base plugin schema to include storage manager-specific hooks, ensuring that any implementation of a storage manager plugin adheres to the expected structure and provides necessary functionality for managing storage within the StudioCMS system while maintaining compatibility with the overall system.
+ * Schema for validating the structure of the storage manager plugin configuration, including metadata such as identifier, name, dependencies on other plugins, and the specific hooks related to storage management that the plugin implements. This schema extends the base plugin schema to include storage manager-specific hooks, ensuring that any implementation of a storage manager plugin adheres to the expected structure and provides necessary functionality for managing storage within the StudioCMS system while maintaining compatibility with the overall system.
  */
 export class StudioCMSStorageManagerSchema extends StudioCMSPluginBaseSchema.extend<StudioCMSStorageManagerSchema>(
 	'StudioCMSStorageManagerSchema'

--- a/packages/studiocms/src/test-utils.ts
+++ b/packages/studiocms/src/test-utils.ts
@@ -268,7 +268,7 @@ export class StudioCMSPluginTester {
 	/**
 	 * Retrieves information about the current plugin.
 	 *
-	 * @returns An object containing the plugin's identifier, name, minimum required StudioCMS version, and dependencies.
+	 * @returns An object containing the plugin's identifier, name, and dependencies.
 	 */
 	public getPluginInfo(): Pick<StudioCMSPlugin, 'identifier' | 'name' | 'requires'> {
 		return {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

## Description

- Closes #1449

- What does this PR change?

so this removes the deprecated `studiocmsMinimumVersion` field itself from `StudioCMSPluginBaseSchema` and cleans up the stale JSDoc that still mentioned version checks.

use peerDependencies instead.

## Testing

no new tests, this only deletes an optional, deprecated schema field with no remaining runtime enforcement and stale JSDoc.
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

docs may need a check: if the plugin authoring guide still mentions `studiocmsMinimumVersion`, it should point to `peerDependencies` instead.
<!-- Could this affect a user’s behavior? We probably need to update docs! -->

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the deprecated `studiocmsMinimumVersion` plugin configuration field.
  * Plugins still using this field will receive a TypeScript error.

* **Documentation**
  * Updated plugin documentation to remove outdated minimum-version validation references.
  * Use `peerDependencies` to declare StudioCMS compatibility instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->