### PR TITLE
Update Kysely dependencies and update migration functionality

### DIFF
--- a/.changeset/sixty-results-sip.md
+++ b/.changeset/sixty-results-sip.md
@@ -1,4 +1,5 @@
 ---
+"studiocms": minor
 "@withstudiocms/kysely": minor
 "@withstudiocms/sdk": minor
 ---

--- a/.changeset/sixty-results-sip.md
+++ b/.changeset/sixty-results-sip.md
@@ -1,0 +1,6 @@
+---
+"@withstudiocms/kysely": minor
+"@withstudiocms/sdk": minor
+---
+
+Update Kysely and Libsql database Clients

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -73,7 +73,6 @@
     "vite",
     "vitest",
     "zod",
-    "kysely",
     "typescript",
     "diff",
     "@changesets/changelog-github",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -62,7 +62,6 @@
     }
   ],
   "ignoreDeps": [
-    "@libsql/client",
     "@types/node",
     "@vitest/coverage-v8",
     "sharp",

--- a/packages/@withstudiocms/kysely/package.json
+++ b/packages/@withstudiocms/kysely/package.json
@@ -44,6 +44,14 @@
       "types": "./dist/kysely.d.ts",
       "default": "./dist/kysely.js"
     },
+    "./kysely-migration": {
+      "types": "./dist/kysely-migration.d.ts",
+      "default": "./dist/kysely-migration.js"
+    },
+    "./kysely-readonly": {
+      "types": "./dist/kysely-readonly.d.ts",
+      "default": "./dist/kysely-readonly.js"
+    },
     "./client": {
       "types": "./dist/client.d.ts",
       "default": "./dist/client.js"

--- a/packages/@withstudiocms/kysely/src/core/migrator.ts
+++ b/packages/@withstudiocms/kysely/src/core/migrator.ts
@@ -1,11 +1,6 @@
 import { Effect } from 'effect';
-import {
-	type Dialect,
-	type Kysely,
-	type Migration,
-	type MigrationProvider,
-	Migrator,
-} from 'kysely';
+import type { Dialect, Kysely } from 'kysely';
+import { type Migration, type MigrationProvider, Migrator } from 'kysely/migration';
 import { kyselyClient, makeDBClientLive } from './client.js';
 import { MigratorError } from './errors.js';
 

--- a/packages/@withstudiocms/kysely/src/kysely-migration.ts
+++ b/packages/@withstudiocms/kysely/src/kysely-migration.ts
@@ -1,0 +1,3 @@
+/* v8 ignore start */
+export * from 'kysely/migration';
+/* v8 ignore stop */

--- a/packages/@withstudiocms/kysely/src/kysely-readonly.ts
+++ b/packages/@withstudiocms/kysely/src/kysely-readonly.ts
@@ -1,0 +1,3 @@
+/* v8 ignore start */
+export * from 'kysely/readonly';
+/* v8 ignore stop */

--- a/packages/@withstudiocms/sdk/src/migrator.ts
+++ b/packages/@withstudiocms/sdk/src/migrator.ts
@@ -4,13 +4,12 @@
 import type { Effect } from '@withstudiocms/effect';
 import type { MigratorError } from '@withstudiocms/kysely/core/errors';
 import { makeMigratorLive } from '@withstudiocms/kysely/core/migrator';
+import type { Dialect, Kysely } from '@withstudiocms/kysely/kysely';
 import type {
-	Dialect,
-	Kysely,
 	Migration,
 	MigrationInfo,
 	MigrationResultSet,
-} from '@withstudiocms/kysely/kysely';
+} from '@withstudiocms/kysely/kysely-migration';
 
 /**
  * Dynamically imports a migration module by its name.

--- a/packages/studiocms/src/cli/migrator/index.ts
+++ b/packages/studiocms/src/cli/migrator/index.ts
@@ -4,7 +4,7 @@ import { StudioCMSColorwayBg, StudioCMSColorwayInfoBg } from '@withstudiocms/cli
 import { label } from '@withstudiocms/cli-kit/messages';
 import { Cli, Effect, runEffect } from '@withstudiocms/effect';
 import { intro, log, outro, select, tasks } from '@withstudiocms/effect/clack';
-import type { MigrationInfo, MigrationResult } from '@withstudiocms/kysely/kysely';
+import type { MigrationInfo, MigrationResult } from '@withstudiocms/kysely/kysely-migration';
 import { getMigratorLive } from '@withstudiocms/sdk/migrator';
 import { getDbDriver, parseDbDialect } from '../../db/index.js';
 import { genLogger } from '../../effect.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,14 +89,14 @@ catalogs:
       version: 3.22.1
   kysely:
     '@libsql/client':
-      specifier: ^0.15.15
-      version: 0.15.15
+      specifier: ^0.17.4
+      version: 0.17.4
     '@types/pg':
       specifier: ^8.23.1
       version: 8.23.1
     kysely:
-      specifier: ^0.28.17
-      version: 0.28.17
+      specifier: ^0.29.5
+      version: 0.29.5
     mysql2:
       specifier: ^3.23.3
       version: 3.23.3
@@ -919,13 +919,13 @@ importers:
     dependencies:
       '@libsql/client':
         specifier: catalog:kysely
-        version: 0.15.15
+        version: 0.17.4
       effect:
         specifier: catalog:effect
         version: 3.22.1
       kysely:
         specifier: catalog:kysely
-        version: 0.28.17
+        version: 0.29.5
       mysql2:
         specifier: catalog:kysely
         version: 3.23.3(@types/node@22.20.1)
@@ -956,7 +956,7 @@ importers:
         version: link:../../effectify
       kysely:
         specifier: catalog:kysely
-        version: 0.28.17
+        version: 0.29.5
       zod:
         specifier: catalog:astrojs-min
         version: 4.4.3
@@ -1045,7 +1045,7 @@ importers:
         version: 1.2.93
       '@libsql/client':
         specifier: catalog:kysely
-        version: 0.15.15
+        version: 0.17.4
       '@nanostores/i18n':
         specifier: ^1.3.3
         version: 1.3.3(nanostores@1.5.1)
@@ -1196,7 +1196,7 @@ importers:
         version: 0.108.1(@effect/cluster@0.60.2(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1)
       '@libsql/client':
         specifier: catalog:kysely
-        version: 0.15.15
+        version: 0.17.4
       '@studiocms/blog':
         specifier: workspace:*
         version: link:../packages/@studiocms/blog
@@ -1238,8 +1238,8 @@ importers:
         specifier: ^0.108.1
         version: 0.108.1(@effect/cluster@0.60.2(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1)
       '@libsql/client':
-        specifier: ^0.15.15
-        version: 0.15.15
+        specifier: ^0.17.4
+        version: 0.17.4
       '@studiocms/blog':
         specifier: ^0.3.0
         version: link:../../packages/@studiocms/blog
@@ -1358,8 +1358,8 @@ importers:
         specifier: ^0.108.1
         version: 0.108.1(@effect/cluster@0.60.2(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1)
       '@libsql/client':
-        specifier: ^0.15.15
-        version: 0.15.15
+        specifier: ^0.17.4
+        version: 0.17.4
       '@studiocms/html':
         specifier: ^0.3.0
         version: link:../../packages/@studiocms/html
@@ -2678,11 +2678,11 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@libsql/client@0.15.15':
-    resolution: {integrity: sha512-twC0hQxPNHPKfeOv3sNT6u2pturQjLcI+CnpTM0SjRpocEGgfiZ7DWKXLNnsothjyJmDqEsBQJ5ztq9Wlu470w==}
+  '@libsql/client@0.17.4':
+    resolution: {integrity: sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==}
 
-  '@libsql/core@0.15.15':
-    resolution: {integrity: sha512-C88Z6UKl+OyuKKPwz224riz02ih/zHYI3Ho/LAcVOgjsunIRZoBw7fjRfaH9oPMmSNeQfhGklSG2il1URoOIsA==}
+  '@libsql/core@0.17.4':
+    resolution: {integrity: sha512-LqF9gIvnJ38nmAH1y/ChizHqDO/MO1wLgA96XrraulEEbqXxLjleSH92YWTolbuJKgPUmGu4aJk9W3UnAcxLOQ==}
 
   '@libsql/darwin-arm64@0.5.29':
     resolution: {integrity: sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==}
@@ -2694,12 +2694,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@libsql/hrana-client@0.7.0':
-    resolution: {integrity: sha512-OF8fFQSkbL7vJY9rfuegK1R7sPgQ6kFMkDamiEccNUvieQ+3urzfDFI616oPl8V7T9zRmnTkSjMOImYCAVRVuw==}
-
-  '@libsql/isomorphic-fetch@0.3.1':
-    resolution: {integrity: sha512-6kK3SUK5Uu56zPq/Las620n5aS9xJq+jMBcNSOmjhNf/MUvdyji4vrMTqD7ptY7/4/CAVEAYDeotUz60LNQHtw==}
-    engines: {node: '>=18.0.0'}
+  '@libsql/hrana-client@0.10.0':
+    resolution: {integrity: sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw==}
 
   '@libsql/isomorphic-ws@0.1.5':
     resolution: {integrity: sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==}
@@ -4583,10 +4579,6 @@ packages:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
     engines: {node: '>=0.10'}
 
-  data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
-
   data-urls@1.1.0:
     resolution: {integrity: sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==}
 
@@ -4997,10 +4989,6 @@ packages:
       picomatch:
         optional: true
 
-  fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
-
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
@@ -5066,10 +5054,6 @@ packages:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
     engines: {node: '>=18.3.0'}
     hasBin: true
-
-  formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
 
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
@@ -5607,9 +5591,9 @@ packages:
     resolution: {integrity: sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==}
     engines: {node: '>=18'}
 
-  kysely@0.28.17:
-    resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
-    engines: {node: '>=20.0.0'}
+  kysely@0.29.5:
+    resolution: {integrity: sha512-ooa+eSbBNPTo3MycPEuW5jdrxQdQwdtB3LC3h43FiXQbIry5tR0C5lDG7eealK0E4D7XjrnOP5DIUg/LyjRMYQ==}
+    engines: {node: '>=22.0.0'}
 
   launder@1.7.1:
     resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
@@ -6099,11 +6083,6 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
@@ -6115,10 +6094,6 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
-
-  node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
@@ -7485,10 +7460,6 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
-
-  web-streams-polyfill@3.3.3:
-    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
-    engines: {node: '>= 8'}
 
   web-vitals@6.1.1:
     resolution: {integrity: sha512-r93gKnR6ZC2O8F3JrS0AAGIQ0v0OhXuyg4DAj2oG7K+GPkwXfUSc3ZcWeu50AsV5yIc6xxnTjERipJ6EvSw2vg==}
@@ -9118,10 +9089,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@libsql/client@0.15.15':
+  '@libsql/client@0.17.4':
     dependencies:
-      '@libsql/core': 0.15.15
-      '@libsql/hrana-client': 0.7.0
+      '@libsql/core': 0.17.4
+      '@libsql/hrana-client': 0.10.0
       js-base64: 3.9.2
       libsql: 0.5.29
       promise-limit: 2.7.0
@@ -9129,7 +9100,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@libsql/core@0.15.15':
+  '@libsql/core@0.17.4':
     dependencies:
       js-base64: 3.9.2
 
@@ -9139,17 +9110,13 @@ snapshots:
   '@libsql/darwin-x64@0.5.29':
     optional: true
 
-  '@libsql/hrana-client@0.7.0':
+  '@libsql/hrana-client@0.10.0':
     dependencies:
-      '@libsql/isomorphic-fetch': 0.3.1
       '@libsql/isomorphic-ws': 0.1.5
       js-base64: 3.9.2
-      node-fetch: 3.3.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  '@libsql/isomorphic-fetch@0.3.1': {}
 
   '@libsql/isomorphic-ws@0.1.5':
     dependencies:
@@ -11063,8 +11030,6 @@ snapshots:
       assert-plus: 1.0.0
     optional: true
 
-  data-uri-to-buffer@4.0.1: {}
-
   data-urls@1.1.0:
     dependencies:
       abab: 2.0.6
@@ -11515,11 +11480,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  fetch-blob@3.2.0:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.3.3
-
   fflate@0.8.3: {}
 
   figures@6.1.0:
@@ -11586,10 +11546,6 @@ snapshots:
   formatly@0.3.0:
     dependencies:
       fd-package-json: 2.0.0
-
-  formdata-polyfill@4.0.10:
-    dependencies:
-      fetch-blob: 3.2.0
 
   fresh@2.0.0: {}
 
@@ -12282,7 +12238,7 @@ snapshots:
 
   ky@1.14.3: {}
 
-  kysely@0.28.17: {}
+  kysely@0.29.5: {}
 
   launder@1.7.1:
     dependencies:
@@ -13016,19 +12972,11 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
-  node-domexception@1.0.0: {}
-
   node-fetch-native@1.6.7: {}
 
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-
-  node-fetch@3.3.2:
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
 
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
@@ -14511,8 +14459,6 @@ snapshots:
   walk-up-path@4.0.0: {}
 
   web-namespaces@2.0.1: {}
-
-  web-streams-polyfill@3.3.3: {}
 
   web-vitals@6.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -80,9 +80,9 @@ catalogs:
     effect: ^3.22.1
 
   kysely:
-    "@libsql/client": ^0.15.15
+    "@libsql/client": ^0.17.4
     "@types/pg": ^8.23.1
-    kysely: ^0.28.17
+    kysely: ^0.29.5
     pg: ^8.23.0
     mysql2: ^3.23.3
 

--- a/templates/blog-libsql/package.json
+++ b/templates/blog-libsql/package.json
@@ -24,7 +24,7 @@
     "@astrojs/node": "^11.1.3",
     "@effect/platform": "^0.97.1",
     "@effect/platform-node": "^0.108.1",
-    "@libsql/client": "^0.15.15",
+    "@libsql/client": "^0.17.4",
     "@studiocms/blog": "^0.3.0",
     "@studiocms/md": "^0.3.0",
     "astro": "^7.2.3",

--- a/templates/headless-libsql/package.json
+++ b/templates/headless-libsql/package.json
@@ -25,7 +25,7 @@
     "@astrojs/node": "^11.1.3",
     "@effect/platform": "^0.97.1",
     "@effect/platform-node": "^0.108.1",
-    "@libsql/client": "^0.15.15",
+    "@libsql/client": "^0.17.4",
     "@studiocms/md": "^0.3.0",
     "@studiocms/html": "^0.3.0",
     "astro": "^7.2.3",


### PR DESCRIPTION
This pull request updates the Kysely and Libsql database clients to their latest versions and makes related code and dependency adjustments to ensure compatibility. It also exposes new entrypoints for Kysely migration and readonly APIs, and cleans up unused dependencies.

- Closes #1713 

**Dependency Upgrades:**

* Upgraded `kysely` from `0.28.17` to `0.29.5` and `@libsql/client` from `0.15.15` to `0.17.4`, along with related Libsql packages and transitive dependencies. This ensures compatibility with the latest features and fixes. (`pnpm-lock.yaml`, `.changeset/sixty-results-sip.md`, [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5610-R5596) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2681-R2685) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2697-R2698) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9121-R9103) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1241-R1242) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1361-R1362) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1048-R1048) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1199-R1199) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL922-R928) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL959-R959) F05959fbL62R62, F05959fbL74R73)

**API and Entrypoint Enhancements:**

* Added new entrypoints in `@withstudiocms/kysely` for `kysely-migration` and `kysely-readonly`, allowing consumers to import migration and readonly APIs directly. (`package.json`, `kysely-migration.ts`, `kysely-readonly.ts`, [[1]](diffhunk://#diff-501bee9684f93e05933d2e2d64785f4b3f98339ee678e196936fee728fdf6635R47-R54) [[2]](diffhunk://#diff-bff035d853ba95b8cc7c9a2b71bf6f12e88cb8d7bc2cbab4a90d418f24a2a148R1-R3) [[3]](diffhunk://#diff-80da2889a91e4c5e5a8a65f1104d345c423e970bf9d30c1afde165c91f9c95d7R1-R3)

**Code Compatibility Adjustments:**

* Updated imports in migration-related code to use the new Kysely migration entrypoint and types, ensuring compatibility with the upgraded Kysely package. (`migrator.ts` in both `@withstudiocms/kysely` and `@withstudiocms/sdk`, [[1]](diffhunk://#diff-ab95751372a64a7edd10c40c30892be2e069d00ca8e54c98154854ebc22f99c8L2-R3) [[2]](diffhunk://#diff-19efafa30be6d1cc3e58e32229025929418adf87c267ef29641a0257dfb01666R7-R12)

**Dependency Cleanup:**

* Removed now-unnecessary or deprecated dependencies and polyfills (such as `node-fetch`, `fetch-blob`, `formdata-polyfill`, `web-streams-polyfill`, `node-domexception`, `data-uri-to-buffer`) from the lockfile, reducing bundle size and potential conflicts. (`pnpm-lock.yaml`, [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4586-L4589) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5000-L5003) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5070-L5073) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6102-L6106) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6119-L6122) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7489-L7492) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11066-L11067) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11518-L11522) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11590-L11593) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13019-L13032) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL14515-L14516)

**Renovate Configuration Update:**

* Updated `.github/renovate.json` to stop ignoring `kysely` and `@libsql/client` dependencies, so they will be included in future automated update PRs. [[1]](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3L65) [[2]](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3L77)