### PR TITLE
Add @changesets packages to ignoreDeps in renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,6 +77,10 @@
     "zod",
     "kysely",
     "typescript",
-    "diff"
+    "diff",
+    "@changesets/changelog-github",
+    "@changesets/cli",
+    "@changesets/config",
+    "@changesets/write"
   ]
 }


### PR DESCRIPTION
This pull request updates the `.github/renovate.json` configuration to include several new dependencies related to Changesets, which is a tool for managing versioning and changelogs. This will help automate changelog generation and version management in the project.

Prevents any potential upgrade issues for the time being.

Dependency management:

* Added `@changesets/changelog-github`, `@changesets/cli`, `@changesets/config`, and `@changesets/write` to the list of dependencies managed by Renovate, enabling automated updates and maintenance for Changesets tooling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance settings to exclude selected packages from upgrade proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->