### PR TITLE
Migrate from external kysely-turso package to local driver implementation

### DIFF
--- a/.changeset/calm-books-dance.md
+++ b/.changeset/calm-books-dance.md
@@ -1,0 +1,6 @@
+---
+"@withstudiocms/kysely": minor
+"studiocms": minor
+---
+
+Migrate from external `kysely-turso` package to local driver

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -65,7 +65,6 @@
     "@libsql/client",
     "@types/node",
     "@vitest/coverage-v8",
-    "drizzle-orm",
     "sharp",
     "node",
     "npm",

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -228,7 +228,7 @@ const config: KnipConfig = {
 			ignore: ['**/*'],
 		},
 		playground: {
-			ignoreDependencies: ['sharp', '@libsql/client', 'kysely-turso', '@effect/platform-node'],
+			ignoreDependencies: ['sharp', '@libsql/client', '@effect/platform-node'],
 			astro: {
 				entry: [
 					'studiocms.config.{js,cjs,mjs,ts,mts}',

--- a/packages/@withstudiocms/kysely/package.json
+++ b/packages/@withstudiocms/kysely/package.json
@@ -68,6 +68,10 @@
       "types": "./dist/drivers/*.d.ts",
       "default": "./dist/drivers/*.js"
     },
+    "./drivers/kysely-turso": {
+      "types": "./dist/drivers/kysely-turso/index.d.ts",
+      "default": "./dist/drivers/kysely-turso/index.js"
+    },
     "./utils/*": {
       "types": "./dist/utils/*.d.ts",
       "default": "./dist/utils/*.js"
@@ -75,8 +79,7 @@
   },
   "type": "module",
   "dependencies": {
-    "kysely": "catalog:kysely",
-    "kysely-turso": "catalog:kysely"
+    "kysely": "catalog:kysely"
   },
   "devDependencies": {
     "@types/node": "catalog:",
@@ -85,15 +88,11 @@
   "peerDependencies": {
     "@libsql/client": "catalog:kysely",
     "effect": "catalog:effect",
-    "kysely-turso": "catalog:kysely",
     "mysql2": "catalog:kysely",
     "pg": "catalog:kysely"
   },
   "peerDependenciesMeta": {
     "@libsql/client": {
-      "optional": true
-    },
-    "kysely-turso": {
       "optional": true
     },
     "mysql2": {

--- a/packages/@withstudiocms/kysely/src/drivers/kysely-turso/dialect-config.ts
+++ b/packages/@withstudiocms/kysely/src/drivers/kysely-turso/dialect-config.ts
@@ -1,0 +1,36 @@
+// https://github.com/tursodatabase/turso/blob/main/packages/turso-serverless/src/compat.ts
+
+export interface LibSQLDialectConfig {
+	client: LibSQLClient | (() => LibSQLClient | Promise<LibSQLClient>);
+}
+
+export interface LibSQLClient extends LibSQLExecutor {
+	close: () => void;
+	closed: boolean;
+	transaction: (mode?: LibSQLTransactionMode) => Promise<LibSQLTransaction>;
+}
+
+export interface LibSQLTransaction extends LibSQLExecutor {
+	commit: () => Promise<void>;
+	rollback: () => Promise<void>;
+}
+
+interface LibSQLExecutor {
+	// // biome-ignore lint/suspicious/noExplicitAny: this is fine.
+	// execute(this: void, sql: string, args?: any[]): Promise<LibSQLResultSet>
+	execute(this: void, stmt: LibSQLInStatement): Promise<LibSQLResultSet>;
+}
+
+type LibSQLTransactionMode = 'write' | 'read' | 'deferred';
+
+interface LibSQLInStatement {
+	sql: string;
+	// biome-ignore lint/suspicious/noExplicitAny: this is fine.
+	args?: any[];
+}
+
+interface LibSQLResultSet {
+	lastInsertRowid: bigint | undefined;
+	rows: Record<string, unknown>[];
+	rowsAffected: number;
+}

--- a/packages/@withstudiocms/kysely/src/drivers/kysely-turso/dialect.ts
+++ b/packages/@withstudiocms/kysely/src/drivers/kysely-turso/dialect.ts
@@ -1,0 +1,39 @@
+import {
+	type DatabaseIntrospector,
+	type Dialect,
+	type DialectAdapter,
+	type Driver,
+	type Kysely,
+	type QueryCompiler,
+	SqliteAdapter,
+	SqliteIntrospector,
+	SqliteQueryCompiler,
+} from 'kysely';
+import type { LibSQLDialectConfig } from './dialect-config.js';
+import { LibSQLDriver } from './driver.js';
+import { freeze } from './utils.js';
+
+export class LibSQLDialect implements Dialect {
+	readonly #config: LibSQLDialectConfig;
+
+	constructor(config: LibSQLDialectConfig) {
+		this.#config = freeze({ ...config });
+	}
+
+	createAdapter(): DialectAdapter {
+		return new SqliteAdapter();
+	}
+
+	createDriver(): Driver {
+		return new LibSQLDriver(this.#config);
+	}
+
+	// biome-ignore lint/suspicious/noExplicitAny: this is fine.
+	createIntrospector(db: Kysely<any>): DatabaseIntrospector {
+		return new SqliteIntrospector(db);
+	}
+
+	createQueryCompiler(): QueryCompiler {
+		return new SqliteQueryCompiler();
+	}
+}

--- a/packages/@withstudiocms/kysely/src/drivers/kysely-turso/driver.ts
+++ b/packages/@withstudiocms/kysely/src/drivers/kysely-turso/driver.ts
@@ -1,0 +1,122 @@
+import {
+	type CompiledQuery,
+	type DatabaseConnection,
+	type QueryResult,
+	SqliteDriver,
+	type TransactionSettings,
+} from 'kysely';
+import type { LibSQLClient, LibSQLDialectConfig, LibSQLTransaction } from './dialect-config.js';
+
+const BEGIN_TRANSACTION_SYMBOL = Symbol('begin');
+const COMMIT_TRANSACTION_SYMBOL = Symbol('commit');
+const ROLLBACK_TRANSACTION_SYMBOL = Symbol('rollback');
+
+export class LibSQLDriver extends SqliteDriver {
+	readonly #config: LibSQLDialectConfig;
+	#client: LibSQLClient | undefined;
+
+	constructor(config: LibSQLDialectConfig) {
+		super({} as never);
+		this.#config = config;
+	}
+
+	override async acquireConnection(): Promise<DatabaseConnection> {
+		// biome-ignore lint/style/noNonNullAssertion: `init` has already run at this point.
+		return new LibSQLDatabaseConnection(this.#client!);
+	}
+
+	// @ts-expect-error needs to be fixed in core driver.
+	override async beginTransaction(
+		connection: DatabaseConnection,
+		settings: TransactionSettings
+	): Promise<void> {
+		await (connection as LibSQLDatabaseConnection)[BEGIN_TRANSACTION_SYMBOL](settings);
+	}
+
+	override async commitTransaction(connection: DatabaseConnection): Promise<void> {
+		await (connection as LibSQLDatabaseConnection)[COMMIT_TRANSACTION_SYMBOL]();
+	}
+
+	override async destroy(): Promise<void> {
+		if (this.#client?.closed) {
+			return;
+		}
+
+		this.#client?.close();
+	}
+
+	override async init(): Promise<void> {
+		const { client } = this.#config;
+
+		this.#client = isClient(client) ? client : await client();
+	}
+
+	override async releaseConnection(): Promise<void> {
+		// noop
+	}
+
+	override async rollbackTransaction(connection: DatabaseConnection): Promise<void> {
+		await (connection as LibSQLDatabaseConnection)[ROLLBACK_TRANSACTION_SYMBOL]();
+	}
+}
+
+function isClient(thing: unknown): thing is LibSQLClient {
+	return typeof thing === 'object';
+}
+
+class LibSQLDatabaseConnection implements DatabaseConnection {
+	readonly #client: LibSQLClient;
+	#transaction: LibSQLTransaction | undefined;
+
+	constructor(client: LibSQLClient) {
+		this.#client = client;
+	}
+
+	async executeQuery<R>(compiledQuery: CompiledQuery): Promise<QueryResult<R>> {
+		const result = await (this.#transaction || this.#client).execute({
+			args: [...compiledQuery.parameters],
+			sql: compiledQuery.sql,
+		});
+
+		const rows: R[] = [];
+
+		for (const row of result.rows) {
+			const obj: Record<string, unknown> = {};
+
+			for (const key in row) {
+				obj[key] = row[key];
+			}
+
+			rows.push(obj as R);
+		}
+
+		return {
+			insertId: result.lastInsertRowid,
+			numAffectedRows: BigInt(result.rowsAffected),
+			rows,
+		};
+	}
+
+	streamQuery<R>(
+		_compiledQuery: CompiledQuery,
+		_chunkSize?: number
+	): AsyncIterableIterator<QueryResult<R>> {
+		throw new Error('LibSQLDialect does not support streaming.');
+	}
+
+	async [BEGIN_TRANSACTION_SYMBOL](settings: TransactionSettings): Promise<void> {
+		this.#transaction = await this.#client.transaction(
+			settings.accessMode === 'read only' ? 'read' : 'write'
+		);
+	}
+
+	async [COMMIT_TRANSACTION_SYMBOL](): Promise<void> {
+		await this.#transaction?.commit();
+		this.#transaction = undefined;
+	}
+
+	async [ROLLBACK_TRANSACTION_SYMBOL](): Promise<void> {
+		await this.#transaction?.rollback();
+		this.#transaction = undefined;
+	}
+}

--- a/packages/@withstudiocms/kysely/src/drivers/kysely-turso/index.ts
+++ b/packages/@withstudiocms/kysely/src/drivers/kysely-turso/index.ts
@@ -1,0 +1,4 @@
+/** biome-ignore-all lint/performance/noBarrelFile: we're in library context and need an entry point */
+export { LibSQLDialect } from './dialect.js';
+export type { LibSQLDialectConfig } from './dialect-config.js';
+export { LibSQLDriver } from './driver.js';

--- a/packages/@withstudiocms/kysely/src/drivers/kysely-turso/utils.ts
+++ b/packages/@withstudiocms/kysely/src/drivers/kysely-turso/utils.ts
@@ -1,0 +1,11 @@
+export function freeze<T>(thing: T): Readonly<T> {
+	return Object.freeze(thing);
+}
+
+// lifted from `@tursodatabase/serverless/dist/session.js
+const VALID_IDENTIIFER_REGEX = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+
+// lifted from `@tursodatabase/serverless/dist/session.js
+export function isValidIdentifier(str: string | undefined): str is string {
+	return str != null && VALID_IDENTIIFER_REGEX.test(str);
+}

--- a/packages/@withstudiocms/kysely/src/drivers/libsql.ts
+++ b/packages/@withstudiocms/kysely/src/drivers/libsql.ts
@@ -1,6 +1,6 @@
 import { createClient, type Config as LibSQLConfig } from '@libsql/client/node';
 import { Config, Effect, Redacted } from 'effect';
-import { LibSQLDialect } from 'kysely-turso/libsql';
+import { LibSQLDialect } from './kysely-turso/index.js';
 
 /**
  * Configuration class for LibSQL database connections with support for redacted sensitive values.

--- a/packages/@withstudiocms/kysely/src/test-utils.ts
+++ b/packages/@withstudiocms/kysely/src/test-utils.ts
@@ -2,8 +2,8 @@ import { existsSync } from 'node:fs';
 import { unlink } from 'node:fs/promises';
 import { createClient } from '@libsql/client/node';
 import { Effect } from 'effect';
-import { LibSQLDialect } from 'kysely-turso/libsql';
 import { getDBClientLive } from './client.js';
+import { LibSQLDialect } from './drivers/kysely-turso/index.js';
 
 type DBFixtureOptions = {
 	suiteName: string;

--- a/packages/studiocms/src/consts.ts
+++ b/packages/studiocms/src/consts.ts
@@ -287,7 +287,7 @@ export const AstroConfigViteSettings: Partial<AstroConfig['vite']> = {
 		chunkSizeWarningLimit: 1200, // Allow's increase to 1.2 kB for Plugins such as our WYSIWYG editor to not trigger warnings
 		rollupOptions: {
 			// Users will need to install these peer dependencies themselves
-			external: ['@libsql/client', 'kysely-turso', 'pg', 'mysql2'],
+			external: ['@libsql/client', 'pg', 'mysql2'],
 		},
 	},
 	optimizeDeps: {

--- a/playground/package.json
+++ b/playground/package.json
@@ -26,7 +26,6 @@
     "@studiocms/md": "workspace:*",
     "@studiocms/wysiwyg": "workspace:*",
     "astro": "catalog:astrojs-current",
-    "kysely-turso": "catalog:kysely",
     "studiocms": "workspace:*",
     "sharp": "catalog:"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,9 +97,6 @@ catalogs:
     kysely:
       specifier: ^0.28.17
       version: 0.28.17
-    kysely-turso:
-      specifier: ^0.1.1
-      version: 0.1.1
     mysql2:
       specifier: ^3.23.3
       version: 3.23.3
@@ -929,9 +926,6 @@ importers:
       kysely:
         specifier: catalog:kysely
         version: 0.28.17
-      kysely-turso:
-        specifier: catalog:kysely
-        version: 0.1.1(@libsql/client@0.15.15)(kysely@0.28.17)
       mysql2:
         specifier: catalog:kysely
         version: 3.23.3(@types/node@22.20.1)
@@ -1218,9 +1212,6 @@ importers:
       effect:
         specifier: catalog:effect
         version: 3.22.1
-      kysely-turso:
-        specifier: catalog:kysely
-        version: 0.1.1(@libsql/client@0.15.15)(kysely@0.28.17)
       sharp:
         specifier: 'catalog:'
         version: 0.34.5
@@ -1261,9 +1252,6 @@ importers:
       effect:
         specifier: ^3.22.1
         version: 3.22.1
-      kysely-turso:
-        specifier: ^0.1.1
-        version: 0.1.1(@libsql/client@0.15.15)(kysely@0.28.17)
       sharp:
         specifier: ^0.34.3
         version: 0.34.5
@@ -1384,9 +1372,6 @@ importers:
       effect:
         specifier: ^3.22.1
         version: 3.22.1
-      kysely-turso:
-        specifier: ^0.1.1
-        version: 0.1.1(@libsql/client@0.15.15)(kysely@0.28.17)
       sharp:
         specifier: ^0.34.3
         version: 0.34.5
@@ -5621,19 +5606,6 @@ packages:
   ky@1.14.3:
     resolution: {integrity: sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==}
     engines: {node: '>=18'}
-
-  kysely-turso@0.1.1:
-    resolution: {integrity: sha512-00getri8gvMS+Aq0JddZ2ggdJ22iRoAhrfA9n/UvhgtTjjDYUXD7RyRLIn2Ao/TK7tWPxOV1E0bncklxe1KcXg==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@libsql/client': ^0.15.14
-      '@tursodatabase/serverless': ^0.1.3
-      kysely: ^0.28
-    peerDependenciesMeta:
-      '@libsql/client':
-        optional: true
-      '@tursodatabase/serverless':
-        optional: true
 
   kysely@0.28.17:
     resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
@@ -12309,12 +12281,6 @@ snapshots:
   kubernetes-types@1.30.0: {}
 
   ky@1.14.3: {}
-
-  kysely-turso@0.1.1(@libsql/client@0.15.15)(kysely@0.28.17):
-    dependencies:
-      kysely: 0.28.17
-    optionalDependencies:
-      '@libsql/client': 0.15.15
 
   kysely@0.28.17: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -83,7 +83,6 @@ catalogs:
     "@libsql/client": ^0.15.15
     "@types/pg": ^8.23.1
     kysely: ^0.28.17
-    kysely-turso: ^0.1.1
     pg: ^8.23.0
     mysql2: ^3.23.3
 

--- a/templates/blog-libsql/package.json
+++ b/templates/blog-libsql/package.json
@@ -29,7 +29,6 @@
     "@studiocms/md": "^0.3.0",
     "astro": "^7.2.3",
     "effect": "^3.22.1",
-    "kysely-turso": "^0.1.1",
     "sharp": "^0.34.3",
     "studiocms": "^0.4.4"
   }

--- a/templates/headless-libsql/package.json
+++ b/templates/headless-libsql/package.json
@@ -30,7 +30,6 @@
     "@studiocms/html": "^0.3.0",
     "astro": "^7.2.3",
     "effect": "^3.22.1",
-    "kysely-turso": "^0.1.1",
     "sharp": "^0.34.3",
     "studiocms": "^0.4.4"
   }


### PR DESCRIPTION
This pull request migrates the codebase from using the external `kysely-turso` package to a new, locally maintained Turso/LibSQL driver. This change reduces external dependencies and gives more control over the driver implementation. The migration touches package dependencies, configuration, and introduces a new driver implementation.

- Next PR will unlock the `kysely` and `@libsql/client` dependencies for updates, and fix anything that needs to be fixed for the latest versions.

The most important changes are:

**Dependency and Configuration Cleanup:**
* Removed all references to the external `kysely-turso` package from dependencies, peerDependencies, and configuration files such as `package.json`, `pnpm-lock.yaml`, and `pnpm-workspace.yaml`. This also includes updates to template and playground projects to no longer require `kysely-turso` as a dependency. [[1]](diffhunk://#diff-501bee9684f93e05933d2e2d64785f4b3f98339ee678e196936fee728fdf6635R71-R82) [[2]](diffhunk://#diff-501bee9684f93e05933d2e2d64785f4b3f98339ee678e196936fee728fdf6635L88-L98) [[3]](diffhunk://#diff-d10bbb79c9085774698fcb9f1badf3ac65912cbde60d22eeb18259814ab89688L29) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL100-L102) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL932-L934) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1221-L1223) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1264-L1266) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1387-L1389) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5625-L5637) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12313-L12318) [[11]](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL86) [[12]](diffhunk://#diff-8cb838827da32f4949e0e4c73d9ad30a6202a8524957ce8d526ce3f417c04ca4L32) [[13]](diffhunk://#diff-1a1c19ae2afe498bf1a1cf10b7483e4d015f8ad34b9a3975b4f1b133d2b0583aL33) [[14]](diffhunk://#diff-4400a8657f93c31e84a6d36104c667eecfb1847d3ac159e1329aa9d48329fe5fL290-R290) [[15]](diffhunk://#diff-d5963738993926b3ad1d6763702f9e7a611bb6eb9d1e2c4c184f36acf7e5959fL231-R231)

**Local Turso/LibSQL Driver Implementation:**
* Added a new local driver under `packages/@withstudiocms/kysely/src/drivers/kysely-turso/` implementing the Turso/LibSQL dialect, including `dialect-config.ts`, `dialect.ts`, `driver.ts`, and utility functions. This provides a drop-in replacement for the removed external package. [[1]](diffhunk://#diff-c36cc044dc7d7926eaf788e48af038e3f289c2e95930d5e20fd3928f1df301a3R1-R36) [[2]](diffhunk://#diff-49647e9a19fc7cf38a8e57f563e12a5647913a2e6f8eb348aa8e3f53cd49e708R1-R39) [[3]](diffhunk://#diff-18626c85ae925746febba82e96729f296b2e1d9afa14cd6a53bfca59b722917dR1-R122) [[4]](diffhunk://#diff-2827e9eb4926201eb13ce7cac151b4cb3d073dc2c852c13897be7bf132112fcbR1-R11) [[5]](diffhunk://#diff-c87e0bbf8a10298665096edbcab5bd862b6180c96b08be57a546d3122b19ff8cR1-R4)

**Internal Refactoring:**
* Updated all internal imports and usages to reference the new local driver instead of the external package, ensuring seamless integration and compatibility. [[1]](diffhunk://#diff-5648c04a6932de6445cebd08bf1c9d3cb94fca4577868b3fb645d79a8a5563f3L3-R3) [[2]](diffhunk://#diff-091af39f728da26c32ba17532f8d6b0ae8d9c8b6440ad17969d250d02af9759cL5-R6)

**Changelog Update:**
* Added a changeset documenting the migration from the external `kysely-turso` package to the local driver.

This migration will make the project more maintainable and reduce reliance on third-party packages for Turso/LibSQL support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a built-in Turso/libSQL driver for Kysely.
  - Exposed dialect, driver, transaction, and client configuration APIs for connecting to Turso/libSQL databases.
  - Added support for client factories, transactions, query execution, and affected-row results.

- **Chores**
  - Removed the need for the external `kysely-turso` package from supported templates and tooling.
  - Updated package metadata and release documentation to reflect the integrated driver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->