### PR TITLE
fix: normalize Windows paths in virtual module imports

### DIFF
--- a/.changeset/eager-masks-beg.md
+++ b/.changeset/eager-masks-beg.md
@@ -1,0 +1,11 @@
+---
+"@withstudiocms/component-registry": patch
+"@withstudiocms/internal_helpers": patch
+"@studiocms/markdown-remark": patch
+"@studiocms/markdoc": patch
+"@studiocms/mdx": patch
+"@studiocms/md": patch
+"studiocms": patch
+---
+
+Fix Windows builds failing with "Expected unicode escape" when absolute paths with backslashes were embedded in virtual module import strings

--- a/.github/workflows/ci-path-resolver.yml
+++ b/.github/workflows/ci-path-resolver.yml
@@ -1,0 +1,76 @@
+name: CI - Path Resolver
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/@withstudiocms/internal_helpers/src/pathResolver.ts"
+      - "packages/@withstudiocms/internal_helpers/src/toModuleSpecifier.ts"
+      - "packages/@withstudiocms/internal_helpers/test/pathResolver.test.ts"
+      - "packages/@withstudiocms/internal_helpers/test/toModuleSpecifier.test.ts"
+      - "packages/@withstudiocms/internal_helpers/package.json"
+      - "packages/@withstudiocms/internal_helpers/vitest.config.ts"
+      - ".github/workflows/ci-path-resolver.yml"
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - "packages/@withstudiocms/internal_helpers/src/pathResolver.ts"
+      - "packages/@withstudiocms/internal_helpers/src/toModuleSpecifier.ts"
+      - "packages/@withstudiocms/internal_helpers/test/pathResolver.test.ts"
+      - "packages/@withstudiocms/internal_helpers/test/toModuleSpecifier.test.ts"
+      - "packages/@withstudiocms/internal_helpers/package.json"
+      - "packages/@withstudiocms/internal_helpers/vitest.config.ts"
+      - ".github/workflows/ci-path-resolver.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-path-resolver-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  os-independent:
+    name: toModuleSpecifier (OS-independent)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Tools & Dependencies
+        uses: withstudiocms/automations/.github/actions/install@f32588d80ce35d57905264f7fa473b0f6e297c0a # main
+
+      - name: Build internal_helpers
+        run: pnpm --filter @withstudiocms/internal_helpers build
+
+      - name: Run OS-independent tests
+        run: pnpm --filter @withstudiocms/internal_helpers exec vitest run test/toModuleSpecifier.test.ts
+
+  os-sensitive:
+    name: pathResolver (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Tools & Dependencies
+        uses: withstudiocms/automations/.github/actions/install@f32588d80ce35d57905264f7fa473b0f6e297c0a # main
+
+      - name: Build internal_helpers
+        run: pnpm --filter @withstudiocms/internal_helpers build
+
+      - name: Run OS-sensitive tests
+        run: pnpm --filter @withstudiocms/internal_helpers exec vitest run test/pathResolver.test.ts

--- a/packages/@studiocms/blog/vitest.config.ts
+++ b/packages/@studiocms/blog/vitest.config.ts
@@ -1,5 +1,6 @@
 import { internalMarkdownIntegration } from '@studiocms/md';
 import { addVirtualImports } from '@withstudiocms/internal_helpers/astro-integration';
+import { toModuleSpecifier } from '@withstudiocms/internal_helpers/toModuleSpecifier';
 import type { AstroIntegration } from 'astro';
 import { getViteConfig } from 'astro/config';
 import { defineProject, mergeConfig } from 'vitest/config';
@@ -33,8 +34,8 @@ const testIntegration: AstroIntegration = {
 							return [{ text: 'Home', href: '/', }, { text: 'Blog', href: '/blog' }];
 						}
 					`,
-					'studiocms:components': `export { default as FormattedDate } from '${resolve('./test/fixtures/FormattedDate.astro')}';`,
-					'studiocms:imageHandler/components': `export { default as CustomImage } from '${resolve('./test/fixtures/CustomImage.astro')}';`,
+					'studiocms:components': `export { default as FormattedDate } from ${toModuleSpecifier(resolve('./test/fixtures/FormattedDate.astro'))};`,
+					'studiocms:imageHandler/components': `export { default as CustomImage } from ${toModuleSpecifier(resolve('./test/fixtures/CustomImage.astro'))};`,
 				},
 			});
 		},

--- a/packages/@studiocms/markdoc/src/index.ts
+++ b/packages/@studiocms/markdoc/src/index.ts
@@ -7,6 +7,7 @@
 /// <reference types="studiocms/v/types" />
 
 import { addVirtualImports } from '@withstudiocms/internal_helpers/astro-integration';
+import { toModuleSpecifier } from '@withstudiocms/internal_helpers/toModuleSpecifier';
 import type { AstroIntegration } from 'astro';
 import { definePlugin } from 'studiocms/plugins';
 import type { StudioCMSPluginDef } from 'studiocms/schemas';
@@ -48,7 +49,7 @@ export function internalMarkDocIntegration(
 					name: packageIdentifier,
 					imports: {
 						'studiocms:markdoc/renderer': `
-							import { renderMarkDoc as _render } from '${internalRenderer}';
+							import { renderMarkDoc as _render } from ${toModuleSpecifier(internalRenderer)};
 
 							export const renderMarkDoc = _render;
 							export default renderMarkDoc;

--- a/packages/@studiocms/markdown-remark/src/integration/index.ts
+++ b/packages/@studiocms/markdown-remark/src/integration/index.ts
@@ -1,7 +1,9 @@
 /// <reference types="./virtual.d.ts" preserve="true" />
 
 import { addVirtualImports } from '@withstudiocms/internal_helpers/astro-integration';
-import createPathResolver from '@withstudiocms/internal_helpers/pathResolver';
+import createPathResolver, {
+	toModuleSpecifier,
+} from '@withstudiocms/internal_helpers/pathResolver';
 import type { AstroIntegration } from 'astro';
 import { MarkdownRemarkError } from '../errors.ts';
 import type { StudioCMSMarkdownRemarkIntegrationOptions } from '../types.ts';
@@ -28,7 +30,7 @@ const markdownRemark = (
 		verbose = defaultIntegrationOptions.verbose,
 	} = opts;
 
-	const { resolve } = createPathResolver(import.meta.url);
+	const { resolve, resolveModuleSpecifier } = createPathResolver(import.meta.url);
 
 	// We resolve the headings CSS path here so that it can be imported in the virtual CSS module.
 	const headingsCSS = resolve('../styles/headings.css');
@@ -65,9 +67,11 @@ const markdownRemark = (
 				addVirtualImports(params, {
 					name: '@studiocms/markdown-remark',
 					imports: {
-						'studiocms:markdown-remark': `export * from '${virtualComponents}';`,
-						'studiocms:markdown-remark/css': `import '${headingsCSS}'; ${
-							markdownExtended.callouts ? `import '${resolvedCalloutTheme}';` : ''
+						'studiocms:markdown-remark': `export * from ${resolveModuleSpecifier(virtualComponents)};`,
+						'studiocms:markdown-remark/css': `import ${resolveModuleSpecifier(headingsCSS)}; ${
+							markdownExtended.callouts
+								? `import ${resolveModuleSpecifier(resolvedCalloutTheme)};`
+								: ''
 						}`,
 						'studiocms:markdown-remark/user-components': `
 							export const componentKeys = ${JSON.stringify(Object.keys(components).map((name) => name.toLowerCase()))};
@@ -80,7 +84,7 @@ const markdownRemark = (
 											`Invalid component name "${name}": must be a valid JavaScript identifier when lowercased.`
 										);
 									}
-									return `export { default as ${id} } from '${astroRootResolve(path)}';`;
+									return `export { default as ${id} } from ${toModuleSpecifier(astroRootResolve(path))};`;
 								})
 								.join('\n')}
 						`,

--- a/packages/@studiocms/md/src/index.ts
+++ b/packages/@studiocms/md/src/index.ts
@@ -7,6 +7,7 @@
 /// <reference types="studiocms/v/types" />
 
 import { addVirtualImports } from '@withstudiocms/internal_helpers/astro-integration';
+import { toModuleSpecifier } from '@withstudiocms/internal_helpers/toModuleSpecifier';
 import type { AstroIntegration } from 'astro';
 import { Schema } from 'effect';
 import { definePlugin } from 'studiocms/plugins';
@@ -55,11 +56,11 @@ export function internalMarkdownIntegration(options: MarkdownSchemaOptions = {})
 							export default config;
 						`,
 						'studiocms:md/pre-render': `
-							export { preRender } from '${internalRenderer}';
+							export { preRender } from ${toModuleSpecifier(internalRenderer)};
 							`,
 						'studiocms:md/styles': `
-							import '${resolve('./styles/md-remark-headings.css')}';
-							${resolvedCalloutTheme ? `import '${resolvedCalloutTheme}';` : ''}
+							import ${toModuleSpecifier(resolve('./styles/md-remark-headings.css'))};
+							${resolvedCalloutTheme ? `import ${toModuleSpecifier(resolvedCalloutTheme)};` : ''}
 						`,
 					},
 				});

--- a/packages/@studiocms/mdx/src/index.ts
+++ b/packages/@studiocms/mdx/src/index.ts
@@ -7,6 +7,7 @@
 /// <reference types="studiocms/v/types" />
 
 import { addVirtualImports } from '@withstudiocms/internal_helpers/astro-integration';
+import { toModuleSpecifier } from '@withstudiocms/internal_helpers/toModuleSpecifier';
 import type { AstroIntegration } from 'astro';
 import { definePlugin } from 'studiocms/plugins';
 import type { StudioCMSPluginDef } from 'studiocms/schemas';
@@ -49,7 +50,7 @@ export function internalMDXIntegration(
 					name: packageIdentifier,
 					imports: {
 						'studiocms:mdx/renderer': `
-							import { renderMDX as _render } from '${internalRenderer}';
+							import { renderMDX as _render } from ${toModuleSpecifier(internalRenderer)};
 
 							export const renderMDX = _render;
 							export default renderMDX;

--- a/packages/@withstudiocms/component-registry/src/registry/handler.ts
+++ b/packages/@withstudiocms/component-registry/src/registry/handler.ts
@@ -2,7 +2,9 @@
 
 import { deepmerge, Effect, runEffect, Schema } from '@withstudiocms/effect';
 import { addVirtualImports } from '@withstudiocms/internal_helpers/astro-integration';
-import createPathResolver from '@withstudiocms/internal_helpers/pathResolver';
+import createPathResolver, {
+	toModuleSpecifier,
+} from '@withstudiocms/internal_helpers/pathResolver';
 import type { HookParameters } from 'astro';
 import type { ComponentRegistryEntry } from '../types.js';
 import { convertHyphensToUnderscores, integrationLogger } from '../utils.js';
@@ -167,7 +169,7 @@ export const componentRegistryHandler = async (
 			// Log the start of the component registry setup
 			integrationLogger(logInfo, 'Setting up component registry...');
 
-			const { resolve } = createPathResolver(import.meta.url);
+			const { resolve, resolveModuleSpecifier } = createPathResolver(import.meta.url);
 			const { resolve: astroConfigResolve } = createPathResolver(params.config.root.pathname);
 
 			// Resolve necessary paths and registry
@@ -236,7 +238,9 @@ export const componentRegistryHandler = async (
 
 					// Add the component key and import statement
 					componentKeys.push(safeKeyName);
-					components.push(`export { default as ${safeKeyName} } from '${resolvedPath}';`);
+					components.push(
+						`export { default as ${safeKeyName} } from ${toModuleSpecifier(resolvedPath)};`
+					);
 
 					// Register the component in the registry
 					yield* registry.registerComponentFromFile(resolvedPath, keyName);
@@ -282,7 +286,7 @@ export const componentRegistryHandler = async (
 				imports: {
 					[InternalId]: buildVirtualImport(componentKeys, componentProps, components),
 					[NameInternalId]: `export default '${name}'; export const name = '${name}';`,
-					[RuntimeInternalId]: `export * from '${virtualRuntimeImport}';`,
+					[RuntimeInternalId]: `export * from ${resolveModuleSpecifier(virtualRuntimeImport)};`,
 					...(virtualId ? buildAliasExports(virtualId) : {}),
 				},
 			});

--- a/packages/@withstudiocms/internal_helpers/package.json
+++ b/packages/@withstudiocms/internal_helpers/package.json
@@ -71,6 +71,10 @@
       "types": "./dist/pathResolver.d.ts",
       "default": "./dist/pathResolver.js"
     },
+    "./toModuleSpecifier": {
+      "types": "./dist/toModuleSpecifier.d.ts",
+      "default": "./dist/toModuleSpecifier.js"
+    },
     "./debug-info-provider": {
       "types": "./dist/debug-info-provider.d.ts",
       "default": "./dist/debug-info-provider.js"

--- a/packages/@withstudiocms/internal_helpers/src/pathResolver.ts
+++ b/packages/@withstudiocms/internal_helpers/src/pathResolver.ts
@@ -1,9 +1,36 @@
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { toModuleSpecifier } from './toModuleSpecifier.js';
 
+export { toModuleSpecifier } from './toModuleSpecifier.js';
+
+/**
+ * Interface representing a path resolver with methods to resolve paths and URLs.
+ */
 interface PathResolver {
+	/**
+	 * Resolve path segments against the base directory and return a platform-native absolute filesystem path.
+	 *
+	 * @param segments - Path segments to resolve.
+	 * @returns The resolved absolute filesystem path (platform-native separators).
+	 */
 	resolve: (...segments: string[]) => string;
+
+	/**
+	 * Resolve path segments against the base directory and return a file:// URL.
+	 *
+	 * @param segments - Path segments to resolve.
+	 * @returns The resolved file URL.
+	 */
 	resolveURL: (...segments: string[]) => URL;
+
+	/**
+	 * Resolve path segments against the base directory and return a JS module specifier.
+	 *
+	 * @param segments - Path segments to resolve.
+	 * @returns The resolved module specifier (JSON-quoted, POSIX-normalized).
+	 */
+	resolveModuleSpecifier: (...segments: string[]) => string;
 }
 
 /**
@@ -20,7 +47,8 @@ interface PathResolver {
  *   - a filesystem path string (absolute or relative).
  * @returns An object with two helpers:
  *   - `resolve(...segments: string[]): string` — resolves the given path segments
- *     against the computed base directory and returns an absolute filesystem path.
+ *     against the computed base directory and returns a platform-native absolute
+ *     filesystem path (same contract as `path.resolve`).
  *   - `resolveURL(...segments: string[]): URL` — resolves the given path segments
  *     against the computed base directory and returns a `file://` URL.
  *
@@ -48,7 +76,7 @@ function createPathResolver(baseOption: string): PathResolver {
 		 * Resolve path segments against the base directory.
 		 *
 		 * @param segments - Path segments to resolve.
-		 * @returns The resolved absolute filesystem path.
+		 * @returns The resolved absolute filesystem path (platform-native separators).
 		 */
 		resolve: (...segments: string[]): string => path.resolve(baseDir, ...segments),
 
@@ -59,6 +87,17 @@ function createPathResolver(baseOption: string): PathResolver {
 		 * @returns The resolved file URL.
 		 */
 		resolveURL: (...segments: string[]): URL => pathToFileURL(path.resolve(baseDir, ...segments)),
+
+		/**
+		 * Resolve path segments against the base directory and return a JS module specifier.
+		 *
+		 * @param segments - Path segments to resolve.
+		 * @returns The resolved module specifier (JSON-quoted, POSIX-normalized).
+		 */
+		resolveModuleSpecifier: (...segments: string[]): string => {
+			const resolvedPath = path.resolve(baseDir, ...segments);
+			return toModuleSpecifier(resolvedPath);
+		},
 	};
 }
 

--- a/packages/@withstudiocms/internal_helpers/src/toModuleSpecifier.ts
+++ b/packages/@withstudiocms/internal_helpers/src/toModuleSpecifier.ts
@@ -1,0 +1,13 @@
+/**
+ * Convert a filesystem path or URL into a JS module specifier literal (JSON-quoted).
+ * Paths are normalized to POSIX separators because Vite/Rollup normalize
+ * module ids to POSIX internally; JSON.stringify is what makes the result
+ * safe to embed (escaping backslashes, quotes, etc.).
+ *
+ * URL inputs use `.href` (e.g. `file://…`), which Vite accepts as a module id.
+ */
+export function toModuleSpecifier(filePath: string | URL): string {
+	let normalized = filePath instanceof URL ? filePath.href : filePath;
+	normalized = process.platform === 'win32' ? normalized.replaceAll('\\', '/') : normalized;
+	return JSON.stringify(normalized);
+}

--- a/packages/@withstudiocms/internal_helpers/src/toModuleSpecifier.ts
+++ b/packages/@withstudiocms/internal_helpers/src/toModuleSpecifier.ts
@@ -7,7 +7,6 @@
  * URL inputs use `.href` (e.g. `file://…`), which Vite accepts as a module id.
  */
 export function toModuleSpecifier(filePath: string | URL): string {
-	let normalized = filePath instanceof URL ? filePath.href : filePath;
-	normalized = process.platform === 'win32' ? normalized.replaceAll('\\', '/') : normalized;
-	return JSON.stringify(normalized);
+	const normalized = filePath instanceof URL ? filePath.href : filePath;
+	return JSON.stringify(normalized.replaceAll('\\', '/'));
 }

--- a/packages/@withstudiocms/internal_helpers/src/utils/pageTypeFilter.ts
+++ b/packages/@withstudiocms/internal_helpers/src/utils/pageTypeFilter.ts
@@ -1,3 +1,5 @@
+import { toModuleSpecifier } from '../toModuleSpecifier.js';
+
 /**
  * Generates an export statement for a renderer component based on the provided component path and page type.
  *
@@ -10,7 +12,7 @@ export function rendererComponentFilter(comp: string | undefined, safePageType: 
 	if (!comp) {
 		throw new Error(`Renderer Component path is required for page type: ${safePageType}`);
 	}
-	return `export { default as ${safePageType} } from '${comp}';`;
+	return `export { default as ${safePageType} } from ${toModuleSpecifier(comp)};`;
 }
 
 /**
@@ -25,5 +27,5 @@ export function pageContentComponentFilter(comp: string | undefined, safePageTyp
 	if (!comp) {
 		throw new Error(`Page Content Component path is required for page type: ${safePageType}`);
 	}
-	return `export { default as ${safePageType} } from '${comp}';`;
+	return `export { default as ${safePageType} } from ${toModuleSpecifier(comp)};`;
 }

--- a/packages/@withstudiocms/internal_helpers/test/pathResolver.test.ts
+++ b/packages/@withstudiocms/internal_helpers/test/pathResolver.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, test } from 'vitest';
 import createPathResolver from '../src/pathResolver.js';
 import { parentSuiteName, sharedTags } from './test-utils.js';
 
-const localSuiteName = 'Path Resolver Tests';
+const localSuiteName = 'Path Resolver Tests (OS-sensitive)';
 
 describe(parentSuiteName, () => {
 	let testFileUrl: string;
@@ -218,16 +218,21 @@ describe(parentSuiteName, () => {
 		expect(fileURLToPath(resolvedURL)).toBe(resolvedPath);
 	});
 
-	test('should work with both Windows and Unix-style paths', async () => {
+	test('resolve returns platform-native separators', async () => {
 		await allure.parentSuite(parentSuiteName);
 		await allure.suite(localSuiteName);
-		await allure.subSuite('should work with both Windows and Unix-style paths');
+		await allure.subSuite('resolve returns platform-native separators');
 		await allure.tags(...sharedTags);
 
 		const resolver = createPathResolver(process.cwd());
 		const result = resolver.resolve('src', 'utils', 'helper.ts');
+		const expected = path.join(process.cwd(), 'src', 'utils', 'helper.ts');
 
-		// Should always produce platform-appropriate separators
-		expect(result).toBe(path.join(process.cwd(), 'src', 'utils', 'helper.ts'));
+		expect(result).toBe(expected);
+		if (process.platform === 'win32') {
+			expect(result).toContain('\\');
+		} else {
+			expect(result).not.toContain('\\');
+		}
 	});
 });

--- a/packages/@withstudiocms/internal_helpers/test/toModuleSpecifier.test.ts
+++ b/packages/@withstudiocms/internal_helpers/test/toModuleSpecifier.test.ts
@@ -1,0 +1,59 @@
+import * as allure from 'allure-js-commons';
+import { describe, expect, test } from 'vitest';
+import { toModuleSpecifier } from '../src/toModuleSpecifier.js';
+import { parentSuiteName, sharedTags } from './test-utils.js';
+
+const localSuiteName = 'toModuleSpecifier Tests (OS-independent)';
+
+describe(parentSuiteName, () => {
+	test('JSON-quotes and POSIX-normalizes Windows-style paths', async () => {
+		await allure.parentSuite(parentSuiteName);
+		await allure.suite(localSuiteName);
+		await allure.subSuite('JSON-quotes and POSIX-normalizes Windows-style paths');
+		await allure.tags(...sharedTags);
+
+		const windowsStyle = 'E:\\AI Projects\\node_modules\\studiocms\\dist\\utils\\safeString.js';
+		const specifier = toModuleSpecifier(windowsStyle);
+
+		expect(specifier).toBe(
+			JSON.stringify('E:/AI Projects/node_modules/studiocms/dist/utils/safeString.js')
+		);
+		expect(specifier.startsWith('"')).toBe(true);
+		expect(specifier).not.toContain('\\u');
+	});
+
+	test('escapes backslash sequences that would be JS escapes if unquoted', async () => {
+		await allure.parentSuite(parentSuiteName);
+		await allure.suite(localSuiteName);
+		await allure.subSuite('escapes backslash sequences that would be JS escapes if unquoted');
+		await allure.tags(...sharedTags);
+
+		const windowsStyle = 'E:\\node_modules\\pkg\\utils\\file.js';
+		const specifier = toModuleSpecifier(windowsStyle);
+		const embedded = `from ${specifier}`;
+
+		expect(embedded).toBe('from "E:/node_modules/pkg/utils/file.js"');
+		expect(embedded).not.toMatch(/\\[unt]/);
+	});
+
+	test('JSON.stringify alone would escape; POSIX form matches Vite module ids', async () => {
+		await allure.parentSuite(parentSuiteName);
+		await allure.suite(localSuiteName);
+		await allure.subSuite('JSON.stringify alone would escape; POSIX form matches Vite module ids');
+		await allure.tags(...sharedTags);
+
+		const raw = 'C:\\Users\\test\\file.js';
+		expect(JSON.stringify(raw)).toBe('"C:\\\\Users\\\\test\\\\file.js"');
+		expect(toModuleSpecifier(raw)).toBe('"C:/Users/test/file.js"');
+	});
+
+	test('URL inputs use href as the module specifier', async () => {
+		await allure.parentSuite(parentSuiteName);
+		await allure.suite(localSuiteName);
+		await allure.subSuite('URL inputs use href as the module specifier');
+		await allure.tags(...sharedTags);
+
+		const fileUrl = new URL('file:///E:/AI%20Projects/pkg/service.js');
+		expect(toModuleSpecifier(fileUrl)).toBe(JSON.stringify(fileUrl.href));
+	});
+});

--- a/packages/@withstudiocms/internal_helpers/test/utils.test.ts
+++ b/packages/@withstudiocms/internal_helpers/test/utils.test.ts
@@ -185,8 +185,14 @@ describe(parentSuiteName, () => {
 		{
 			comp: './components/Renderer.astro',
 			safePageType: 'BlogPage',
-			expected: `export { default as BlogPage } from './components/Renderer.astro';`,
+			expected: `export { default as BlogPage } from "./components/Renderer.astro";`,
 			description: 'returns correct export statement for valid input',
+		},
+		{
+			comp: 'E:\\projects\\node_modules\\pkg\\utils\\Renderer.astro',
+			safePageType: 'WinPage',
+			expected: `export { default as WinPage } from "E:/projects/node_modules/pkg/utils/Renderer.astro";`,
+			description: 'POSIX-normalizes Windows paths in the export specifier',
 		},
 		{
 			comp: undefined,
@@ -230,8 +236,14 @@ describe(parentSuiteName, () => {
 		{
 			comp: './components/PageContent.astro',
 			safePageType: 'DocsPage',
-			expected: `export { default as DocsPage } from './components/PageContent.astro';`,
+			expected: `export { default as DocsPage } from "./components/PageContent.astro";`,
 			description: 'returns correct export statement for valid input',
+		},
+		{
+			comp: 'E:\\projects\\node_modules\\pkg\\utils\\PageContent.astro',
+			safePageType: 'WinDocs',
+			expected: `export { default as WinDocs } from "E:/projects/node_modules/pkg/utils/PageContent.astro";`,
+			description: 'POSIX-normalizes Windows paths in the export specifier',
 		},
 		{
 			comp: undefined,

--- a/packages/studiocms/src/handlers/pluginHandler.ts
+++ b/packages/studiocms/src/handlers/pluginHandler.ts
@@ -5,7 +5,9 @@ import {
 	type Messages,
 	pluginLogger,
 } from '@withstudiocms/internal_helpers/astro-integration';
-import createPathResolver from '@withstudiocms/internal_helpers/pathResolver';
+import createPathResolver, {
+	toModuleSpecifier,
+} from '@withstudiocms/internal_helpers/pathResolver';
 import {
 	convertToSafeString,
 	pageContentComponentFilter,
@@ -44,7 +46,7 @@ import { buildTranslations, loadJsTranslations } from '../utils/lang-helper.js';
 import { NoOpStorageManager } from './storage-manager/no-op.js';
 
 // Resolver Function
-const { resolve } = createPathResolver(import.meta.url);
+const { resolve, resolveModuleSpecifier } = createPathResolver(import.meta.url);
 
 type VirtualImport = {
 	id: string;
@@ -399,6 +401,12 @@ export const pluginHandler = async (
 	let finalStorageManagerModulePath: string | undefined;
 	let finalStorageManagerName: string | undefined;
 
+	function getFinalStorageManagerModulePath() {
+		return finalStorageManagerModulePath
+			? `export { default } from ${toModuleSpecifier(finalStorageManagerModulePath)};`
+			: `export { default } from ${resolveModuleSpecifier('./storage-manager/core/no-op-storage-manager.js')};`;
+	}
+
 	/////
 
 	/**
@@ -592,7 +600,7 @@ export const pluginHandler = async (
 		const { endpointPath, formattedName, name, svg, requiredEnvVariables } = oAuthProvider;
 		const safeName = convertToSafeString(name);
 		let enabled = true;
-		const endpoints = `export { initSession as ${safeName}_initSession, initCallback as ${safeName}_initCallback } from '${endpointPath}';`;
+		const endpoints = `export { initSession as ${safeName}_initSession, initCallback as ${safeName}_initCallback } from ${toModuleSpecifier(endpointPath)};`;
 		const env = loadEnv('', process.cwd(), '');
 
 		if (requiredEnvVariables) {
@@ -708,7 +716,7 @@ export const pluginHandler = async (
 
 	const remapAugmentComps = (components: Record<string, string>) =>
 		Object.entries(components)
-			.map(([key, value]) => `export { default as ${key} } from '${value}';`)
+			.map(([key, value]) => `export { default as ${key} } from ${toModuleSpecifier(value)};`)
 			.join('\n');
 
 	/////
@@ -791,9 +799,7 @@ export const pluginHandler = async (
 			},
 			{
 				id: 'studiocms:storage-manager/module',
-				content: `
-						export { default } from '${finalStorageManagerModulePath}';
-					`,
+				content: getFinalStorageManagerModulePath(),
 			},
 			{
 				id: 'studiocms:storage-manager/name',
@@ -909,9 +915,7 @@ export const pluginHandler = async (
 							pluginSettingsEndpoints.push({
 								identifier: safeData.identifier,
 								safeIdentifier: convertToSafeString(safeData.identifier),
-								apiEndpoint: `
-											export { onSave as ${convertToSafeString(safeData.identifier)}_onSave } from '${endpoint}';
-										`,
+								apiEndpoint: `export { onSave as ${convertToSafeString(safeData.identifier)}_onSave } from ${toModuleSpecifier(endpoint)};`,
 							});
 						}
 
@@ -965,9 +969,9 @@ export const pluginHandler = async (
 								identifier: identifier,
 								safeIdentifier: convertToSafeString(identifier),
 								apiEndpoint: `
-											export { onCreate as ${convertToSafeString(identifier)}_onCreate } from '${apiEndpoint}';
-											export { onEdit as ${convertToSafeString(identifier)}_onEdit } from '${apiEndpoint}';
-											export { onDelete as ${convertToSafeString(identifier)}_onDelete } from '${apiEndpoint}';
+											export { onCreate as ${convertToSafeString(identifier)}_onCreate } from ${toModuleSpecifier(apiEndpoint)};
+											export { onEdit as ${convertToSafeString(identifier)}_onEdit } from ${toModuleSpecifier(apiEndpoint)};
+											export { onDelete as ${convertToSafeString(identifier)}_onDelete } from ${toModuleSpecifier(apiEndpoint)};
 										`,
 							});
 						}
@@ -1022,7 +1026,7 @@ export const pluginHandler = async (
 						});
 
 						imageServiceEndpoints.push(
-							`export { default as ${convertToSafeString(imageService.identifier)} } from '${imageService.servicePath}';`
+							`export { default as ${convertToSafeString(imageService.identifier)} } from ${toModuleSpecifier(imageService.servicePath)};`
 						);
 					}
 				},
@@ -1106,7 +1110,7 @@ export const pluginHandler = async (
 			{
 				id: 'virtual:studiocms/components/Editors',
 				content: `
-						import { convertToSafeString } from '${resolve('../utils/safeString.js')}';
+						import { convertToSafeString } from ${resolveModuleSpecifier('../utils/safeString.js')};
 						export const editorKeys = ${JSON.stringify([
 							...allPageTypes.map(({ identifier }) => convertToSafeString(identifier)),
 						])};
@@ -1127,7 +1131,7 @@ export const pluginHandler = async (
 						const components: Record<string, string> = item.body?.components || {};
 
 						const remappedComps = Object.entries(components).map(
-							([key, value]) => `export { default as ${key} } from '${value}';`
+							([key, value]) => `export { default as ${key} } from ${toModuleSpecifier(value)};`
 						);
 
 						return remappedComps.join('\n');
@@ -1179,7 +1183,7 @@ export const pluginHandler = async (
 
 							const remappedComps = Object.entries(components).map(
 								([key, value]) =>
-									`export { default as ${convertToSafeString(item.title + key)} } from '${value}';`
+									`export { default as ${convertToSafeString(item.title + key)} } from ${toModuleSpecifier(value)};`
 							);
 
 							return remappedComps.join('\n');
@@ -1205,7 +1209,7 @@ export const pluginHandler = async (
 
 							const remappedComps = Object.entries(components).map(
 								([key, value]) =>
-									`export { default as ${convertToSafeString(item.title + key)} } from '${value}';`
+									`export { default as ${convertToSafeString(item.title + key)} } from ${toModuleSpecifier(value)};`
 							);
 
 							return remappedComps.join('\n');
@@ -1215,7 +1219,7 @@ export const pluginHandler = async (
 			{
 				id: 'studiocms:plugins/dashboard-pages/user',
 				content: `
-						import { convertToSafeString } from '${resolve('../utils/safeString.js')}';
+						import { convertToSafeString } from ${resolveModuleSpecifier('../utils/safeString.js')};
 						import * as components from 'studiocms:plugins/dashboard-pages/components/user';
 
 						const currentComponents = ${JSON.stringify(availableDashboardPages.user || [])};
@@ -1239,7 +1243,7 @@ export const pluginHandler = async (
 			{
 				id: 'studiocms:plugins/dashboard-pages/admin',
 				content: `
-						import { convertToSafeString } from '${resolve('../utils/safeString.js')}';
+						import { convertToSafeString } from ${resolveModuleSpecifier('../utils/safeString.js')};
 						import * as components from 'studiocms:plugins/dashboard-pages/components/admin';
 
 						const currentComponents = ${JSON.stringify(availableDashboardPages.admin || [])};
@@ -1342,7 +1346,7 @@ export const pluginHandler = async (
 				content: `
 						import * as augments from 'virtual:studiocms/plugins/augments';
 						import * as postProcessorAugments from 'virtual:studiocms/plugins/post-processor-augments';
-						import { convertToSafeString } from '${resolve('../utils/safeString.js')}';
+						import { convertToSafeString } from ${resolveModuleSpecifier('../utils/safeString.js')};
 
 						const pluginAugments = ${JSON.stringify(pluginAugments || [])};
 						const postProcessorPluginAugments = ${JSON.stringify(postProcessorAugments || [])};
@@ -1422,7 +1426,9 @@ export const pluginHandler = async (
 			},
 			{
 				id: 'studiocms:dashboard/augments/scripts',
-				content: dashboardAugmentScripts.map((script) => `import '${script}';`).join('\n'),
+				content: dashboardAugmentScripts
+					.map((script) => `import ${toModuleSpecifier(script)};`)
+					.join('\n'),
 			},
 			{
 				id: 'studiocms:plugins/list',
@@ -1437,9 +1443,7 @@ export const pluginHandler = async (
 			},
 			{
 				id: 'studiocms:storage-manager/module',
-				content: `
-						export { default } from '${finalStorageManagerModulePath}';
-					`,
+				content: getFinalStorageManagerModulePath(),
 			},
 			{
 				id: 'studiocms:storage-manager/name',

--- a/packages/studiocms/src/handlers/setupDbStudio.ts
+++ b/packages/studiocms/src/handlers/setupDbStudio.ts
@@ -3,7 +3,7 @@ import createPathResolver from '@withstudiocms/internal_helpers/pathResolver';
 import type { HookParameters } from 'astro';
 import type { StudioCMSConfig } from '../schemas/index.js';
 
-const { resolve } = createPathResolver(import.meta.url);
+const { resolve, resolveModuleSpecifier } = createPathResolver(import.meta.url);
 
 export const setupDbStudio = async (
 	params: HookParameters<'astro:config:setup'>,
@@ -15,7 +15,7 @@ export const setupDbStudio = async (
 	addVirtualImports(params, {
 		name: 'studiocms:db-studio',
 		imports: {
-			'virtual:studiocms/db-studio/connection': `export { createConnectionFromConfig } from '${resolve(`../toolbar/db-viewer/studio/virtual-connection/${dialect}.js`)}';`,
+			'virtual:studiocms/db-studio/connection': `export { createConnectionFromConfig } from ${resolveModuleSpecifier(`../toolbar/db-viewer/studio/virtual-connection/${dialect}.js`)};`,
 		},
 	});
 

--- a/packages/studiocms/src/plugins/analytics/index.ts
+++ b/packages/studiocms/src/plugins/analytics/index.ts
@@ -10,7 +10,7 @@ import { WEB_VITALS_ENDPOINT_PATH } from './consts.js';
 import { getAnalyticsDbClient } from './db-client.js';
 import { StudioCMSMetricTableDefinition } from './table.js';
 
-const { resolve } = createPathResolver(import.meta.url);
+const { resolve, resolveModuleSpecifier } = createPathResolver(import.meta.url);
 
 /**
  * Resolves a path within the analytics plugin.
@@ -58,14 +58,14 @@ const webVitalsIntegration = (): AstroIntegration => {
 				});
 
 				// Client-side performance measurement script.
-				injectScript('page', `import '${resolve('./client-script.js')}';`);
+				injectScript('page', `import ${resolveModuleSpecifier('./client-script.js')};`);
 
 				// Virtual import for dashboard web vitals components and data fetching.
 				addVirtualImports(params, {
 					name: pkgName,
 					imports: {
 						'studiocms-dashboard:web-vitals': `
-                            export * from '${resolve('./assets/webVital.js')}';
+                            export * from ${resolveModuleSpecifier('./assets/webVital.js')};
                         `,
 					},
 				});

--- a/packages/studiocms/src/virtuals/utils.ts
+++ b/packages/studiocms/src/virtuals/utils.ts
@@ -70,7 +70,7 @@ export const VirtualModuleBuilder = (resolve: (...path: Array<string>) => string
 	 * Generates import statements for a list of module paths (for side effects).
 	 */
 	const ambientScripts = (items: Array<string>): string =>
-		items.map((item) => `import '${resolve(item)}';`).join('\n');
+		items.map((item) => `import ${JSON.stringify(resolve(item))};`).join('\n');
 
 	/**
 	 * Generates code to re-export a named export (and optionally as default) from a module.

--- a/packages/studiocms/test/virtuals/utils.test.ts
+++ b/packages/studiocms/test/virtuals/utils.test.ts
@@ -116,8 +116,8 @@ describe(parentSuiteName, () => {
 		await step('Testing ambientScripts method', async () => {
 			const items = ['foo.js', 'bar.js'];
 			const result = builder.ambientScripts(items);
-			expect(result).toContain("import 'foo.js';");
-			expect(result).toContain("import 'bar.js';");
+			expect(result).toContain('import "foo.js";');
+			expect(result).toContain('import "bar.js";');
 		});
 	});
 

--- a/packages/studiocms/vitest.config.ts
+++ b/packages/studiocms/vitest.config.ts
@@ -15,7 +15,7 @@ import {
 } from './src/virtuals/i18n/v-files';
 import { buildVirtualConfig } from './src/virtuals/utils';
 
-const { resolve } = createPathResolver(import.meta.url);
+const { resolve, resolveModuleSpecifier } = createPathResolver(import.meta.url);
 
 const CMSConfig: StudioCMSOptions = {
 	dbStartPage: false,
@@ -47,8 +47,8 @@ const testIntegration: AstroIntegration = {
 				imports: {
 					'studiocms:version': `export default '0.0.0-test';`,
 					'studiocms:i18n/config': `export default ${JSON.stringify({ ...testConfig.locale.i18n })}`,
-					'studiocms:i18n': `export * from '${resolve('./src/virtuals/i18n/server.ts')}';`,
-					'studiocms:i18n/client': `export * from '${resolve('./src/virtuals/i18n/client.ts')}';`,
+					'studiocms:i18n': `export * from ${resolveModuleSpecifier('./src/virtuals/i18n/server.ts')};`,
+					'studiocms:i18n/client': `export * from ${resolveModuleSpecifier('./src/virtuals/i18n/client.ts')};`,
 					'studiocms:i18n/virtual': `
 						export const availableTranslationFileKeys = ${JSON.stringify(availableTranslationFileKeys)};
 						export const availableTranslations = ${JSON.stringify(availableTranslations)};
@@ -63,8 +63,8 @@ const testIntegration: AstroIntegration = {
 						// Test-only identity renderer: mirrors API shape but skips sanitization on purpose.
 						'export const createRenderer = (result, sanitize, preRenderer) => (content) => content;',
 					'studiocms:auth/scripts/three': `export const hello = 'world';`,
-					'studiocms:auth/utils/validImages': `export * from '${resolve('./src/virtuals/auth/validImages/index.ts')}';`,
-					'studiocms:lib': `export * from '${resolve('./src/virtuals/lib/routeMap.ts')}';`,
+					'studiocms:auth/utils/validImages': `export * from ${resolveModuleSpecifier('./src/virtuals/auth/validImages/index.ts')};`,
+					'studiocms:lib': `export * from ${resolveModuleSpecifier('./src/virtuals/lib/routeMap.ts')};`,
 					'studiocms:plugins/auth/providers': `export const oAuthButtons = ${JSON.stringify([
 						{
 							enabled: true,
@@ -80,7 +80,7 @@ const testIntegration: AstroIntegration = {
 						},
 					])};`,
 					'virtual:studiocms/sitemaps': `export const sitemaps = ['./sitemap-blog.xml', './sitemap-shop.xml'];`,
-					'studiocms:components': `export { default as Generator } from '${resolve('./test/fixtures/Generator.astro')}';`,
+					'studiocms:components': `export { default as Generator } from ${resolveModuleSpecifier('./test/fixtures/Generator.astro')};`,
 					'studiocms:plugins/augments':
 						'export const renderAugments = []; export const renderPostProcessorAugments = [];',
 				},


### PR DESCRIPTION
This pull request addresses a critical cross-platform issue with Windows builds failing due to unescaped backslashes in virtual module import strings. It introduces a new utility, `toModuleSpecifier`, to safely generate module specifiers for import statements, normalizing paths and escaping special characters. The utility is integrated throughout the codebase, and a dedicated CI workflow is added to ensure robust path resolution across operating systems.

- Closes: #1059 

The most important changes are:

**Cross-platform Path Handling & Bug Fixes:**
* Introduced the `toModuleSpecifier` utility (`packages/@withstudiocms/internal_helpers/src/toModuleSpecifier.ts`) to convert filesystem paths and URLs into JSON-quoted, POSIX-normalized JS module specifiers, preventing Windows build errors due to unescaped backslashes. 
* Updated all virtual import generation and export statements across packages (e.g., `@studiocms/md`, `@studiocms/mdx`, `@studiocms/markdoc`, `@studiocms/markdown-remark`, `@withstudiocms/component-registry`) to use `toModuleSpecifier` for safer, cross-platform imports. 

**Internal Helpers & API Improvements:**
* Exported `toModuleSpecifier` from `pathResolver.ts` and added a new `resolveModuleSpecifier` method to the `PathResolver` interface, providing a unified API for path, URL, and module specifier resolution. 
* Updated `package.json` exports for `@withstudiocms/internal_helpers` to include the new `toModuleSpecifier` entry point. 

**Testing & CI:**
* Added a new GitHub Actions workflow (`.github/workflows/ci-path-resolver.yml`) to run path resolution tests on Ubuntu, Windows, and macOS, ensuring continued cross-platform compatibility.

These changes collectively ensure that virtual import paths are safely constructed and compatible across all supported operating systems, eliminating a major source of build failures on Windows.

@coderabbitai ignore